### PR TITLE
Add durable websocket wrapper API

### DIFF
--- a/.changeset/bright-sockets-hibernate.md
+++ b/.changeset/bright-sockets-hibernate.md
@@ -1,0 +1,7 @@
+---
+"effect-cf": minor
+---
+
+Add Effect-native Durable Object WebSocket APIs for hibernatable application sockets.
+
+`DurableObjectWebSocket.acceptUpgrade` now returns a wrapped `DurableWebSocket` server socket with Effect-based `send`, `close`, and attachment helpers. `DurableObjectState.getWebSockets` and `acceptWebSocket` now use the same wrapper, and schema-backed attachment helpers support typed rehydration of hibernated sockets.

--- a/examples/chat/durable-objects/chat-room/src/ConnectionManager.ts
+++ b/examples/chat/durable-objects/chat-room/src/ConnectionManager.ts
@@ -1,20 +1,26 @@
 import type { ChatPeer } from "@effect-cf/example-contracts/Schemas";
-import { Context, Effect, Layer } from "effect";
-import { DurableObjectState } from "effect-cf";
+import { Context, Effect, Layer, Option, Schema as S } from "effect";
+import { DurableObjectState, DurableObjectWebSocket } from "effect-cf";
 
 const heartbeatTtlMillis = 45_000;
 
