### PR TITLE
feat: add KV definition bindings

### DIFF
--- a/.changeset/clean-kv-definitions.md
+++ b/.changeset/clean-kv-definitions.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add reusable KV definitions with Queue-style binding helpers so packages can share typed KV schemas without choosing concrete Cloudflare binding names.

--- a/packages/effect-cf/src/Kv.ts
+++ b/packages/effect-cf/src/Kv.ts
@@ -52,6 +52,26 @@ export interface KvDefinition<Key, Value, EncodedValue> {
   readonly value: S.Codec<Value, EncodedValue>;
 }
 
+/**
+ * Reusable typed KV resource definition without a concrete Cloudflare binding name.
+ */
+export interface Definition<
+  Id extends string = string,
+  Key = unknown,
+  Value = unknown,
+  EncodedValue = unknown,
+> {
+  readonly id: Id;
+  /** Codec used to encode/decode keys. */
+  readonly key: S.Codec<Key, string>;
+  /** Codec used to encode/decode values. */
+  readonly value: S.Codec<Value, EncodedValue>;
+}
+
+export namespace Definition {
+  export type Any = Definition<string, any, any, any>;
+}
+
 declare const KvServiceTypeId: unique symbol;
 
 /** Nominal service marker for KV services created with {@link make}. */
@@ -61,6 +81,16 @@ export interface KvService<Id extends string, Key, Value, EncodedValue> {
     readonly key: Key;
     readonly value: Value;
     readonly encodedValue: EncodedValue;
+  };
+}
+
+declare const BindingServiceTypeId: unique symbol;
+
+/** Nominal service marker for KV bindings created from a reusable {@link Definition}. */
+export interface BindingService<Id extends string, Self extends Definition.Any> {
+  readonly [BindingServiceTypeId]: {
+    readonly id: Id;
+    readonly definition: Self;
   };
 }
 
@@ -91,6 +121,66 @@ export const make = <Id extends string, Key, Value, EncodedValue>(
   definition: KvDefinition<Key, Value, EncodedValue>,
 ) =>
   Service<KvService<Id, Key, Value, EncodedValue>>()<Id, Key, Value, EncodedValue>(id, definition);
