### PR TITLE
chore: recover accidental major release

### DIFF
--- a/.changeset/wrapped-durable-websocket-handlers.md
+++ b/.changeset/wrapped-durable-websocket-handlers.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Type Durable Object websocket lifecycle handlers with `DurableWebSocket` instead of raw `WebSocket`, so handlers can use the Effect-native durable socket API without manually wrapping Cloudflare sockets.

--- a/examples/chat/durable-objects/chat-room/CHANGELOG.md
+++ b/examples/chat/durable-objects/chat-room/CHANGELOG.md
@@ -1,13 +1,5 @@
 # chat-room-do
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-  - @effect-cf/example-contracts@0.0.2
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/chat/durable-objects/chat-room/package.json
+++ b/examples/chat/durable-objects/chat-room/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chat-room-do",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/chat/packages/contracts/CHANGELOG.md
+++ b/examples/chat/packages/contracts/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @effect-cf/example-contracts
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/chat/packages/contracts/package.json
+++ b/examples/chat/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-cf/example-contracts",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/examples/chat/web/CHANGELOG.md
+++ b/examples/chat/web/CHANGELOG.md
@@ -1,12 +1,5 @@
 # chat-web
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @effect-cf/example-contracts@0.0.2
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/chat/web/package.json
+++ b/examples/chat/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chat-web",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/chat/workers/analytics/CHANGELOG.md
+++ b/examples/chat/workers/analytics/CHANGELOG.md
@@ -1,13 +1,5 @@
 # chat-analytics-worker
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-  - @effect-cf/example-contracts@0.0.2
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/chat/workers/analytics/package.json
+++ b/examples/chat/workers/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chat-analytics-worker",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/chat/workers/api/CHANGELOG.md
+++ b/examples/chat/workers/api/CHANGELOG.md
@@ -1,13 +1,5 @@
 # chat-api-worker
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-  - @effect-cf/example-contracts@0.0.2
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/chat/workers/api/package.json
+++ b/examples/chat/workers/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chat-api-worker",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/queue-workflow/workers/app/CHANGELOG.md
+++ b/examples/queue-workflow/workers/app/CHANGELOG.md
@@ -1,12 +1,5 @@
 # queue-workflow-app
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/queue-workflow/workers/app/package.json
+++ b/examples/queue-workflow/workers/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "queue-workflow-app",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/todo-http/workers/api/CHANGELOG.md
+++ b/examples/todo-http/workers/api/CHANGELOG.md
@@ -1,12 +1,5 @@
 # todo-http-api-worker
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/todo-http/workers/api/package.json
+++ b/examples/todo-http/workers/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-http-api-worker",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/todo-rpc-http/workers/api/CHANGELOG.md
+++ b/examples/todo-rpc-http/workers/api/CHANGELOG.md
@@ -1,12 +1,5 @@
 # todo-rpc-http-api-worker
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/todo-rpc-http/workers/api/package.json
+++ b/examples/todo-rpc-http/workers/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-rpc-http-api-worker",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/todo-rpc-ws/durable-objects/todo-store/CHANGELOG.md
+++ b/examples/todo-rpc-ws/durable-objects/todo-store/CHANGELOG.md
@@ -1,13 +1,5 @@
 # todo-rpc-ws-store-do
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-  - @effect-cf/todo-rpc-ws-domain@0.0.2
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/todo-rpc-ws/durable-objects/todo-store/package.json
+++ b/examples/todo-rpc-ws/durable-objects/todo-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-rpc-ws-store-do",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/todo-rpc-ws/packages/domain/CHANGELOG.md
+++ b/examples/todo-rpc-ws/packages/domain/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @effect-cf/todo-rpc-ws-domain
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/todo-rpc-ws/packages/domain/package.json
+++ b/examples/todo-rpc-ws/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-cf/todo-rpc-ws-domain",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/examples/todo-rpc-ws/web/CHANGELOG.md
+++ b/examples/todo-rpc-ws/web/CHANGELOG.md
@@ -1,12 +1,5 @@
 # todo-rpc-ws-web
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @effect-cf/todo-rpc-ws-domain@0.0.2
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/todo-rpc-ws/web/package.json
+++ b/examples/todo-rpc-ws/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-rpc-ws-web",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/todo-rpc-ws/workers/api/CHANGELOG.md
+++ b/examples/todo-rpc-ws/workers/api/CHANGELOG.md
@@ -1,13 +1,5 @@
 # todo-rpc-ws-api-worker
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-  - @effect-cf/todo-rpc-ws-domain@0.0.2
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/todo-rpc-ws/workers/api/package.json
+++ b/examples/todo-rpc-ws/workers/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-rpc-ws-api-worker",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/todos/workers/api/CHANGELOG.md
+++ b/examples/todos/workers/api/CHANGELOG.md
@@ -1,12 +1,5 @@
 # todos-api-worker
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/todos/workers/api/package.json
+++ b/examples/todos/workers/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todos-api-worker",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/todos/workers/web/CHANGELOG.md
+++ b/examples/todos/workers/web/CHANGELOG.md
@@ -1,12 +1,5 @@
 # todos-web-worker
 
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [[`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76)]:
-  - effect-cf@1.0.0
-
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/todos/workers/web/package.json
+++ b/examples/todos/workers/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todos-web-worker",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/effect-cf/CHANGELOG.md
+++ b/packages/effect-cf/CHANGELOG.md
@@ -1,11 +1,5 @@
 # effect-cf
 
-## 1.0.0
-
-### Major Changes
-
-- [#8](https://github.com/danieljvdm/effect-cf/pull/8) [`a7a4f1b`](https://github.com/danieljvdm/effect-cf/commit/a7a4f1be58745da8977b1037a0007902cf835e76) Thanks [@danieljvdm](https://github.com/danieljvdm)! - Type Durable Object websocket lifecycle handlers with `DurableWebSocket` instead of raw `WebSocket`, so handlers can use the Effect-native durable socket API without manually wrapping Cloudflare sockets.
-
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-cf",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Effect-native primitives for Cloudflare Workers and bindings.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Revert the accidental `Version Packages (#9)` major release commit in git.
- Restore the durable websocket handler changeset as a `minor` release for `effect-cf`.
- Remove generated `1.0.0` changelog/package version changes so the next release can publish the intended `0.3.0` line.

## Validation

- `vp check`

## Notes

- Deleted the accidental git tag `effect-cf@1.0.0` from origin.
- `npm unpublish effect-cf@1.0.0 --force` returned success locally, but `npm view` still resolves `1.0.0` and local npm auth now returns `E401`, so registry cleanup still needs valid npm auth or the next release to move `latest` to `0.3.0`.