### PR TITLE
Fix CI and release setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,6 @@ jobs:
           node-version: "24"
           cache: true
       - run: vp install
+      - run: vp run effect-cf#build
       - run: vp check
       - run: vp test

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "utils",
   "version": "0.0.0",
+  "private": true,
   "description": "A starter for creating a TypeScript package.",
   "homepage": "https://github.com/author/library#readme",
   "bugs": {


### PR DESCRIPTION
## Summary
- Build `effect-cf` before CI checks so workspace consumers can resolve package exports on fresh runners.
- Mark the internal `utils` workspace private so Changesets does not try to publish it.

## Verification
- `vp run effect-cf#build`
- `vp check`
- `vp test`