-interface ConnectionAttachment {
-  readonly id: string;
-  readonly connectedAt: number;
-  readonly lastHeartbeat: number;
-  readonly roomId: string;
-  readonly userId: string;
-  readonly restored: boolean;
-}
+const ConnectionAttachment = S.Struct({
+  id: S.String,
+  connectedAt: S.Number,
+  lastHeartbeat: S.Number,
+  roomId: S.String,
+  userId: S.String,
+  restored: S.Boolean,
+});
+
+type ConnectionAttachment = S.Schema.Type<typeof ConnectionAttachment>;
+
+const Attachments = DurableObjectWebSocket.attachment(ConnectionAttachment);
+
+type ConnectionSocket = DurableObjectWebSocket.DurableWebSocket<ConnectionAttachment>;
 
 export interface Connection {
-  readonly socket: WebSocket;
+  readonly socket: ConnectionSocket;
   readonly id: string;
   readonly connectedAt: number;
   readonly lastHeartbeat: number;
@@ -29,48 +35,18 @@ export interface ConnectionMetadata {
 }
 
 export interface ConnectionManagerService {
-  readonly add: (socket: WebSocket, metadata: ConnectionMetadata) => Effect.Effect<Connection>;
-  readonly heartbeat: (socket: WebSocket) => Effect.Effect<Connection>;
-  readonly get: (socket: WebSocket) => Effect.Effect<Connection | undefined>;
-  readonly remove: (socket: WebSocket) => Effect.Effect<Connection | undefined>;
-  readonly list: (roomId: string) => Effect.Effect<ReadonlyArray<ChatPeer>>;
+  readonly add: (
+    socket: ConnectionSocket,
+    metadata: ConnectionMetadata,
+  ) => Effect.Effect<Connection, unknown>;
+  readonly heartbeat: (socket: ConnectionSocket) => Effect.Effect<Connection, unknown>;
+  readonly get: (socket: ConnectionSocket) => Effect.Effect<Connection | undefined, unknown>;
+  readonly remove: (socket: ConnectionSocket) => Effect.Effect<Connection | undefined, unknown>;
+  readonly list: (roomId: string) => Effect.Effect<ReadonlyArray<ChatPeer>, unknown>;
   readonly restoredCount: Effect.Effect<number>;
-  readonly cleanup: Effect.Effect<void>;
+  readonly cleanup: Effect.Effect<void, unknown>;
   readonly count: Effect.Effect<number>;
 }
-
-const readAttachment = (socket: WebSocket): ConnectionAttachment | undefined => {
-  const attachment = socket.deserializeAttachment();
-
-  if (
-    typeof attachment !== "object" ||
-    attachment === null ||
-    !("lastHeartbeat" in attachment) ||
-    !("roomId" in attachment) ||
-    !("userId" in attachment) ||
-    typeof attachment.lastHeartbeat !== "number" ||
-    typeof attachment.roomId !== "string" ||
-    typeof attachment.userId !== "string"
-  ) {
-    return undefined;
-  }
-
-  return {
-    id:
-      "id" in attachment && typeof attachment.id === "string" ? attachment.id : crypto.randomUUID(),
-    connectedAt:
-      "connectedAt" in attachment && typeof attachment.connectedAt === "number"
-        ? attachment.connectedAt
-        : attachment.lastHeartbeat,
-    lastHeartbeat: attachment.lastHeartbeat,
-    roomId: attachment.roomId,
-    userId: attachment.userId,
-    restored:
-      "restored" in attachment && typeof attachment.restored === "boolean"
-        ? attachment.restored
-        : true,
-  };
-};
 
 const toPeer = (connection: Connection): ChatPeer => ({
   id: connection.id,
@@ -88,10 +64,10 @@ export class ConnectionManager extends Context.Service<
     this,
     Effect.gen(function* () {
       const state = yield* DurableObjectState.DurableObjectState;
-      const connections = new Map<WebSocket, Connection>();
+      const connections = new Map<ConnectionSocket, Connection>();
 
       const remember = (
-        socket: WebSocket,
+        socket: ConnectionSocket,
         metadata: ConnectionMetadata,
         options?: {
           readonly id?: string;
@@ -99,93 +75,98 @@ export class ConnectionManager extends Context.Service<
           readonly lastHeartbeat?: number;
           readonly restored?: boolean;
         },
-      ) => {
-        const now = Date.now();
-        const connection = {
-          socket,
-          id: options?.id ?? crypto.randomUUID(),
-          connectedAt: options?.connectedAt ?? now,
-          lastHeartbeat: options?.lastHeartbeat ?? now,
-          roomId: metadata.roomId,
-          userId: metadata.userId,
-          restored: options?.restored ?? false,
-        } satisfies Connection;
-
-        connections.set(socket, connection);
-        socket.serializeAttachment({
-          id: connection.id,
-          connectedAt: connection.connectedAt,
-          lastHeartbeat: connection.lastHeartbeat,
-          roomId: connection.roomId,
-          userId: connection.userId,
-          restored: connection.restored,
-        } satisfies ConnectionAttachment);
-
-        return connection;
-      };
-
-      for (const socket of state.raw.getWebSockets()) {
-        const attachment = readAttachment(socket);
-        if (attachment !== undefined) {
-          remember(
+      ) =>
+        Effect.gen(function* () {
+          const now = Date.now();
+          const connection = {
             socket,
-            { roomId: attachment.roomId, userId: attachment.userId },
-            { ...attachment, restored: true },
-          );
-        }
-      }
+            id: options?.id ?? crypto.randomUUID(),
+            connectedAt: options?.connectedAt ?? now,
+            lastHeartbeat: options?.lastHeartbeat ?? now,
+            roomId: metadata.roomId,
+            userId: metadata.userId,
+            restored: options?.restored ?? false,
+          } satisfies Connection;
 
-      const getConnection = (socket: WebSocket) => {
-        const current = connections.get(socket);
-        if (current !== undefined) {
-          return current;
-        }
+          connections.set(socket, connection);
+          yield* Attachments.serialize(socket, {
+            id: connection.id,
+            connectedAt: connection.connectedAt,
+            lastHeartbeat: connection.lastHeartbeat,
+            roomId: connection.roomId,
+            userId: connection.userId,
+            restored: connection.restored,
+          } satisfies ConnectionAttachment);
 
-        const attachment = readAttachment(socket);
-        if (attachment === undefined) {
-          return undefined;
-        }
+          return connection;
+        });
 
-        return remember(
+      for (const { socket, attachment } of yield* Attachments.rehydrate({
+        onInvalid: "ignore-and-close",
+      })) {
+        yield* remember(
           socket,
           { roomId: attachment.roomId, userId: attachment.userId },
-          attachment,
+          { ...attachment, restored: true },
         );
-      };
+      }
 
-      const pruneStale = () => {
+      const getConnection = (
+        socket: ConnectionSocket,
+      ): Effect.Effect<Connection | undefined, unknown> =>
+        Effect.gen(function* () {
+          const current = connections.get(socket);
+          if (current !== undefined) {
+            return current;
+          }
+
+          const attachment = yield* Attachments.deserialize(socket).pipe(
+            Effect.catch(() => Effect.succeed(Option.none())),
+          );
+          if (Option.isNone(attachment)) {
+            return undefined;
+          }
+
+          return yield* remember(
+            socket,
+            { roomId: attachment.value.roomId, userId: attachment.value.userId },
+            attachment.value,
+          );
+        });
+
+      const pruneStale = Effect.gen(function* () {
         const now = Date.now();
-        for (const socket of state.raw.getWebSockets()) {
-          const connection = getConnection(socket);
+        for (const socket of yield* state.getWebSockets()) {
+          const connection = yield* getConnection(socket);
           if (connection !== undefined && now - connection.lastHeartbeat > heartbeatTtlMillis) {
             connections.delete(socket);
-            socket.close(1000, "heartbeat timeout");
+            yield* socket.close(1000, "heartbeat timeout").pipe(Effect.ignore);
           }
         }
-      };
+      });
 
       return {
-        add: (socket, metadata) => Effect.sync(() => remember(socket, metadata)),
+        add: (socket, metadata) => remember(socket, metadata),
         heartbeat: (socket) =>
-          Effect.sync(() => {
-            const current = getConnection(socket);
+          Effect.gen(function* () {
+            const current = yield* getConnection(socket);
             const metadata = current ?? { roomId: "general", userId: "anonymous" };
-            return remember(socket, metadata, {
+            return yield* remember(socket, metadata, {
               id: current?.id,
               connectedAt: current?.connectedAt,
               restored: current?.restored,
             });
           }),
-        get: (socket) => Effect.sync(() => getConnection(socket)),
+        get: (socket) => getConnection(socket),
         remove: (socket) =>
-          Effect.sync(() => {
-            const connection = getConnection(socket);
+          Effect.gen(function* () {
+            const connection = yield* getConnection(socket);
             connections.delete(socket);
             return connection;
           }),
         list: (roomId) =>
-          Effect.sync(() => {
-            pruneStale();
+          Effect.gen(function* () {
+            yield* pruneStale;
             return Array.from(connections.values())
               .filter((connection) => connection.roomId === roomId)
               .map(toPeer);
@@ -193,9 +174,7 @@ export class ConnectionManager extends Context.Service<
         restoredCount: Effect.sync(
           () => Array.from(connections.values()).filter((connection) => connection.restored).length,
         ),
-        cleanup: Effect.sync(() => {
-          pruneStale();
-        }),
+        cleanup: pruneStale,
         count: Effect.sync(() => connections.size),
       } satisfies ConnectionManagerService;
     }),

--- a/examples/chat/durable-objects/chat-room/src/index.ts
+++ b/examples/chat/durable-objects/chat-room/src/index.ts
@@ -19,19 +19,13 @@ const roomFromRequest = (request: Request) => {
 
 type ChatRoomContext = ConnectionManager | ChatRepository;
 
-const layer: Layer.Layer<ChatRoomContext, never, DurableObjectState.DurableObjectState> =
+const layer: Layer.Layer<ChatRoomContext, unknown, DurableObjectState.DurableObjectState> =
   Layer.mergeAll(ConnectionManager.layer, ChatRepository.layer);
 
 const encode = (event: ChatServerEvent) => JSON.stringify(event);
 
-const send = (socket: WebSocket, event: ChatServerEvent) => {
-  try {
-    socket.send(encode(event));
-  } catch {
-    // Broadcasts are best-effort. A racing close must not make an already-persisted
-    // message fail its RPC caller.
-  }
-};
+const send = (socket: DurableObjectWebSocket.DurableWebSocket, event: ChatServerEvent) =>
+  socket.send(encode(event)).pipe(Effect.ignore);
 
 const parseClientEvent = (message: string): ChatClientEvent | undefined => {
   try {
@@ -68,11 +62,7 @@ const broadcastPresence = (roomId: string) =>
     });
 
     for (const peer of yield* state.getWebSockets(roomId)) {
-      try {
-        peer.send(payload);
-      } catch {
-        // Best-effort presence update.
-      }
+      yield* peer.send(payload).pipe(Effect.ignore);
     }
   });
 
@@ -91,11 +81,7 @@ const appendAndBroadcast = (
     const payload = encode({ type: "message", message });
 
     for (const peer of yield* state.getWebSockets(message.roomId)) {
-      try {
-        peer.send(payload);
-      } catch {
-        // Best-effort message fanout after durable persistence.
-      }
+      yield* peer.send(payload).pipe(Effect.ignore);
     }
 
     return message;
@@ -136,7 +122,7 @@ const ChatRoomLive = ChatRoom.make(layer, {
     const peers = yield* connections.list(roomId);
     const restoredConnections = yield* connections.restoredCount;
 
-    send(upgrade.server, {
+    yield* send(upgrade.server, {
       type: "ready",
       roomId,
       self: {
@@ -157,67 +143,69 @@ const ChatRoomLive = ChatRoom.make(layer, {
 
     return upgrade.response;
   }),
-  webSocketMessage: (socket, message) =>
-    Effect.gen(function* () {
-      const connections = yield* ConnectionManager;
+  ...DurableObjectWebSocket.handlers<ChatRoomContext | DurableObjectState.DurableObjectState>({
+    message: (socket, message) =>
+      Effect.gen(function* () {
+        const connections = yield* ConnectionManager;
 
-      if (message === "ping") {
-        socket.send("pong");
-        return;
-      }
+        if (message === "ping") {
+          yield* socket.send("pong").pipe(Effect.ignore);
+          return;
+        }
 
-      if (typeof message !== "string") {
-        return;
-      }
+        if (typeof message !== "string") {
+          return;
+        }
 
-      const event = parseClientEvent(message);
-      if (event === undefined) {
-        send(socket, { type: "error", message: "Unsupported chat event" });
-        return;
-      }
+        const event = parseClientEvent(message);
+        if (event === undefined) {
+          yield* send(socket, { type: "error", message: "Unsupported chat event" });
+          return;
+        }
 
-      const connection = yield* connections.heartbeat(socket);
+        const connection = yield* connections.heartbeat(socket);
 
-      if (event.type === "heartbeat") {
-        const count = yield* connections.count;
-        send(socket, {
-          type: "heartbeat",
-          at: new Date(connection.lastHeartbeat).toISOString(),
-          connectionCount: count,
+        if (event.type === "heartbeat") {
+          const count = yield* connections.count;
+          yield* send(socket, {
+            type: "heartbeat",
+            at: new Date(connection.lastHeartbeat).toISOString(),
+            connectionCount: count,
+          });
+          yield* broadcastPresence(connection.roomId);
+          return;
+        }
+
+        const text = event.text.trim();
+        if (text === "") {
+          yield* send(socket, { type: "error", message: "Message text is required" });
+          return;
+        }
+
+        yield* appendAndBroadcast({
+          roomId: connection.roomId,
+          userId: connection.userId,
+          text,
         });
         yield* broadcastPresence(connection.roomId);
-        return;
-      }
-
-      const text = event.text.trim();
-      if (text === "") {
-        send(socket, { type: "error", message: "Message text is required" });
-        return;
-      }
-
-      yield* appendAndBroadcast({
-        roomId: connection.roomId,
-        userId: connection.userId,
-        text,
-      });
-      yield* broadcastPresence(connection.roomId);
-    }),
-  webSocketClose: (socket) =>
-    Effect.gen(function* () {
-      const connections = yield* ConnectionManager;
-      const connection = yield* connections.remove(socket);
-      if (connection !== undefined) {
-        yield* broadcastPresence(connection.roomId);
-      }
-    }),
-  webSocketError: (socket) =>
-    Effect.gen(function* () {
-      const connections = yield* ConnectionManager;
-      const connection = yield* connections.remove(socket);
-      if (connection !== undefined) {
-        yield* broadcastPresence(connection.roomId);
-      }
-    }),
+      }),
+    close: (socket) =>
+      Effect.gen(function* () {
+        const connections = yield* ConnectionManager;
+        const connection = yield* connections.remove(socket);
+        if (connection !== undefined) {
+          yield* broadcastPresence(connection.roomId);
+        }
+      }),
+    error: (socket) =>
+      Effect.gen(function* () {
+        const connections = yield* ConnectionManager;
+        const connection = yield* connections.remove(socket);
+        if (connection !== undefined) {
+          yield* broadcastPresence(connection.roomId);
+        }
+      }),
+  }),
   alarm: () =>
     Effect.gen(function* () {
       const connections = yield* ConnectionManager;

--- a/examples/todo-rpc-ws/durable-objects/todo-store/src/index.ts
+++ b/examples/todo-rpc-ws/durable-objects/todo-store/src/index.ts
@@ -72,21 +72,23 @@ export const TodoStoreLive = DurableObject.make(layer, {
     yield* transport.accept(upgrade.server);
     return upgrade.response;
   }),
-  webSocketMessage: (socket, message) =>
-    Effect.gen(function* () {
-      const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
-      yield* transport.message(socket, message);
-    }),
-  webSocketClose: (socket) =>
-    Effect.gen(function* () {
-      const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
-      yield* transport.close(socket);
-    }),
-  webSocketError: (socket, error) =>
-    Effect.gen(function* () {
-      const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
-      yield* transport.error(socket, error);
-    }),
+  ...DurableObjectWebSocket.handlers({
+    message: (socket, message) =>
+      Effect.gen(function* () {
+        const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
+        yield* transport.message(socket, message);
+      }),
+    close: (socket) =>
+      Effect.gen(function* () {
+        const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
+        yield* transport.close(socket);
+      }),
+    error: (socket, error) =>
+      Effect.gen(function* () {
+        const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
+        yield* transport.error(socket, error);
+      }),
+  }),
 });
 export class TodoStoreDurableObject extends TodoStoreLive {}
 export default Worker.make(Layer.empty, {

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -71,6 +71,66 @@ export const CounterDurableObject = Counter.make(Layer.empty, {
 
 Define Wrangler bindings and migrations in the consuming application.
 
+## Durable Object WebSockets
+
+Durable Object application sockets should use the hibernation-compatible state API. Accept sockets with `DurableObjectWebSocket.acceptUpgrade(...)`; do not call `server.accept()` or attach native `message` listeners in application code.
+
+```ts
+import { Effect, Schema as S } from "effect";
+import { DurableObjectState, DurableObjectWebSocket, Worker } from "effect-cf";
+
+const ConnectionAttachment = S.Struct({
+  id: S.String,
+  roomId: S.String,
+});
+
+const Attachments = DurableObjectWebSocket.attachment(ConnectionAttachment);
+
+export const fetch = Effect.gen(function* () {
+  const request = yield* Worker.NativeRequest;
+
+  if (!Worker.isWebSocketUpgrade(request)) {
+    return new Response("Expected WebSocket upgrade", { status: 426 });
+  }
+
+  const upgrade = yield* DurableObjectWebSocket.acceptUpgrade({ tags: ["room:general"] });
+  yield* Attachments.serialize(upgrade.server, {
+    id: crypto.randomUUID(),
+    roomId: "general",
+  });
+  yield* upgrade.server.send(JSON.stringify({ type: "ready" }));
+
+  return upgrade.response;
+});
+```
+
+`DurableWebSocket` keeps the native socket available as `socket.raw`, while `send`, `close`, `serializeAttachment`, and `deserializeAttachment` return typed `Effect` failures. Use `state.getWebSockets(tag)` to retrieve wrapped sockets for broadcast and rehydration.
+
+Schema-backed attachments can rehydrate hibernated sockets:
+
+```ts
+const restored =
+  yield *
+  Attachments.rehydrate({
+    tag: "room:general",
+    onInvalid: "ignore-and-close",
+  });
+
+for (const { socket, attachment } of restored) {
+  yield * socket.send(`restored:${attachment.id}`).pipe(Effect.ignore);
+}
+```
+
+Worker-to-Durable-Object forwarding should stay native so WebSocket upgrade responses are preserved:
+
+```ts
+if (Worker.isWebSocketUpgrade(request)) {
+  return yield * ChatRooms.byName(roomId).fetch(request);
+}
+```
+
+Use `DurableObjectRpcWebSocket.layer(...)` for Effect RPC-over-WebSocket transports. It owns protocol parsing and RPC client bookkeeping; use `DurableWebSocket` for general application sockets, rooms, presence, and broadcast flows.
+
 ## License
 
 MIT

--- a/packages/effect-cf/src/DurableObjectRpcWebSocket.ts
+++ b/packages/effect-cf/src/DurableObjectRpcWebSocket.ts
@@ -4,6 +4,7 @@ import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
 import * as RpcServer from "effect/unstable/rpc/RpcServer";
 
 import { DurableObjectState } from "./DurableObjectState";
+import type { DurableWebSocket } from "./DurableObjectWebSocket";
 
 const defaultAttachmentKey = "effectCloudflareRpcClientId";
 const defaultTag = "effect-cf-rpc";
@@ -25,15 +26,18 @@ export type NativeWebSocketMessage = string | ArrayBuffer;
  * Service API used to wire websocket lifecycle events to Effect RPC server protocol.
  */
 export interface DurableObjectRpcWebSocketService {
-  readonly accept: (socket: WebSocket) => Effect.Effect<void>;
-  readonly message: (socket: WebSocket, message: NativeWebSocketMessage) => Effect.Effect<void>;
-  readonly close: (socket: WebSocket) => Effect.Effect<void>;
-  readonly error: (socket: WebSocket, error: unknown) => Effect.Effect<void>;
+  readonly accept: (socket: DurableWebSocket) => Effect.Effect<void>;
+  readonly message: (
+    socket: DurableWebSocket,
+    message: NativeWebSocketMessage,
+  ) => Effect.Effect<void>;
+  readonly close: (socket: DurableWebSocket) => Effect.Effect<void>;
+  readonly error: (socket: DurableWebSocket, error: unknown) => Effect.Effect<void>;
 }
 
 interface RpcConnection {
   readonly id: number;
-  readonly socket: WebSocket;
+  readonly socket: DurableWebSocket;
   readonly parser: RpcSerialization.Parser;
 }
 
@@ -64,20 +68,20 @@ export const layer = (options: LayerOptions = {}) =>
         | ((clientId: number, data: RpcMessage.FromClientEncoded) => Effect.Effect<void>)
         | undefined;
 
-      const reserveClientId = (socket: WebSocket) => {
-        const attachment = readAttachment(socket, attachmentKey);
+      const reserveClientId = (socket: DurableWebSocket) => {
+        const attachment = readAttachment(socket.raw, attachmentKey);
         if (attachment !== undefined) {
           nextClientId = Math.max(nextClientId, attachment + 1);
           return attachment;
         }
 
         const id = nextClientId++;
-        writeAttachment(socket, attachmentKey, id);
+        writeAttachment(socket.raw, attachmentKey, id);
         return id;
       };
 
-      const register = (socket: WebSocket) => {
-        const existing = connectionsBySocket.get(socket);
+      const register = (socket: DurableWebSocket) => {
+        const existing = connectionsBySocket.get(socket.raw);
         if (existing !== undefined) {
           return existing;
         }
@@ -88,20 +92,20 @@ export const layer = (options: LayerOptions = {}) =>
           parser: serialization.makeUnsafe(),
         } satisfies RpcConnection;
 
-        connectionsBySocket.set(socket, connection);
+        connectionsBySocket.set(socket.raw, connection);
         connectionsById.set(connection.id, connection);
         clientIds.add(connection.id);
         return connection;
       };
 
-      const unregister = (socket: WebSocket) =>
+      const unregister = (socket: DurableWebSocket) =>
         Effect.sync(() => {
-          const connection = connectionsBySocket.get(socket);
+          const connection = connectionsBySocket.get(socket.raw);
           if (connection === undefined) {
             return;
           }
 
-          connectionsBySocket.delete(socket);
+          connectionsBySocket.delete(socket.raw);
           connectionsById.delete(connection.id);
           clientIds.delete(connection.id);
           Queue.offerUnsafe(disconnects, connection.id);
@@ -116,12 +120,12 @@ export const layer = (options: LayerOptions = {}) =>
           try {
             const encoded = connection.parser.encode(response);
             if (encoded !== undefined) {
-              connection.socket.send(encoded);
+              connection.socket.raw.send(encoded);
             }
           } catch (cause) {
             const encoded = connection.parser.encode(RpcMessage.ResponseDefectEncoded(cause));
             if (encoded !== undefined) {
-              connection.socket.send(encoded);
+              connection.socket.raw.send(encoded);
             }
           }
         });
@@ -138,7 +142,7 @@ export const layer = (options: LayerOptions = {}) =>
           end: (clientId) =>
             Effect.sync(() => {
               const connection = connectionsById.get(clientId);
-              connection?.socket.close();
+              connection?.socket.raw.close();
             }),
           clientIds: Effect.sync(() => clientIds),
           initialMessage: Effect.succeed(Option.none()),

--- a/packages/effect-cf/src/DurableObjectState.ts
+++ b/packages/effect-cf/src/DurableObjectState.ts
@@ -1,6 +1,7 @@
 import { Cause, Context, Effect, Exit } from "effect";
 
 import { fromDurableObjectStorage, type DurableObjectStorage } from "./DurableObjectStorage";
+import { fromWebSocket, type DurableWebSocket } from "./DurableObjectWebSocket";
 
 /**
  * Effect-friendly wrapper around Cloudflare `DurableObjectState`.
@@ -35,21 +36,21 @@ export interface DurableObjectStateService {
    */
   blockConcurrencyWhileOrReset<A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R>;
   /** Accepts a websocket connection for hibernation-capable Durable Objects. */
-  acceptWebSocket(ws: WebSocket, tags?: Array<string>): Effect.Effect<void>;
+  acceptWebSocket(ws: DurableWebSocket, tags?: Array<string>): Effect.Effect<void>;
   /** Lists active sockets, optionally filtered by tag. */
-  getWebSockets(tag?: string): Effect.Effect<Array<WebSocket>>;
+  getWebSockets(tag?: string): Effect.Effect<Array<DurableWebSocket>>;
   /** Configures automatic request/response handling for sockets. */
   setWebSocketAutoResponse(pair?: WebSocketRequestResponsePair): Effect.Effect<void>;
   /** Gets the configured websocket auto-response pair. */
   getWebSocketAutoResponse: Effect.Effect<WebSocketRequestResponsePair | null>;
   /** Timestamp of the last automatic websocket response for a socket. */
-  getWebSocketAutoResponseTimestamp(ws: WebSocket): Effect.Effect<Date | null>;
+  getWebSocketAutoResponseTimestamp(ws: DurableWebSocket): Effect.Effect<Date | null>;
   /** Sets the timeout for hibernatable websocket events. */
   setHibernatableWebSocketEventTimeout(timeoutMs?: number): Effect.Effect<void>;
   /** Gets the timeout for hibernatable websocket events. */
   getHibernatableWebSocketEventTimeout: Effect.Effect<number | null>;
   /** Reads tags attached to a websocket. */
-  getTags(ws: WebSocket): Effect.Effect<Array<string>>;
+  getTags(ws: DurableWebSocket): Effect.Effect<Array<string>>;
   /**
    * Forcibly resets the Durable Object. Cloudflare logs an uncaught Error using
    * the optional reason, and the method is not available in `wrangler dev` local
@@ -97,20 +98,21 @@ export const fromDurableObjectState = (
         ),
       ),
     ),
-  acceptWebSocket: (ws: WebSocket, tags?: Array<string>) =>
-    Effect.sync(() => state.acceptWebSocket(ws, tags)),
-  getWebSockets: (tag?: string) => Effect.sync(() => state.getWebSockets(tag)),
+  acceptWebSocket: (ws: DurableWebSocket, tags?: Array<string>) =>
+    Effect.sync(() => state.acceptWebSocket(ws.raw, tags)),
+  getWebSockets: (tag?: string) =>
+    Effect.sync(() => state.getWebSockets(tag).map((socket) => fromWebSocket(socket))),
   setWebSocketAutoResponse: (pair?: WebSocketRequestResponsePair) =>
     Effect.sync(() => state.setWebSocketAutoResponse(pair)),
   getWebSocketAutoResponse: Effect.sync(() => state.getWebSocketAutoResponse()),
-  getWebSocketAutoResponseTimestamp: (ws: WebSocket) =>
-    Effect.sync(() => state.getWebSocketAutoResponseTimestamp(ws)),
+  getWebSocketAutoResponseTimestamp: (ws: DurableWebSocket) =>
+    Effect.sync(() => state.getWebSocketAutoResponseTimestamp(ws.raw)),
   setHibernatableWebSocketEventTimeout: (timeoutMs?: number) =>
     Effect.sync(() => state.setHibernatableWebSocketEventTimeout(timeoutMs)),
   getHibernatableWebSocketEventTimeout: Effect.sync(() =>
     state.getHibernatableWebSocketEventTimeout(),
   ),
-  getTags: (ws: WebSocket) => Effect.sync(() => state.getTags(ws)),
+  getTags: (ws: DurableWebSocket) => Effect.sync(() => state.getTags(ws.raw)),
   abort: (reason?: string) => Effect.sync(() => state.abort(reason)),
 });
 

--- a/packages/effect-cf/src/DurableObjectWebSocket.ts
+++ b/packages/effect-cf/src/DurableObjectWebSocket.ts
@@ -1,6 +1,81 @@
-import { Effect } from "effect";
+import { Data, Effect, Option, Schema as S } from "effect";
 
 import { DurableObjectState } from "./DurableObjectState";
+
+/** Data supported by Cloudflare websocket `send`. */
+export type DurableWebSocketSendData = string | ArrayBuffer | ArrayBufferView;
+
+/** Error raised when sending on a Durable Object websocket fails. */
+export class DurableWebSocketSendError extends Data.TaggedError("DurableWebSocketSendError")<{
+  readonly cause: unknown;
+}> {}
+
+/** Error raised when closing a Durable Object websocket fails. */
+export class DurableWebSocketCloseError extends Data.TaggedError("DurableWebSocketCloseError")<{
+  readonly cause: unknown;
+}> {}
+
+/** Error raised when serializing or deserializing a websocket attachment fails. */
+export class DurableWebSocketAttachmentError extends Data.TaggedError(
+  "DurableWebSocketAttachmentError",
+)<{
+  readonly operation: "serialize" | "deserialize";
+  readonly cause: unknown;
+}> {}
+
+/** Effect-native wrapper around a hibernatable Durable Object websocket. */
+export interface DurableWebSocket<Attachment = unknown> {
+  /** Underlying Cloudflare websocket. */
+  readonly raw: WebSocket;
+  /** Sends a message through the socket. */
+  send(data: DurableWebSocketSendData): Effect.Effect<void, DurableWebSocketSendError>;
+  /** Closes the socket. */
+  close(code?: number, reason?: string): Effect.Effect<void, DurableWebSocketCloseError>;
+  /** Serializes hibernation attachment metadata onto the socket. */
+  serializeAttachment<A = Attachment>(
+    value: A,
+  ): Effect.Effect<void, DurableWebSocketAttachmentError>;
+  /** Deserializes hibernation attachment metadata from the socket. */
+  readonly deserializeAttachment: Effect.Effect<unknown, DurableWebSocketAttachmentError>;
+}
+
+const wrappers = new WeakMap<WebSocket, DurableWebSocket<unknown>>();
+
+/** Wraps a native Cloudflare websocket in the Effect-native Durable Object API. */
+export const fromWebSocket = <Attachment = unknown>(
+  raw: WebSocket,
+): DurableWebSocket<Attachment> => {
+  const existing = wrappers.get(raw);
+  if (existing !== undefined) {
+    return existing as DurableWebSocket<Attachment>;
+  }
+
+  const socket: DurableWebSocket<unknown> = {
+    raw,
+    send: (data) =>
+      Effect.try({
+        try: () => raw.send(data),
+        catch: (cause) => new DurableWebSocketSendError({ cause }),
+      }),
+    close: (code, reason) =>
+      Effect.try({
+        try: () => raw.close(code, reason),
+        catch: (cause) => new DurableWebSocketCloseError({ cause }),
+      }),
+    serializeAttachment: (value) =>
+      Effect.try({
+        try: () => raw.serializeAttachment(value),
+        catch: (cause) => new DurableWebSocketAttachmentError({ operation: "serialize", cause }),
+      }),
+    deserializeAttachment: Effect.try({
+      try: () => raw.deserializeAttachment(),
+      catch: (cause) => new DurableWebSocketAttachmentError({ operation: "deserialize", cause }),
+    }),
+  };
+
+  wrappers.set(raw, socket);
+  return socket as DurableWebSocket<Attachment>;
+};
 
 /**
  * Options for accepting an incoming websocket request in a Durable Object.
@@ -15,9 +90,9 @@ export interface AcceptUpgradeOptions<Attachment = unknown> {
 /**
  * Result of a websocket upgrade accepted by {@link acceptUpgrade}.
  */
-export interface AcceptedUpgrade {
+export interface AcceptedUpgrade<Attachment = unknown> {
   readonly client: WebSocket;
-  readonly server: WebSocket;
+  readonly server: DurableWebSocket<Attachment>;
   readonly response: Response;
 }
 
@@ -35,15 +110,15 @@ export interface AcceptedUpgrade {
  */
 export const acceptUpgrade = <Attachment = unknown>(
   options: AcceptUpgradeOptions<Attachment> = {},
-): Effect.Effect<AcceptedUpgrade, never, DurableObjectState> =>
+): Effect.Effect<AcceptedUpgrade<Attachment>, never, DurableObjectState> =>
   Effect.gen(function* () {
     const state = yield* DurableObjectState;
     const pair = new WebSocketPair();
     const client = pair[0];
-    const server = pair[1];
+    const server = fromWebSocket<Attachment>(pair[1]);
 
     if (options.attachment !== undefined) {
-      server.serializeAttachment(options.attachment);
+      server.raw.serializeAttachment(options.attachment);
     }
 
     yield* state.acceptWebSocket(
@@ -60,3 +135,137 @@ export const acceptUpgrade = <Attachment = unknown>(
       }),
     };
   });
+
+export type AttachmentInvalidPolicy = "ignore" | "ignore-and-close" | "fail";
+
+export interface AttachmentRehydrateOptions {
+  /** Optional Durable Object websocket tag filter. */
+  readonly tag?: string | undefined;
+  /** Invalid attachment behavior. Defaults to skipping invalid sockets. */
+  readonly onInvalid?: AttachmentInvalidPolicy | undefined;
+}
+
+export interface RehydratedDurableWebSocket<Attachment> {
+  readonly socket: DurableWebSocket<Attachment>;
+  readonly attachment: Attachment;
+}
+
+export interface DurableWebSocketAttachment<Attachment, Encoded> {
+  serialize(
+    socket: DurableWebSocket<unknown>,
+    value: Attachment,
+  ): Effect.Effect<void, DurableWebSocketAttachmentError>;
+  deserialize(
+    socket: DurableWebSocket<unknown>,
+  ): Effect.Effect<Option.Option<Attachment>, DurableWebSocketAttachmentError>;
+  rehydrate(
+    options?: AttachmentRehydrateOptions,
+  ): Effect.Effect<
+    Array<RehydratedDurableWebSocket<Attachment>>,
+    DurableWebSocketAttachmentError,
+    DurableObjectState
+  >;
+  readonly schema: S.Codec<Attachment, Encoded, never, never>;
+}
+
+/** Creates typed attachment helpers for accepted and rehydrated sockets. */
+export const attachment = <const AttachmentSchema extends S.Codec<any, any, never, never>>(
+  schema: AttachmentSchema,
+): DurableWebSocketAttachment<
+  S.Schema.Type<AttachmentSchema>,
+  S.Codec.Encoded<AttachmentSchema>
+> => {
+  type Attachment = S.Schema.Type<AttachmentSchema>;
+  type Encoded = S.Codec.Encoded<AttachmentSchema>;
+
+  const serialize = (socket: DurableWebSocket<unknown>, value: Attachment) =>
+    S.encodeEffect(schema)(value).pipe(
+      Effect.mapError(
+        (cause) => new DurableWebSocketAttachmentError({ operation: "serialize", cause }),
+      ),
+      Effect.flatMap((encoded) => socket.serializeAttachment(encoded as Encoded)),
+    );
+
+  const deserialize = (socket: DurableWebSocket<unknown>) =>
+    Effect.gen(function* () {
+      const value = yield* socket.deserializeAttachment;
+      if (value == null) {
+        return Option.none<Attachment>();
+      }
+
+      return Option.some(
+        yield* S.decodeUnknownEffect(schema)(value).pipe(
+          Effect.mapError(
+            (cause) => new DurableWebSocketAttachmentError({ operation: "deserialize", cause }),
+          ),
+        ),
+      );
+    });
+
+  const rehydrate = (options: AttachmentRehydrateOptions = {}) =>
+    Effect.gen(function* () {
+      const state = yield* DurableObjectState;
+      const sockets = yield* state.getWebSockets(options.tag);
+      const restored: Array<RehydratedDurableWebSocket<Attachment>> = [];
+      const onInvalid = options.onInvalid ?? "ignore";
+
+      for (const socket of sockets) {
+        const decoded = yield* deserialize(socket).pipe(
+          Effect.match({
+            onFailure: (error) => ({ _tag: "Failure" as const, error }),
+            onSuccess: (value) => ({ _tag: "Success" as const, value }),
+          }),
+        );
+
+        if (decoded._tag === "Success" && Option.isSome(decoded.value)) {
+          restored.push({ socket, attachment: decoded.value.value });
+          continue;
+        }
+
+        if (decoded._tag === "Failure" && onInvalid === "fail") {
+          return yield* Effect.fail(decoded.error);
+        }
+
+        if (decoded._tag === "Failure" && onInvalid === "ignore-and-close") {
+          yield* socket.close(1008, "invalid websocket attachment").pipe(Effect.ignore);
+        }
+      }
+
+      return restored;
+    });
+
+  return { serialize, deserialize, rehydrate, schema };
+};
+
+export interface DurableWebSocketHandlers<R = never, E = unknown> {
+  readonly message?: (
+    socket: DurableWebSocket,
+    message: string | ArrayBuffer,
+  ) => Effect.Effect<void, E, R>;
+  readonly close?: (
+    socket: DurableWebSocket,
+    code: number,
+    reason: string,
+    wasClean: boolean,
+  ) => Effect.Effect<void, E, R>;
+  readonly error?: (socket: DurableWebSocket, error: unknown) => Effect.Effect<void, E, R>;
+}
+
+/** Adapts wrapped websocket lifecycle handlers to `DurableObject.make` raw callbacks. */
+export const handlers = <R = never, E = unknown>(options: DurableWebSocketHandlers<R, E>) => ({
+  webSocketMessage:
+    options.message === undefined
+      ? undefined
+      : (socket: WebSocket, message: string | ArrayBuffer) =>
+          options.message?.(fromWebSocket(socket), message) ?? Effect.void,
+  webSocketClose:
+    options.close === undefined
+      ? undefined
+      : (socket: WebSocket, code: number, reason: string, wasClean: boolean) =>
+          options.close?.(fromWebSocket(socket), code, reason, wasClean) ?? Effect.void,
+  webSocketError:
+    options.error === undefined
+      ? undefined
+      : (socket: WebSocket, error: unknown) =>
+          options.error?.(fromWebSocket(socket), error) ?? Effect.void,
+});

--- a/packages/effect-cf/tests/DurableObjectRpcWebSocket.test.ts
+++ b/packages/effect-cf/tests/DurableObjectRpcWebSocket.test.ts
@@ -5,7 +5,11 @@ import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
 import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
 import * as RpcServer from "effect/unstable/rpc/RpcServer";
 
-import { DurableObjectRpcWebSocket, DurableObjectState } from "../src/index";
+import {
+  DurableObjectRpcWebSocket,
+  DurableObjectState,
+  DurableObjectWebSocket,
+} from "../src/index";
 
 class PingResult extends Schema.Class<PingResult>("PingResult")({
   nonce: Schema.String,
@@ -30,6 +34,7 @@ const TestRpcHandlers = TestRpcs.toLayer(
 
 {
   const socket = makeFakeWebSocket();
+  const durableSocket = DurableObjectWebSocket.fromWebSocket(socket);
   const state = makeFakeDurableObjectState();
 
   layer(makeAppLayer(state))("DurableObjectRpcWebSocket", (it) => {
@@ -37,9 +42,9 @@ const TestRpcHandlers = TestRpcs.toLayer(
       Effect.gen(function* () {
         const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
 
-        yield* transport.accept(socket);
+        yield* transport.accept(durableSocket);
         yield* transport.message(
-          socket,
+          durableSocket,
           JSON.stringify({
             _tag: "Request",
             id: "1",
@@ -68,6 +73,7 @@ const TestRpcHandlers = TestRpcs.toLayer(
 
 {
   const socket = makeFakeWebSocket({ effectCloudflareRpcClientId: 7 });
+  const durableSocket = DurableObjectWebSocket.fromWebSocket(socket);
   const state = makeFakeDurableObjectState({
     socketsByTag: new Map([["test-rpc", [socket]]]),
   });
@@ -82,7 +88,7 @@ const TestRpcHandlers = TestRpcs.toLayer(
         assert.deepStrictEqual(Array.from(clientIds), [7]);
 
         yield* transport.message(
-          socket,
+          durableSocket,
           JSON.stringify({
             _tag: "Request",
             id: "1",
@@ -175,19 +181,20 @@ function makeFakeDurableObjectState(options?: {
     blockConcurrencyWhileOrReset: (effect) => effect,
     acceptWebSocket: (socket, tags) =>
       Effect.sync(() => {
-        accepted.push({ socket, tags });
+        accepted.push({ socket: socket.raw, tags });
         for (const tag of tags ?? []) {
           const current = socketsByTag.get(tag) ?? [];
-          current.push(socket);
+          current.push(socket.raw);
           socketsByTag.set(tag, current);
         }
       }),
     getWebSockets: (tag) =>
       Effect.sync(() => {
-        if (tag !== undefined) {
-          return socketsByTag.get(tag) ?? [];
-        }
-        return Array.from(socketsByTag.values()).flat();
+        const sockets =
+          tag !== undefined
+            ? (socketsByTag.get(tag) ?? [])
+            : Array.from(socketsByTag.values()).flat();
+        return sockets.map((socket) => DurableObjectWebSocket.fromWebSocket(socket));
       }),
     setWebSocketAutoResponse: () => Effect.void,
     getWebSocketAutoResponse: Effect.succeed(null),

--- a/packages/effect-cf/tests/DurableObjectState.test.ts
+++ b/packages/effect-cf/tests/DurableObjectState.test.ts
@@ -1,7 +1,7 @@
 import { assert, it } from "@effect/vitest";
 import { Cause, Context, Effect } from "effect";
 
-import { DurableObjectState } from "../src/index";
+import { DurableObjectState, DurableObjectWebSocket } from "../src/index";
 
 const FailureMessage = Context.Service<{ readonly message: string }>(
   "effect-cf/test/FailureMessage",
@@ -74,9 +74,17 @@ it.effect("wraps hibernation metadata and abort helpers", () =>
 
     tracker.tags.set(ws, ["room:general", "user:1"]);
     tracker.autoResponseTimestamps.set(ws, timestamp);
+    tracker.sockets = [ws];
+    const socket = DurableObjectWebSocket.fromWebSocket(ws);
 
-    assert.deepStrictEqual(yield* service.getTags(ws), ["room:general", "user:1"]);
-    assert.strictEqual(yield* service.getWebSocketAutoResponseTimestamp(ws), timestamp);
+    assert.deepStrictEqual(yield* service.getTags(socket), ["room:general", "user:1"]);
+    assert.strictEqual(yield* service.getWebSocketAutoResponseTimestamp(socket), timestamp);
+    yield* service.acceptWebSocket(socket, ["room:general"]);
+    assert.deepStrictEqual(tracker.acceptedSockets, [{ socket: ws, tags: ["room:general"] }]);
+    assert.deepStrictEqual(
+      (yield* service.getWebSockets()).map((socket) => socket.raw),
+      [ws],
+    );
 
     assert.strictEqual(yield* service.getHibernatableWebSocketEventTimeout, null);
     yield* service.setHibernatableWebSocketEventTimeout(1_000);
@@ -95,6 +103,11 @@ interface BlockConcurrencyTracker {
   readonly rejected: Array<unknown>;
   readonly tags: Map<WebSocket, Array<string>>;
   readonly autoResponseTimestamps: Map<WebSocket, Date>;
+  readonly acceptedSockets: Array<{
+    readonly socket: WebSocket;
+    readonly tags: Array<string> | undefined;
+  }>;
+  sockets: Array<WebSocket>;
   hibernatableTimeout: number | null;
   readonly abortReasons: Array<string | undefined>;
 }
@@ -109,6 +122,8 @@ function makeRawDurableObjectState(): {
     rejected: [],
     tags: new Map(),
     autoResponseTimestamps: new Map(),
+    acceptedSockets: [],
+    sockets: [],
     hibernatableTimeout: null,
     abortReasons: [],
   };
@@ -129,8 +144,10 @@ function makeRawDurableObjectState(): {
         throw error;
       }
     },
-    acceptWebSocket: () => {},
-    getWebSockets: () => [],
+    acceptWebSocket: (socket: WebSocket, tags?: Array<string>) => {
+      tracker.acceptedSockets.push({ socket, tags });
+    },
+    getWebSockets: () => tracker.sockets,
     setWebSocketAutoResponse: () => {},
     getWebSocketAutoResponse: () => null,
     getWebSocketAutoResponseTimestamp: (ws: WebSocket) =>

--- a/packages/effect-cf/tests/DurableObjectWebSocket.worker.test.ts
+++ b/packages/effect-cf/tests/DurableObjectWebSocket.worker.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, it, test } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Option, Schema as S } from "effect";
 
 import { DurableObjectState, DurableObjectWebSocket, Worker } from "../src/index";
 
@@ -35,13 +35,95 @@ it.effect("acceptUpgrade accepts the server socket and returns the client respon
       ),
     );
 
-    assert.deepStrictEqual(upgrade.server.deserializeAttachment(), {
+    assert.deepStrictEqual(yield* upgrade.server.deserializeAttachment, {
       roomId: "general",
       userId: "ada",
     });
-    assert.deepStrictEqual(state.accepted, [{ socket: upgrade.server, tags: ["room:general"] }]);
+    assert.deepStrictEqual(state.accepted, [
+      { socket: upgrade.server.raw, tags: ["room:general"] },
+    ]);
     assert.strictEqual(upgrade.response.status, 101);
     assert.strictEqual(upgrade.response.webSocket, upgrade.client);
+  }),
+);
+
+it.effect("wraps send, close, and attachment operations as Effects", () =>
+  Effect.gen(function* () {
+    const raw = makeFakeWebSocket();
+    const socket = DurableObjectWebSocket.fromWebSocket(raw);
+
+    yield* socket.send("hello");
+    yield* socket.close(1000, "done");
+    yield* socket.serializeAttachment({ id: "abc" });
+
+    assert.deepStrictEqual(raw.sent, ["hello"]);
+    assert.deepStrictEqual(raw.closed, [{ code: 1000, reason: "done" }]);
+    assert.deepStrictEqual(yield* socket.deserializeAttachment, { id: "abc" });
+  }),
+);
+
+it.effect("returns typed failures for wrapped send and close errors", () =>
+  Effect.gen(function* () {
+    const sendError = new Error("send failed");
+    const closeError = new Error("close failed");
+    const sendFailure = yield* DurableObjectWebSocket.fromWebSocket(
+      makeFakeWebSocket({ sendError }),
+    )
+      .send("hello")
+      .pipe(Effect.flip);
+    const closeFailure = yield* DurableObjectWebSocket.fromWebSocket(
+      makeFakeWebSocket({ closeError }),
+    )
+      .close()
+      .pipe(Effect.flip);
+
+    assert.strictEqual(sendFailure._tag, "DurableWebSocketSendError");
+    assert.strictEqual(sendFailure.cause, sendError);
+    assert.strictEqual(closeFailure._tag, "DurableWebSocketCloseError");
+    assert.strictEqual(closeFailure.cause, closeError);
+  }),
+);
+
+it.effect("serializes, deserializes, and rehydrates typed attachments", () =>
+  Effect.gen(function* () {
+    const ConnectionAttachment = S.Struct({ id: S.String });
+    const Attachment = DurableObjectWebSocket.attachment(ConnectionAttachment);
+    const valid = makeFakeWebSocket();
+    const invalid = makeFakeWebSocket({ initialAttachment: { id: 1 } });
+    const missing = makeFakeWebSocket();
+    const state = makeFakeDurableObjectState({ sockets: [valid, invalid, missing] });
+
+    const validSocket = DurableObjectWebSocket.fromWebSocket(valid);
+    const invalidSocket = DurableObjectWebSocket.fromWebSocket(invalid);
+
+    yield* Attachment.serialize(validSocket, { id: "abc" });
+    assert.deepStrictEqual(valid.deserializeAttachment(), { id: "abc" });
+
+    const decoded = yield* Attachment.deserialize(validSocket);
+    assert.strictEqual(Option.isSome(decoded), true);
+    if (Option.isSome(decoded)) {
+      assert.deepStrictEqual(decoded.value, { id: "abc" });
+    }
+
+    const decodeFailure = yield* Attachment.deserialize(invalidSocket).pipe(Effect.flip);
+    assert.strictEqual(decodeFailure._tag, "DurableWebSocketAttachmentError");
+    assert.strictEqual(decodeFailure.operation, "deserialize");
+
+    const rehydrated = yield* Attachment.rehydrate({ onInvalid: "ignore-and-close" }).pipe(
+      Effect.provideService(
+        DurableObjectState.DurableObjectState,
+        DurableObjectState.DurableObjectState.of(state),
+      ),
+    );
+
+    assert.deepStrictEqual(
+      rehydrated.map((connection) => connection.attachment),
+      [{ id: "abc" }],
+    );
+    assert.deepStrictEqual(invalid.closed, [
+      { code: 1008, reason: "invalid websocket attachment" },
+    ]);
+    assert.deepStrictEqual(missing.closed, []);
   }),
 );
 
@@ -52,9 +134,12 @@ interface FakeDurableObjectState extends DurableObjectState.DurableObjectStateSe
   }>;
 }
 
-function makeFakeDurableObjectState(): FakeDurableObjectState {
+function makeFakeDurableObjectState(options?: {
+  readonly sockets?: Array<WebSocket>;
+}): FakeDurableObjectState {
   const accepted: Array<{ readonly socket: WebSocket; readonly tags: Array<string> | undefined }> =
     [];
+  const sockets = options?.sockets ?? [];
 
   return {
     raw: {} as globalThis.DurableObjectState,
@@ -65,9 +150,10 @@ function makeFakeDurableObjectState(): FakeDurableObjectState {
     blockConcurrencyWhileOrReset: (effect) => effect,
     acceptWebSocket: (socket, tags) =>
       Effect.sync(() => {
-        accepted.push({ socket, tags });
+        accepted.push({ socket: socket.raw, tags });
       }),
-    getWebSockets: () => Effect.succeed([]),
+    getWebSockets: () =>
+      Effect.succeed(sockets.map((socket) => DurableObjectWebSocket.fromWebSocket(socket))),
     setWebSocketAutoResponse: () => Effect.void,
     getWebSocketAutoResponse: Effect.succeed(null),
     getWebSocketAutoResponseTimestamp: () => Effect.succeed(null),
@@ -77,4 +163,46 @@ function makeFakeDurableObjectState(): FakeDurableObjectState {
     abort: () => Effect.void,
     accepted,
   };
+}
+
+interface FakeWebSocket extends WebSocket {
+  readonly sent: Array<string | ArrayBuffer | ArrayBufferView>;
+  readonly closed: Array<{
+    readonly code: number | undefined;
+    readonly reason: string | undefined;
+  }>;
+}
+
+function makeFakeWebSocket(options?: {
+  readonly initialAttachment?: unknown;
+  readonly sendError?: unknown;
+  readonly closeError?: unknown;
+}): FakeWebSocket {
+  let attachment: unknown = options?.initialAttachment ?? null;
+  const sent: Array<string | ArrayBuffer | ArrayBufferView> = [];
+  const closed: Array<{ readonly code: number | undefined; readonly reason: string | undefined }> =
+    [];
+
+  return {
+    sent,
+    closed,
+    send(message: string | ArrayBuffer | ArrayBufferView) {
+      if (options?.sendError !== undefined) {
+        throw options.sendError;
+      }
+      sent.push(message);
+    },
+    close(code?: number, reason?: string) {
+      if (options?.closeError !== undefined) {
+        throw options.closeError;
+      }
+      closed.push({ code, reason });
+    },
+    serializeAttachment(value: unknown) {
+      attachment = value;
+    },
+    deserializeAttachment() {
+      return attachment;
+    },
+  } as unknown as FakeWebSocket;
 }


### PR DESCRIPTION
## Summary
- Add an Effect-native DurableWebSocket wrapper for Durable Object application sockets, including typed send/close/attachment errors and schema-backed attachment rehydration.
- Make Durable Object websocket state and RPC websocket transport use the wrapped socket surface so examples no longer bridge through raw sockets.
- Update chat and todo RPC websocket examples, docs, tests, and add a changeset for the effect-cf API change.

## Validation
- vp check
- vp test