### PR TITLE
Add Worker fetch shorthand

### DIFF
--- a/.changeset/warm-workers-greet.md
+++ b/.changeset/warm-workers-greet.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add a fetch-handler shorthand for `Worker.make(layer, effect)`.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,56 @@ npm install effect-cf "effect@^4.0.0-beta.65"
 
 Binding types come from code-owned definitions such as `Worker.Tag(...)` and `DurableObject.Tag(...)`. Generated Wrangler types are only used as local config checks.
 
+## A Taste
+
+A Worker can route HTTP with Effect and call a Durable Object through a typed binding:
+
+```ts
+import { Effect, Layer, Schema as S } from "effect";
+import { HttpRouter, HttpServerResponse } from "effect/unstable/http";
+import { DurableObject, DurableObjectState, Worker } from "effect-cf";
+
+class Counter extends DurableObject.Tag<Counter>()("Counter", {
+  increment: DurableObject.method({ success: S.Number }),
+}) {}
+
+const CounterLive = Counter.make(Layer.empty, {
+  rpc: {
+    increment: () =>
+      Effect.gen(function* () {
+        const state = yield* DurableObjectState.DurableObjectState;
+        const current = yield* state.storage.get<number>("count");
+        const next = (current ?? 0) + 1;
+        yield* state.storage.put("count", next);
+        return next;
+      }),
+  },
+});
+
+export class CounterDurableObject extends CounterLive {}
+
+const Counters = Counter.namespace("Counters", { binding: "COUNTER" });
+
+const app = Effect.gen(function* () {
+  const router = yield* HttpRouter.HttpRouter;
+  const counter = Counters.byName("home");
+
+  return yield* router
+    .get(
+      "/",
+      Effect.gen(function* () {
+        const count = yield* counter.increment();
+        return HttpServerResponse.text(`Viewed ${count} times`);
+      }),
+    )
+    .asHttpEffect();
+});
+
+export default Worker.make(Layer.mergeAll(HttpRouter.layer, Counters.layer), app);
+```
+
+`COUNTER` is still declared in `wrangler.jsonc`, but the callable API is inferred from the `Counter` class. The Worker and Durable Object both run through `effect-cf` runtime boundaries.
+
 ## Examples
 
 The `examples/` directory demonstrates package usage across Workers, Durable Objects, service bindings, and frontend consumers.

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -211,10 +211,27 @@ const renderFetchSuccess = <E, R>(
         ),
   );
 
-export const make = <ROut, LayerError, const Rpc extends WorkerRpc<ROut> = Record<never, never>>(
+const isWorkerOptions = <ROut, Rpc extends WorkerRpc<ROut>>(
+  options: WorkerOptions<ROut, Rpc> | WorkerHandler<ROut>,
+): options is WorkerOptions<ROut, Rpc> =>
+  typeof options === "object" && options !== null && ("fetch" in options || "rpc" in options);
+
+export function make<ROut, LayerError>(
+  layer: Layer.Layer<ROut, LayerError, ExecutionContext | WorkerContext | WorkerEnvironment>,
+  fetch: WorkerHandler<ROut>,
+): WorkerClass<Record<never, never>, ROut>;
+export function make<ROut, LayerError, const Rpc extends WorkerRpc<ROut> = Record<never, never>>(
   layer: Layer.Layer<ROut, LayerError, ExecutionContext | WorkerContext | WorkerEnvironment>,
   options: WorkerOptions<ROut, Rpc>,
-): WorkerClass<Rpc, ROut> => {
+): WorkerClass<Rpc, ROut>;
+export function make<ROut, LayerError, const Rpc extends WorkerRpc<ROut> = Record<never, never>>(
+  layer: Layer.Layer<ROut, LayerError, ExecutionContext | WorkerContext | WorkerEnvironment>,
+  optionsOrFetch: WorkerOptions<ROut, Rpc> | WorkerHandler<ROut>,
+): WorkerClass<Rpc, ROut> {
+  const options = isWorkerOptions(optionsOrFetch)
+    ? optionsOrFetch
+    : ({ fetch: optionsOrFetch } as WorkerOptions<ROut, Rpc>);
+
   class EffectWorker extends CloudflareWorkerEntrypoint<WorkerEnv> {
     readonly runtime: ManagedRuntime.ManagedRuntime<RuntimeContext<ROut>, LayerError>;
 
@@ -280,7 +297,7 @@ export const make = <ROut, LayerError, const Rpc extends WorkerRpc<ROut> = Recor
   );
 
   return Entrypoint.assumeEntrypointClass<WorkerClass<Rpc, ROut>>(EffectWorker);
-};
+}
 
 export const makeFetchHandler = <ROut, LayerError, Env extends WorkerEnv = WorkerEnv>(
   layer: Layer.Layer<ROut, LayerError, ExecutionContext | WorkerContext | WorkerEnvironment>,

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -36,6 +36,22 @@ test("Worker.makeFetchHandler returns an ExportedHandler-compatible fetch object
   await expect(response.text()).resolves.toBe("ok");
 });
 
+test("Worker.make accepts a fetch Effect shorthand", async () => {
+  const Live = Worker.make(
+    Layer.succeed(RenderValue, "from-shorthand"),
+    Effect.gen(function* () {
+      const value = yield* RenderValue;
+
+      return new Response(value);
+    }),
+  );
+  const worker = new Live(makeExecutionContext(), {} as Cloudflare.Env);
+
+  const response = await worker.fetch(new Request("https://worker.test/"));
+
+  await expect(response.text()).resolves.toBe("from-shorthand");
+});
+
 test("Worker.fetch renders Effect HttpServerResponse values", async () => {
   const Live = Worker.make(Layer.succeed(RenderValue, "from-context"), {
     fetch: Effect.gen(function* () {


### PR DESCRIPTION
## Summary
- Add `Worker.make(layer, effect)` as a fetch-only shorthand while preserving the existing `{ fetch, rpc }` form.
- Add focused Worker boundary coverage for the shorthand.
- Add a README example showing a Worker `HttpRouter` calling a typed Durable Object counter.
- Add a minor changeset for the public API enhancement.

## Verification
- `vp test packages/effect-cf/tests/WorkerBoundary.test.ts`
- `vp check`
- `vp test`