### PR TITLE
Add baseline changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Binding types come from code-owned definitions such as `Worker.Tag(...)` and `Du
 
 The `examples/` directory demonstrates package usage across Workers, Durable Objects, service bindings, and frontend consumers.
 
+## Changelog
+
+See [packages/effect-cf/CHANGELOG.md](./packages/effect-cf/CHANGELOG.md).
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/packages/effect-cf/CHANGELOG.md
+++ b/packages/effect-cf/CHANGELOG.md
@@ -1,0 +1,9 @@
+# effect-cf
+
+## 0.1.0
+
+Initial public release.
+
+- Add Effect-native Worker and Durable Object entrypoint helpers.
+- Add typed Worker service binding and Durable Object namespace helpers.
+- Add KV, Durable Object state/storage, RPC, and WebSocket primitives.

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -9,6 +9,7 @@
     "directory": "packages/effect-cf"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "src"
   ],


### PR DESCRIPTION
## Summary
- Add a baseline `effect-cf` changelog for the already-published `0.1.0` release.
- Link the package changelog from the root README.
- Include `CHANGELOG.md` in future npm package contents.

## Verification
- `vp check`