### PR TITLE
feat!: type durable websocket handlers as DurableWebSocket

### DIFF
--- a/.changeset/wrapped-durable-websocket-handlers.md
+++ b/.changeset/wrapped-durable-websocket-handlers.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": major
+---
+
+Type Durable Object websocket lifecycle handlers with `DurableWebSocket` instead of raw `WebSocket`, so handlers can use the Effect-native durable socket API without manually wrapping Cloudflare sockets.

--- a/examples/chat/durable-objects/chat-room/src/index.ts
+++ b/examples/chat/durable-objects/chat-room/src/index.ts
@@ -143,69 +143,67 @@ const ChatRoomLive = ChatRoom.make(layer, {
 
     return upgrade.response;
   }),
-  ...DurableObjectWebSocket.handlers<ChatRoomContext | DurableObjectState.DurableObjectState>({
-    message: (socket, message) =>
-      Effect.gen(function* () {
-        const connections = yield* ConnectionManager;
+  webSocketMessage: (socket, message) =>
+    Effect.gen(function* () {
+      const connections = yield* ConnectionManager;
 
-        if (message === "ping") {
-          yield* socket.send("pong").pipe(Effect.ignore);
-          return;
-        }
+      if (message === "ping") {
+        yield* socket.send("pong").pipe(Effect.ignore);
+        return;
+      }
 
-        if (typeof message !== "string") {
-          return;
-        }
+      if (typeof message !== "string") {
+        return;
+      }
 
-        const event = parseClientEvent(message);
-        if (event === undefined) {
-          yield* send(socket, { type: "error", message: "Unsupported chat event" });
-          return;
-        }
+      const event = parseClientEvent(message);
+      if (event === undefined) {
+        yield* send(socket, { type: "error", message: "Unsupported chat event" });
+        return;
+      }
 
-        const connection = yield* connections.heartbeat(socket);
+      const connection = yield* connections.heartbeat(socket);
 
-        if (event.type === "heartbeat") {
-          const count = yield* connections.count;
-          yield* send(socket, {
-            type: "heartbeat",
-            at: new Date(connection.lastHeartbeat).toISOString(),
-            connectionCount: count,
-          });
-          yield* broadcastPresence(connection.roomId);
-          return;
-        }
-
-        const text = event.text.trim();
-        if (text === "") {
-          yield* send(socket, { type: "error", message: "Message text is required" });
-          return;
-        }
-
-        yield* appendAndBroadcast({
-          roomId: connection.roomId,
-          userId: connection.userId,
-          text,
+      if (event.type === "heartbeat") {
+        const count = yield* connections.count;
+        yield* send(socket, {
+          type: "heartbeat",
+          at: new Date(connection.lastHeartbeat).toISOString(),
+          connectionCount: count,
         });
         yield* broadcastPresence(connection.roomId);
-      }),
-    close: (socket) =>
-      Effect.gen(function* () {
-        const connections = yield* ConnectionManager;
-        const connection = yield* connections.remove(socket);
-        if (connection !== undefined) {
-          yield* broadcastPresence(connection.roomId);
-        }
-      }),
-    error: (socket) =>
-      Effect.gen(function* () {
-        const connections = yield* ConnectionManager;
-        const connection = yield* connections.remove(socket);
-        if (connection !== undefined) {
-          yield* broadcastPresence(connection.roomId);
-        }
-      }),
-  }),
+        return;
+      }
+
+      const text = event.text.trim();
+      if (text === "") {
+        yield* send(socket, { type: "error", message: "Message text is required" });
+        return;
+      }
+
+      yield* appendAndBroadcast({
+        roomId: connection.roomId,
+        userId: connection.userId,
+        text,
+      });
+      yield* broadcastPresence(connection.roomId);
+    }),
+  webSocketClose: (socket) =>
+    Effect.gen(function* () {
+      const connections = yield* ConnectionManager;
+      const connection = yield* connections.remove(socket);
+      if (connection !== undefined) {
+        yield* broadcastPresence(connection.roomId);
+      }
+    }),
+  webSocketError: (socket) =>
+    Effect.gen(function* () {
+      const connections = yield* ConnectionManager;
+      const connection = yield* connections.remove(socket);
+      if (connection !== undefined) {
+        yield* broadcastPresence(connection.roomId);
+      }
+    }),
   alarm: () =>
     Effect.gen(function* () {
       const connections = yield* ConnectionManager;

--- a/examples/todo-rpc-ws/durable-objects/todo-store/src/index.ts
+++ b/examples/todo-rpc-ws/durable-objects/todo-store/src/index.ts
@@ -72,23 +72,21 @@ export const TodoStoreLive = DurableObject.make(layer, {
     yield* transport.accept(upgrade.server);
     return upgrade.response;
   }),
-  ...DurableObjectWebSocket.handlers({
-    message: (socket, message) =>
-      Effect.gen(function* () {
-        const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
-        yield* transport.message(socket, message);
-      }),
-    close: (socket) =>
-      Effect.gen(function* () {
-        const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
-        yield* transport.close(socket);
-      }),
-    error: (socket, error) =>
-      Effect.gen(function* () {
-        const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
-        yield* transport.error(socket, error);
-      }),
-  }),
+  webSocketMessage: (socket, message) =>
+    Effect.gen(function* () {
+      const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
+      yield* transport.message(socket, message);
+    }),
+  webSocketClose: (socket) =>
+    Effect.gen(function* () {
+      const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
+      yield* transport.close(socket);
+    }),
+  webSocketError: (socket, error) =>
+    Effect.gen(function* () {
+      const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
+      yield* transport.error(socket, error);
+    }),
 });
 export class TodoStoreDurableObject extends TodoStoreLive {}
 export default Worker.make(Layer.empty, {

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -144,7 +144,7 @@ Durable Object application sockets should use the hibernation-compatible state A
 
 ```ts
 import { Effect, Schema as S } from "effect";
-import { DurableObjectState, DurableObjectWebSocket, Worker } from "effect-cf";
+import { DurableObject, DurableObjectState, DurableObjectWebSocket, Worker } from "effect-cf";
 
 const ConnectionAttachment = S.Struct({
   id: S.String,
@@ -172,6 +172,17 @@ export const fetch = Effect.gen(function* () {
 ```
 
 `DurableWebSocket` keeps the native socket available as `socket.raw`, while `send`, `close`, `serializeAttachment`, and `deserializeAttachment` return typed `Effect` failures. Use `state.getWebSockets(tag)` to retrieve wrapped sockets for broadcast and rehydration.
+
+`DurableObject.make` lifecycle handlers receive wrapped sockets automatically:
+
+```ts
+export const RoomLive = DurableObject.make(layer, {
+  webSocketMessage: (socket, message) =>
+    Effect.gen(function* () {
+      yield* socket.send(message);
+    }),
+});
+```
 
 Schema-backed attachments can rehydrate hibernated sockets:
 

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -4,6 +4,7 @@ import { Effect, Layer, ManagedRuntime, type Scope } from "effect";
 import { NativeRequest } from "./Worker";
 import { WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { DurableObjectState, fromDurableObjectState } from "./DurableObjectState";
+import { fromWebSocket, type DurableWebSocket } from "./DurableObjectWebSocket";
 import * as DurableObjectDefinition from "./DurableObjectDefinition";
 import * as Entrypoint from "./internal/Entrypoint";
 
@@ -84,17 +85,17 @@ export interface DurableObjectOptions<ROut, Rpc extends DurableObjectRpc<ROut>> 
     alarmInfo?: globalThis.AlarmInvocationInfo,
   ) => Effect.Effect<void, unknown, HandlerContext<ROut>>;
   readonly webSocketMessage?: (
-    socket: WebSocket,
+    socket: DurableWebSocket,
     message: string | ArrayBuffer,
   ) => Effect.Effect<void, unknown, HandlerContext<ROut>>;
   readonly webSocketClose?: (
-    socket: WebSocket,
+    socket: DurableWebSocket,
     code: number,
     reason: string,
     wasClean: boolean,
   ) => Effect.Effect<void, unknown, HandlerContext<ROut>>;
   readonly webSocketError?: (
-    socket: WebSocket,
+    socket: DurableWebSocket,
     error: unknown,
   ) => Effect.Effect<void, unknown, HandlerContext<ROut>>;
 }
@@ -172,7 +173,7 @@ export const make = <
 
     webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> | void {
       if (options.webSocketMessage !== undefined) {
-        return this[RunSymbol](options.webSocketMessage(socket, message));
+        return this[RunSymbol](options.webSocketMessage(fromWebSocket(socket), message));
       }
     }
 
@@ -183,13 +184,15 @@ export const make = <
       wasClean: boolean,
     ): Promise<void> | void {
       if (options.webSocketClose !== undefined) {
-        return this[RunSymbol](options.webSocketClose(socket, code, reason, wasClean));
+        return this[RunSymbol](
+          options.webSocketClose(fromWebSocket(socket), code, reason, wasClean),
+        );
       }
     }
 
     webSocketError(socket: WebSocket, error: unknown): Promise<void> | void {
       if (options.webSocketError !== undefined) {
-        return this[RunSymbol](options.webSocketError(socket, error));
+        return this[RunSymbol](options.webSocketError(fromWebSocket(socket), error));
       }
     }
   }

--- a/packages/effect-cf/src/DurableObjectWebSocket.ts
+++ b/packages/effect-cf/src/DurableObjectWebSocket.ts
@@ -251,21 +251,9 @@ export interface DurableWebSocketHandlers<R = never, E = unknown> {
   readonly error?: (socket: DurableWebSocket, error: unknown) => Effect.Effect<void, E, R>;
 }
 
-/** Adapts wrapped websocket lifecycle handlers to `DurableObject.make` raw callbacks. */
+/** Maps compact websocket lifecycle handler names to `DurableObject.make` options. */
 export const handlers = <R = never, E = unknown>(options: DurableWebSocketHandlers<R, E>) => ({
-  webSocketMessage:
-    options.message === undefined
-      ? undefined
-      : (socket: WebSocket, message: string | ArrayBuffer) =>
-          options.message?.(fromWebSocket(socket), message) ?? Effect.void,
-  webSocketClose:
-    options.close === undefined
-      ? undefined
-      : (socket: WebSocket, code: number, reason: string, wasClean: boolean) =>
-          options.close?.(fromWebSocket(socket), code, reason, wasClean) ?? Effect.void,
-  webSocketError:
-    options.error === undefined
-      ? undefined
-      : (socket: WebSocket, error: unknown) =>
-          options.error?.(fromWebSocket(socket), error) ?? Effect.void,
+  webSocketMessage: options.message,
+  webSocketClose: options.close,
+  webSocketError: options.error,
 });

--- a/packages/effect-cf/tests/index.test.ts
+++ b/packages/effect-cf/tests/index.test.ts
@@ -6,6 +6,7 @@ import {
   DurableObject,
   DurableObjectNamespace,
   DurableObjectState,
+  DurableObjectWebSocket,
   ServiceBinding,
   Worker,
   WorkerEnvironment,
@@ -270,6 +271,23 @@ test("DurableObject preserves server, client, handler, and namespace types", () 
       Counters.call(stub, "add", 1, "one"),
     );
     expectType<Effect.Effect<unknown, unknown, Scope.Scope>>(Counters.scopedCall(stub, "resource"));
+
+    DurableObject.make(Layer.empty, {
+      webSocketMessage: (socket, message) => {
+        expectType<DurableObjectWebSocket.DurableWebSocket>(socket);
+        expectType<string | ArrayBuffer>(message);
+        return Effect.void;
+      },
+      webSocketClose: (socket) => {
+        expectType<DurableObjectWebSocket.DurableWebSocket>(socket);
+        return Effect.void;
+      },
+      webSocketError: (socket, error) => {
+        expectType<DurableObjectWebSocket.DurableWebSocket>(socket);
+        expectType<unknown>(error);
+        return Effect.void;
+      },
+    });
 
     void class extends DurableObject.Tag<object>()(
       "InvalidCounter",


### PR DESCRIPTION
## Summary

- Type Durable Object websocket lifecycle handlers with `DurableWebSocket` instead of raw `WebSocket`.
- Wrap Cloudflare sockets once at the `DurableObject.make` boundary so consumers do not need manual `fromWebSocket(...)` calls.
- Add a major changeset for the breaking public handler type change.

## Validation

- `vp run effect-cf#check`
- `vp run effect-cf#build`
- `vp check`
- `vp test`