+
+const makeDefinition = <Id extends string, Key, Value, EncodedValue>(
+  id: Id,
+  definition: { readonly key: S.Codec<Key, string>; readonly value: S.Codec<Value, EncodedValue> },
+) => {
+  type SelfDefinition = Definition<Id, Key, Value, EncodedValue>;
+  const kvDefinition: SelfDefinition = {
+    id,
+    key: definition.key,
+    value: definition.value,
+  };
+
+  return Object.assign(kvDefinition, {
+    Binding:
+      <Self>() =>
+      <BindingId extends string>(
+        bindingId: BindingId,
+        binding: Omit<KvDefinition<Key, Value, EncodedValue>, "key" | "value">,
+      ) =>
+        Service<Self>()<BindingId, Key, Value, EncodedValue>(bindingId, {
+          ...binding,
+          key: definition.key,
+          value: definition.value,
+        }),
+    binding: <BindingId extends string>(
+      bindingId: BindingId,
+      binding: Omit<KvDefinition<Key, Value, EncodedValue>, "key" | "value">,
+    ) =>
+      Service<BindingService<BindingId, SelfDefinition>>()<BindingId, Key, Value, EncodedValue>(
+        bindingId,
+        {
+          ...binding,
+          key: definition.key,
+          value: definition.value,
+        },
+      ),
+  });
+};
+
+export const Tag =
+  <_Self>() =>
+  <Id extends string, Key, Value, EncodedValue>(
+    id: Id,
+    definition: {
+      readonly key: S.Codec<Key, string>;
+      readonly value: S.Codec<Value, EncodedValue>;
+    },
+  ) => {
+    const kvDefinition = makeDefinition(id, definition);
+
+    abstract class KvDefinitionClass {
+      static readonly id = kvDefinition.id;
+      static readonly key = kvDefinition.key;
+      static readonly value = kvDefinition.value;
+      static readonly Binding = kvDefinition.Binding;
+      static readonly binding = kvDefinition.binding;
+    }
+
+    return KvDefinitionClass as (abstract new () => object) & typeof kvDefinition;
+  };
 
 /**
  * Builds a KV service around a Cloudflare KV namespace binding.

--- a/packages/effect-cf/tests/Kv.test.ts
+++ b/packages/effect-cf/tests/Kv.test.ts
@@ -1,7 +1,7 @@
-import { assert, layer } from "@effect/vitest";
+import { assert, expect, layer, test } from "@effect/vitest";
 import { Effect, Layer, Option, Schema as S } from "effect";
 
-import { Kv, WorkerEnvironment } from "../src/index";
+import { Binding, Kv, WorkerEnvironment } from "../src/index";
 
 class TestKv extends Kv.Service<TestKv>()("test/TestKv", {
   binding: "TEST_KV",
@@ -19,6 +19,35 @@ const ValueStyleKv = Kv.make("test/ValueStyleKv", {
   binding: "TEST_KV",
   key: S.String,
   value: S.Struct({ count: S.Number }),
+});
+
+class TestKvDefinition extends Kv.Tag<TestKvDefinition>()("test/TestKvDefinition", {
+  key: S.String,
+  value: S.Struct({ count: S.Number }),
+}) {}
+
+class TestKvBinding extends TestKvDefinition.Binding<TestKvBinding>()("test/TestKvBinding", {
+  binding: "TEST_KV",
+}) {}
+
+const ValueStyleKvBinding = TestKvDefinition.binding("test/ValueStyleKvBinding", {
+  binding: "TEST_KV",
+});
+
+class SharedStringKvDefinition extends Kv.Tag<SharedStringKvDefinition>()(
+  "test/SharedStringKvDefinition",
+  {
+    key: S.String,
+    value: S.String,
+  },
+) {}
+
+const SharedCountKvBinding = TestKvDefinition.binding("test/SharedCountKvBinding", {
+  binding: "TEST_KV",
+});
+
+const SharedStringKvBinding = SharedStringKvDefinition.binding("test/SharedStringKvBinding", {
+  binding: "TEST_KV",
 });
 
 interface PutCall {
@@ -74,6 +103,16 @@ const numberKeyKvLayer = (kv: KVNamespace) =>
 
 const valueStyleKvLayer = (kv: KVNamespace) =>
   ValueStyleKv.layer.pipe(
+    Layer.provide(Layer.succeed(WorkerEnvironment, { TEST_KV: kv } as unknown as Cloudflare.Env)),
+  );
+
+const testKvBindingLayer = (kv: KVNamespace) =>
+  TestKvBinding.layer.pipe(
+    Layer.provide(Layer.succeed(WorkerEnvironment, { TEST_KV: kv } as unknown as Cloudflare.Env)),
+  );
+
+const valueStyleKvBindingLayer = (kv: KVNamespace) =>
+  ValueStyleKvBinding.layer.pipe(
     Layer.provide(Layer.succeed(WorkerEnvironment, { TEST_KV: kv } as unknown as Cloudflare.Env)),
   );
 
@@ -198,6 +237,87 @@ const valueStyleKvLayer = (kv: KVNamespace) =>
 }
 
 {
+  const values = new Map<string, string>();
+  const kv = makeFakeKv({
+    get: async (key) => values.get(key) ?? null,
+    put: async (key, value) => {
+      values.set(key, value as string);
+    },
+  });
+
+  layer(testKvBindingLayer(kv))("definition-backed KV bindings", (it) => {
+    it.effect("roundtrips typed values through class-style bindings", () =>
+      Effect.gen(function* () {
+        values.clear();
+
+        yield* TestKvBinding.put("user:1", { count: 4 });
+        const result = yield* TestKvBinding.get("user:1");
+
+        assert.deepStrictEqual(Option.getOrUndefined(result), { count: 4 });
+        assert.strictEqual(values.get("user:1"), '{"count":4}');
+      }),
+    );
+  });
+}
+
+{
+  const kv = makeFakeKv({
+    get: async () => '{"count":5}',
+  });
+
+  layer(valueStyleKvBindingLayer(kv))("definition-backed KV value-style bindings", (it) => {
+    it.effect("returns the same helper shape as class-style bindings", () =>
+      Effect.gen(function* () {
+        const result = yield* ValueStyleKvBinding.get("user:1");
+
+        assert.deepStrictEqual(Option.getOrUndefined(result), { count: 5 });
+      }),
+    );
+  });
+}
+
+{
+  const values = new Map<string, string>([
+    ["count", '{"count":6}'],
+    ["label", '"ready"'],
+  ]);
+  const kv = makeFakeKv({
+    get: async (key) => values.get(key) ?? null,
+  });
+  const sharedLayer = Layer.merge(SharedCountKvBinding.layer, SharedStringKvBinding.layer).pipe(
+    Layer.provide(Layer.succeed(WorkerEnvironment, { TEST_KV: kv } as unknown as Cloudflare.Env)),
+  );
+
+  layer(sharedLayer)("logical KV definitions sharing one binding", (it) => {
+    it.effect("decodes each logical resource with its own schema", () =>
+      Effect.gen(function* () {
+        const count = yield* SharedCountKvBinding.get("count");
+        const label = yield* SharedStringKvBinding.get("label");
+
+        assert.deepStrictEqual(Option.getOrUndefined(count), { count: 6 });
+        assert.strictEqual(Option.getOrUndefined(label), "ready");
+      }),
+    );
+  });
+}
+
+{
+  const kv = makeFakeKv({
+    get: async () => '{"count":"bad"}',
+  });
+
+  layer(testKvBindingLayer(kv))("definition-backed KV decode errors", (it) => {
+    it.effect("fails when stored JSON does not match the value schema", () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(TestKvBinding.get("user:1"));
+
+        assert.strictEqual(exit._tag, "Failure");
+      }),
+    );
+  });
+}
+
+{
   const cause = new Error("KV unavailable");
   const kv = makeFakeKv({
     get: async () => {
@@ -220,6 +340,34 @@ const valueStyleKvLayer = (kv: KVNamespace) =>
     );
   });
 }
+
+test("definition-backed KV bindings report missing and invalid bindings", async () => {
+  await expect(
+    Effect.runPromise(
+      TestKvBinding.get("missing").pipe(
+        Effect.provide(
+          TestKvBinding.layer.pipe(
+            Layer.provide(Layer.succeed(WorkerEnvironment, {} as Cloudflare.Env)),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toBeInstanceOf(Binding.BindingNotFoundError);
+
+  await expect(
+    Effect.runPromise(
+      TestKvBinding.get("invalid").pipe(
+        Effect.provide(
+          TestKvBinding.layer.pipe(
+            Layer.provide(
+              Layer.succeed(WorkerEnvironment, { TEST_KV: {} } as unknown as Cloudflare.Env),
+            ),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toBeInstanceOf(Binding.BindingValidationError);
+});
 
 {
   const kv = makeFakeKv();


### PR DESCRIPTION
## Summary

- Add reusable KV definitions with Queue-style binding helpers.
- Let packages share typed KV schemas separately from concrete Cloudflare binding names while keeping Kv.make and Kv.Service working.
- Add tests for typed roundtrips, decode failure, binding validation, and multiple logical definitions sharing one physical KV binding.

## Validation

- `vp check`
- `vp test`