### PR TITLE
feat: provide Effect-native binding clients

### DIFF
--- a/.changeset/effect-native-binding-services.md
+++ b/.changeset/effect-native-binding-services.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Provide Effect-native clients when yielding Queue, KV, Worker service, and Durable Object namespace binding tags, while keeping existing static helpers compatible.

--- a/examples/chat/workers/analytics/src/analytics.ts
+++ b/examples/chat/workers/analytics/src/analytics.ts
@@ -9,10 +9,11 @@ import { ApiWorker, ChatRooms } from "./bindings";
 
 const knownUsersFor = (userIds: ReadonlySet<string>) =>
   Effect.gen(function* () {
+    const api = yield* ApiWorker;
     const users: Array<User> = [];
 
     for (const userId of userIds) {
-      const user = yield* ApiWorker.getUser(userId);
+      const user = yield* api.getUser(userId);
       if (user !== null) {
         users.push(user);
       }
@@ -23,7 +24,8 @@ const knownUsersFor = (userIds: ReadonlySet<string>) =>
 
 export const analyzeRoom = (roomId: string) =>
   Effect.gen(function* () {
-    const snapshot = yield* ChatRooms.byName(roomId).getSnapshot(roomId);
+    const rooms = yield* ChatRooms;
+    const snapshot = yield* rooms.byName(roomId).getSnapshot(roomId);
     const userIds = new Set(snapshot.messages.map((message) => message.userId));
     const knownUsers = yield* knownUsersFor(userIds);
 

--- a/examples/chat/workers/api/src/index.ts
+++ b/examples/chat/workers/api/src/index.ts
@@ -38,6 +38,8 @@ export const ApiWorkerLive = ApiWorker.make(layer, {
   fetch: Effect.gen(function* () {
     const request = yield* Worker.NativeRequest;
     const config = yield* ApiConfig;
+    const analytics = yield* AnalyticsWorker;
+    const rooms = yield* ChatRooms;
     const url = new URL(request.url);
 
     if (request.method === "GET" && url.pathname === "/users") {
@@ -56,7 +58,7 @@ export const ApiWorkerLive = ApiWorker.make(layer, {
       socketRoomId !== undefined &&
       Worker.isWebSocketUpgrade(request)
     ) {
-      return yield* ChatRooms.byName(socketRoomId).fetch(request);
+      return yield* rooms.byName(socketRoomId).fetch(request);
     }
 
     const messagesRoomId = roomRoute(url.pathname, "/messages");
@@ -67,12 +69,12 @@ export const ApiWorkerLive = ApiWorker.make(layer, {
       }
 
       const userId = url.searchParams.get("userId") ?? config.defaultUserId;
-      const message = yield* ChatRooms.byName(messagesRoomId).appendMessage({
+      const message = yield* rooms.byName(messagesRoomId).appendMessage({
         roomId: messagesRoomId,
         userId,
         text,
       });
-      const artifact = yield* AnalyticsWorker.recordMessage({
+      const artifact = yield* analytics.recordMessage({
         roomId: messagesRoomId,
         messageId: message.id,
       });
@@ -82,13 +84,13 @@ export const ApiWorkerLive = ApiWorker.make(layer, {
 
     const roomId = roomRoute(url.pathname, "");
     if (request.method === "GET" && roomId !== undefined) {
-      const snapshot = yield* ChatRooms.byName(roomId).getSnapshot(roomId);
+      const snapshot = yield* rooms.byName(roomId).getSnapshot(roomId);
       return json(snapshot);
     }
 
     const analysisRoomId = roomRoute(url.pathname, "/analysis");
     if (request.method === "GET" && analysisRoomId !== undefined) {
-      const artifact = yield* AnalyticsWorker.analyzeRoom(analysisRoomId);
+      const artifact = yield* analytics.analyzeRoom(analysisRoomId);
       return json(artifact);
     }
 

--- a/examples/chat/workers/api/src/users.ts
+++ b/examples/chat/workers/api/src/users.ts
@@ -13,14 +13,15 @@ export const listUsers = Effect.sync(() => Array.from(users.values()));
 
 export const getUser = (userId: string) =>
   Effect.gen(function* () {
-    const cached = yield* UserCache.get(userId);
+    const cache = yield* UserCache;
+    const cached = yield* cache.get(userId);
     if (Option.isSome(cached)) {
       return cached.value;
     }
 
     const user = users.get(userId);
     if (user !== undefined) {
-      yield* UserCache.put(userId, user);
+      yield* cache.put(userId, user);
       return user;
     }
 

--- a/examples/queue-workflow/workers/app/src/queue.ts
+++ b/examples/queue-workflow/workers/app/src/queue.ts
@@ -28,11 +28,15 @@ export class ProcessedEmails extends Context.Service<
 >()("effect-cf/examples/queue-workflow/ProcessedEmails") {}
 
 export const enqueueWelcomeEmail = (to: string) =>
-  EmailQueue.send({
-    to,
-    subject: "Welcome to effect-cf",
-    body: "Thanks for trying the Queue primitives.",
-    priority: "normal",
+  Effect.gen(function* () {
+    const queue = yield* EmailQueue;
+
+    yield* queue.send({
+      to,
+      subject: "Welcome to effect-cf",
+      body: "Thanks for trying the Queue primitives.",
+      priority: "normal",
+    });
   });
 
 export const makeEmailQueueConsumer = (messages: Array<EmailJob>) =>

--- a/examples/todos/workers/web/src/bindings.ts
+++ b/examples/todos/workers/web/src/bindings.ts
@@ -39,13 +39,14 @@ const ApiWorkerHttpClient = Layer.effect(
     return HttpClient.make((request, _url, signal) =>
       Effect.gen(function* () {
         const webRequest = yield* HttpClientRequest.toWeb(request, { signal }).pipe(Effect.orDie);
-        const response = yield* Effect.tryPromise({
-          try: () => api.fetch(webRequest),
-          catch: (cause) =>
-            new HttpClientError.HttpClientError({
-              reason: new HttpClientError.TransportError({ request, cause }),
-            }),
-        });
+        const response = yield* api.fetch(webRequest).pipe(
+          Effect.mapError(
+            (cause) =>
+              new HttpClientError.HttpClientError({
+                reason: new HttpClientError.TransportError({ request, cause }),
+              }),
+          ),
+        );
         return HttpClientResponse.fromWeb(request, response);
       }),
     );

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -99,9 +99,15 @@ export const AvatarQueueConsumer = AvatarJobs.make(Layer.empty, {
       }
     }),
 });
+
+export const enqueueAvatar = (userId: string, imageKey: string) =>
+  Effect.gen(function* () {
+    const queue = yield* AvatarQueue;
+    yield* queue.send({ userId, imageKey });
+  });
 ```
 
-Producers can use `AvatarQueue.send(...)`, `AvatarQueue.sendBatch(...)`, and `AvatarQueue.metrics` from any Worker, Durable Object, or Workflow layer that provides `WorkerEnvironment`.
+Producers should usually use `const queue = yield* AvatarQueue` and then call `queue.send(...)`, `queue.sendBatch(...)`, or `queue.metrics()`. The static `AvatarQueue.send(...)` helpers remain available for compatibility and concise one-off calls.
 
 Queue handlers run inline failures through Cloudflare's normal retry path. If background work scheduled with `WorkerContext.waitUntil(...)` should also make the batch retry, use `WorkerContext.waitUntilPropagating(...)` or `waitUntil(..., { mode: "propagate" })`; the default `waitUntil` mode observes and logs failures without rejecting the native `waitUntil` promise.
 

--- a/packages/effect-cf/src/Binding.ts
+++ b/packages/effect-cf/src/Binding.ts
@@ -45,20 +45,36 @@ const getBinding = <Resource>(
 /**
  * Creates a Context tag + layer for reading and validating a Cloudflare binding.
  */
+export interface BindingService<Self, Id extends string, Service> extends Context.ServiceClass<
+  Self,
+  Id,
+  Service
+> {
+  readonly [TypeId]: typeof TypeId;
+  readonly binding: string;
+  readonly layer: Layer.Layer<
+    Self,
+    BindingNotFoundError | BindingValidationError,
+    WorkerEnvironment
+  >;
+}
+
 export const Service =
   <Self>() =>
-  <Id extends string, Resource>(
+  <Id extends string, Resource, Service = Resource>(
     id: Id,
     binding: string,
     isResource: (value: unknown) => value is Resource,
-  ) => {
-    const tag = Context.Service<Self, Resource>()(id);
+    wrap?: (resource: Resource) => Service,
+  ): BindingService<Self, Id, Service> => {
+    const tag = Context.Service<Self, Service>()(id);
 
     const layer = Layer.effect(
       tag,
       Effect.gen(function* () {
         const env = yield* WorkerEnvironment;
-        return yield* getBinding(env, binding, isResource);
+        const resource = yield* getBinding(env, binding, isResource);
+        return wrap === undefined ? (resource as unknown as Service) : wrap(resource);
       }),
     );
 
@@ -66,5 +82,5 @@ export const Service =
       [TypeId]: TypeId,
       binding,
       layer,
-    });
+    }) as BindingService<Self, Id, Service>;
   };

--- a/packages/effect-cf/src/DurableObjectNamespace.ts
+++ b/packages/effect-cf/src/DurableObjectNamespace.ts
@@ -1,4 +1,4 @@
-import { Data, Effect } from "effect";
+import { Data, Effect, type Scope } from "effect";
 
 import * as Binding from "./Binding";
 import * as CloudflareRpc from "./Rpc";
@@ -110,21 +110,21 @@ type StubMethodSuccess<Api, Method extends keyof Api> = RpcInvocation.AsyncMetho
   Method
 >;
 
-type StubCall<Api extends object> = <Method extends StubMethodKey<Api>>(
+type StubCall<R, Api extends object> = <Method extends StubMethodKey<Api>>(
   stub: DurableObjectStubClient<Api>,
   method: Method,
   ...args: StubMethodArgs<Api, Method>
-) => Effect.Effect<StubMethodSuccess<Api, Method>, DurableObjectRpcError>;
+) => Effect.Effect<StubMethodSuccess<Api, Method>, DurableObjectRpcError, R>;
 
-type DurableObjectDirectClient<Self, Api extends object> = {
+type DurableObjectDirectClient<R, Api extends object> = {
   readonly fetch: (
     input: RequestInfo | URL,
     init?: RequestInit,
-  ) => Effect.Effect<globalThis.Response, DurableObjectFetchError, Self>;
+  ) => Effect.Effect<globalThis.Response, DurableObjectFetchError, R>;
 } & {
   readonly [Method in StubMethodKey<Api>]: (
     ...args: StubMethodArgs<Api, Method>
-  ) => Effect.Effect<StubMethodSuccess<Api, Method>, DurableObjectRpcError, Self>;
+  ) => Effect.Effect<StubMethodSuccess<Api, Method>, DurableObjectRpcError, R>;
 };
 
 type DefinitionNamespaceDirectMethods<
@@ -141,45 +141,88 @@ type DefinitionNamespaceDirectMethods<
 };
 
 type DefinitionDurableObjectDirectClient<
-  Self,
+  R,
   Definition extends DurableObjectDefinition.Definition.Any,
 > = {
   readonly fetch: (
     input: RequestInfo | URL,
     init?: RequestInit,
-  ) => Effect.Effect<globalThis.Response, DurableObjectFetchError, Self>;
+  ) => Effect.Effect<globalThis.Response, DurableObjectFetchError, R>;
 } & {
   readonly [Method in RpcDefinition.Definition.MethodNames<Definition>]: (
     ...args: RpcDefinition.Method.Args<Definition["methods"][Method]>
   ) => Effect.Effect<
     RpcDefinition.Method.Success<Definition["methods"][Method]>,
     DurableObjectRpcError,
-    Self
+    R
   >;
 };
 
 type DefinitionNamespaceDirectClientMethods<
-  Self,
+  R,
   Definition extends DurableObjectDefinition.Definition.Any,
 > = {
   readonly byName: (
     name: string,
     options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
-  ) => DefinitionDurableObjectDirectClient<Self, Definition>;
+  ) => DefinitionDurableObjectDirectClient<R, Definition>;
   readonly byId: (
     id: globalThis.DurableObjectId,
     options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
-  ) => DefinitionDurableObjectDirectClient<Self, Definition>;
+  ) => DefinitionDurableObjectDirectClient<R, Definition>;
 };
 
 type DirectMethods<
-  Self,
+  R,
   Api extends object,
   Definition,
 > = Definition extends DurableObjectDefinition.Definition.Any
   ? DefinitionNamespaceDirectMethods<Api, Definition> &
-      DefinitionNamespaceDirectClientMethods<Self, Definition>
+      DefinitionNamespaceDirectClientMethods<R, Definition>
   : {};
+
+export type DurableObjectNamespaceEffectClient<
+  Api extends object,
+  Definition extends DurableObjectDefinition.Definition.Any | undefined = undefined,
+> = DirectMethods<never, Api, Definition> & {
+  readonly newUniqueId: (
+    options?: globalThis.DurableObjectNamespaceNewUniqueIdOptions,
+  ) => Effect.Effect<globalThis.DurableObjectId>;
+  readonly idFromName: (name: string) => Effect.Effect<globalThis.DurableObjectId>;
+  readonly idFromString: (id: string) => Effect.Effect<globalThis.DurableObjectId>;
+  readonly get: (
+    id: globalThis.DurableObjectId,
+    options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+  ) => Effect.Effect<DurableObjectStubClient<Api>>;
+  readonly getByName: (
+    name: string,
+    options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+  ) => Effect.Effect<DurableObjectStubClient<Api>>;
+  readonly jurisdiction: (
+    jurisdiction: globalThis.DurableObjectJurisdiction,
+  ) => Effect.Effect<DurableObjectNamespaceClient<Api>>;
+  readonly fetch: (
+    stub: DurableObjectStubClient<Api>,
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Effect.Effect<globalThis.Response, DurableObjectFetchError>;
+  readonly rpc: <Method extends StubMethodKey<Api>>(
+    stub: DurableObjectStubClient<Api>,
+    method: Method,
+    ...args: StubMethodArgs<Api, Method>
+  ) => Effect.Effect<StubMethodSuccess<Api, Method>, DurableObjectRpcError>;
+  readonly call: <Method extends StubMethodKey<Api>>(
+    stub: DurableObjectStubClient<Api>,
+    method: Method,
+    ...args: StubMethodArgs<Api, Method>
+  ) => Effect.Effect<StubMethodSuccess<Api, Method>, DurableObjectRpcError>;
+  readonly scopedCall: <Method extends StubMethodKey<Api>>(
+    stub: DurableObjectStubClient<Api>,
+    method: Method,
+    ...args: StubMethodArgs<Api, Method>
+  ) => Effect.Effect<Awaited<StubMethodSuccess<Api, Method>>, unknown, Scope.Scope>;
+  readonly unsafeRaw: Effect.Effect<DurableObjectNamespaceClient<Api>>;
+};
 
 /**
  * Creates a typed Effect service for a Durable Object namespace binding.
@@ -230,25 +273,170 @@ export const Service =
       hasFunction(value, "newUniqueId") &&
       hasFunction(value, "jurisdiction");
 
-    const tag = Binding.Service<Self>()(id, definition.binding, (value): value is NamespaceClient =>
-      isDurableObjectNamespaceClient(value),
+    const makeClient = (
+      namespace: NamespaceClient,
+    ): DurableObjectNamespaceEffectClient<NamespaceApi, Definition> => {
+      const newUniqueId = (options?: globalThis.DurableObjectNamespaceNewUniqueIdOptions) =>
+        Effect.sync(() => namespace.newUniqueId(options));
+
+      const idFromName = (name: string) => Effect.sync(() => namespace.idFromName(name));
+
+      const idFromString = (id: string) => Effect.sync(() => namespace.idFromString(id));
+
+      const get = (
+        id: globalThis.DurableObjectId,
+        options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+      ) => Effect.sync(() => namespace.get(id, options));
+
+      const getByName = (
+        name: string,
+        options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+      ) => Effect.sync(() => namespace.getByName(name, options));
+
+      const jurisdiction = (value: globalThis.DurableObjectJurisdiction) =>
+        Effect.sync(() => namespace.jurisdiction(value));
+
+      const fetch = (stub: StubClient, input: RequestInfo | URL, init?: RequestInit) =>
+        Effect.tryPromise({
+          try: () => stub.fetch(input, init),
+          catch: (cause) => new DurableObjectFetchError({ binding: definition.binding, cause }),
+        });
+
+      const rpc = <Method extends StubMethodKey<NamespaceApi>>(
+        stub: StubClient,
+        method: Method,
+        ...args: StubMethodArgs<NamespaceApi, Method>
+      ) =>
+        Effect.gen(function* () {
+          const methodName = String(method);
+          const encodedArgs =
+            definition.definition === undefined
+              ? args
+              : yield* RpcDefinition.encodeArgs(
+                  definition.definition,
+                  methodName as RpcDefinition.Definition.MethodNames<NonNullable<Definition>>,
+                  args as never,
+                ).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new DurableObjectRpcError({
+                        binding: definition.binding,
+                        method: methodName,
+                        cause,
+                      }),
+                  ),
+                );
+
+          return yield* RpcInvocation.invokeRpcMethod(
+            stub,
+            method,
+            encodedArgs as StubMethodArgs<NamespaceApi, Method>,
+            (cause) =>
+              new DurableObjectRpcError({
+                binding: definition.binding,
+                method: methodName,
+                cause,
+              }),
+          );
+        });
+
+      const call = <Method extends StubMethodKey<NamespaceApi>>(
+        stub: StubClient,
+        method: Method,
+        ...args: StubMethodArgs<NamespaceApi, Method>
+      ) =>
+        Effect.gen(function* () {
+          const methodName = String(method);
+          const value = yield* CloudflareRpc.resolve(yield* rpc(stub, method, ...args)).pipe(
+            Effect.mapError(
+              (cause) =>
+                new DurableObjectRpcError({
+                  binding: definition.binding,
+                  method: methodName,
+                  cause,
+                }),
+            ),
+          );
+
+          if (definition.definition === undefined) {
+            return value as StubMethodSuccess<NamespaceApi, Method>;
+          }
+
+          const decoded = yield* RpcDefinition.decodeSuccess(
+            definition.definition,
+            methodName as RpcDefinition.Definition.MethodNames<NonNullable<Definition>>,
+            value,
+          ).pipe(
+            Effect.mapError(
+              (cause) =>
+                new DurableObjectRpcError({
+                  binding: definition.binding,
+                  method: methodName,
+                  cause,
+                }),
+            ),
+          );
+
+          return decoded as StubMethodSuccess<NamespaceApi, Method>;
+        });
+
+      const scopedCall = <Method extends StubMethodKey<NamespaceApi>>(
+        stub: StubClient,
+        method: Method,
+        ...args: StubMethodArgs<NamespaceApi, Method>
+      ) =>
+        Effect.gen(function* () {
+          const result = yield* rpc(stub, method, ...args);
+          return yield* CloudflareRpc.scoped(result);
+        });
+
+      const directMethods = makeDirectMethods<never, NamespaceApi, Definition>(
+        definition.definition,
+        {
+          call,
+          fetch,
+          get,
+          getByName,
+        },
+      );
+
+      return Object.assign(directMethods, {
+        newUniqueId,
+        idFromName,
+        idFromString,
+        get,
+        getByName,
+        jurisdiction,
+        fetch,
+        rpc,
+        call,
+        scopedCall,
+        unsafeRaw: Effect.succeed(namespace),
+      }) as DurableObjectNamespaceEffectClient<NamespaceApi, Definition>;
+    };
+
+    const tag = Binding.Service<Self>()(
+      id,
+      definition.binding,
+      (value): value is NamespaceClient => isDurableObjectNamespaceClient(value),
+      makeClient,
     );
 
     const newUniqueId = Effect.fnUntraced(function* (
       options?: globalThis.DurableObjectNamespaceNewUniqueIdOptions,
     ) {
       const namespace = yield* tag;
-      return namespace.newUniqueId(options);
+      return yield* namespace.newUniqueId(options);
     });
 
     const idFromName = Effect.fnUntraced(function* (name: string) {
       const namespace = yield* tag;
-      return namespace.idFromName(name);
+      return yield* namespace.idFromName(name);
     });
 
     const idFromString = Effect.fnUntraced(function* (id: string) {
       const namespace = yield* tag;
-      return namespace.idFromString(id);
+      return yield* namespace.idFromString(id);
     });
 
     const get = Effect.fnUntraced(function* (
@@ -256,7 +444,7 @@ export const Service =
       options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
     ) {
       const namespace = yield* tag;
-      return namespace.get(id, options);
+      return yield* namespace.get(id, options);
     });
 
     const getByName = Effect.fnUntraced(function* (
@@ -264,12 +452,12 @@ export const Service =
       options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
     ) {
       const namespace = yield* tag;
-      return namespace.getByName(name, options);
+      return yield* namespace.getByName(name, options);
     });
 
     const jurisdiction = Effect.fnUntraced(function* (value: globalThis.DurableObjectJurisdiction) {
       const namespace = yield* tag;
-      return namespace.jurisdiction(value);
+      return yield* namespace.jurisdiction(value);
     });
 
     const fetch = (stub: StubClient, input: RequestInfo | URL, init?: RequestInit) =>
@@ -366,6 +554,11 @@ export const Service =
         return yield* CloudflareRpc.scoped(result);
       });
 
+    const unsafeRaw = Effect.fnUntraced(function* () {
+      const namespace = yield* tag;
+      return yield* namespace.unsafeRaw;
+    });
+
     const directMethods = makeDirectMethods<Self, NamespaceApi, Definition>(definition.definition, {
       call,
       fetch,
@@ -386,6 +579,7 @@ export const Service =
       rpc,
       call,
       scopedCall,
+      unsafeRaw,
     }) as typeof tag &
       DirectMethods<Self, NamespaceApi, Definition> & {
         readonly [TypeId]: typeof TypeId;
@@ -400,32 +594,33 @@ export const Service =
         readonly rpc: typeof rpc;
         readonly call: typeof call;
         readonly scopedCall: typeof scopedCall;
+        readonly unsafeRaw: typeof unsafeRaw;
       };
   };
 
 const makeDirectMethods = <
-  Self,
+  R,
   Api extends object,
   Definition extends DurableObjectDefinition.Definition.Any | undefined,
 >(
   rpcDefinition: Definition | undefined,
   helpers: {
-    readonly call: StubCall<Api>;
+    readonly call: StubCall<R, Api>;
     readonly fetch: (
       stub: DurableObjectStubClient<Api>,
       input: RequestInfo | URL,
       init?: RequestInit,
-    ) => Effect.Effect<globalThis.Response, DurableObjectFetchError>;
+    ) => Effect.Effect<globalThis.Response, DurableObjectFetchError, R>;
     readonly get: (
       id: globalThis.DurableObjectId,
       options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
-    ) => Effect.Effect<DurableObjectStubClient<Api>, never, Self>;
+    ) => Effect.Effect<DurableObjectStubClient<Api>, never, R>;
     readonly getByName: (
       name: string,
       options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
-    ) => Effect.Effect<DurableObjectStubClient<Api>, never, Self>;
+    ) => Effect.Effect<DurableObjectStubClient<Api>, never, R>;
   },
-): DirectMethods<Self, Api, Definition> => {
+): DirectMethods<R, Api, Definition> => {
   const methods = {} as Record<string, unknown>;
 
   if (rpcDefinition !== undefined) {
@@ -441,8 +636,8 @@ const makeDirectMethods = <
     }
 
     const makeClient = (
-      getStub: () => Effect.Effect<DurableObjectStubClient<Api>, never, Self>,
-    ): DurableObjectDirectClient<Self, Api> => {
+      getStub: () => Effect.Effect<DurableObjectStubClient<Api>, never, R>,
+    ): DurableObjectDirectClient<R, Api> => {
       const client = {
         fetch: (input: RequestInfo | URL, init?: RequestInit) =>
           Effect.gen(function* () {
@@ -465,7 +660,7 @@ const makeDirectMethods = <
           });
       }
 
-      return client as DurableObjectDirectClient<Self, Api>;
+      return client as DurableObjectDirectClient<R, Api>;
     };
 
     methods.byName = (
@@ -479,5 +674,5 @@ const makeDirectMethods = <
     ) => makeClient(() => helpers.get(id, options));
   }
 
-  return methods as DirectMethods<Self, Api, Definition>;
+  return methods as DirectMethods<R, Api, Definition>;
 };

--- a/packages/effect-cf/src/Kv.ts
+++ b/packages/effect-cf/src/Kv.ts
@@ -84,6 +84,28 @@ export interface KvService<Id extends string, Key, Value, EncodedValue> {
   };
 }
 
+export interface KvClient<Key, Value, EncodedValue> {
+  readonly put: (
+    key: Key,
+    value: Value,
+    options?: KvPutOptions,
+  ) => Effect.Effect<void, KvOperationError | S.SchemaError>;
+  readonly get: (key: Key) => Effect.Effect<Option.Option<Value>, KvOperationError | S.SchemaError>;
+  readonly getWithMetadata: <Metadata>(
+    key: Key,
+    metadataSchema: S.Codec<Metadata, unknown>,
+  ) => Effect.Effect<
+    Option.Option<KvWithMetadata<Value, Metadata>>,
+    KvOperationError | S.SchemaError
+  >;
+  readonly list: <Metadata = unknown>(
+    options?: KvListOptions<Metadata>,
+  ) => Effect.Effect<KvListResult<Key, Metadata>, KvOperationError | S.SchemaError>;
+  readonly remove: (key: Key) => Effect.Effect<void, KvOperationError | S.SchemaError>;
+  readonly unsafeRaw: Effect.Effect<KVNamespace>;
+  readonly definition: KvDefinition<Key, Value, EncodedValue>;
+}
+
 declare const BindingServiceTypeId: unique symbol;
 
 /** Nominal service marker for KV bindings created from a reusable {@link Definition}. */
@@ -208,46 +230,123 @@ export const Service =
     id: Id,
     definition: KvDefinition<Key, Value, EncodedValue>,
   ) => {
-    const tag = Binding.Service<Self>()(id, definition.binding, (value): value is KVNamespace => {
-      if (typeof value !== "object" || value === null) {
-        return false;
-      }
-
-      const resource = value as Record<string, unknown>;
-
-      return (
-        typeof resource.get === "function" &&
-        typeof resource.put === "function" &&
-        typeof resource.delete === "function" &&
-        typeof resource.getWithMetadata === "function" &&
-        typeof resource.list === "function"
-      );
-    });
-
     const encodeKey = S.encodeEffect(definition.key);
     const decodeKey = S.decodeUnknownEffect(definition.key);
     const encodeValue = S.encodeEffect(S.fromJsonString(S.toCodecJson(definition.value)));
     const decodeValue = S.decodeUnknownEffect(S.fromJsonString(S.toCodecJson(definition.value)));
 
+    const makeClient = (kv: KVNamespace): KvClient<Key, Value, EncodedValue> => ({
+      definition,
+      put: Effect.fnUntraced(function* (key: Key, value: Value, options?: KvPutOptions) {
+        const keyEncoded = yield* encodeKey(key);
+        const valueEncoded = yield* encodeValue(value);
+        yield* tryKvPromise(definition.binding, "put", () =>
+          kv.put(keyEncoded, valueEncoded, options),
+        );
+      }),
+      get: Effect.fnUntraced(function* (key: Key) {
+        const keyEncoded = yield* encodeKey(key);
+        const valueEncoded = yield* tryKvPromise(definition.binding, "get", () =>
+          kv.get(keyEncoded),
+        );
+
+        if (valueEncoded === null) {
+          return Option.none();
+        }
+
+        return yield* decodeValue(valueEncoded).pipe(Effect.map(Option.some));
+      }),
+      getWithMetadata: Effect.fnUntraced(function* <Metadata>(
+        key: Key,
+        metadataSchema: S.Codec<Metadata, unknown>,
+      ) {
+        const keyEncoded = yield* encodeKey(key);
+        const result = yield* tryKvPromise(definition.binding, "getWithMetadata", () =>
+          kv.getWithMetadata<Metadata>(keyEncoded),
+        );
+
+        if (result.value === null) {
+          return Option.none();
+        }
+
+        const value = yield* decodeValue(result.value);
+        const metadata =
+          result.metadata === null
+            ? Option.none<Metadata>()
+            : Option.some(yield* S.decodeUnknownEffect(metadataSchema)(result.metadata));
+
+        return Option.some({
+          value,
+          metadata,
+          cacheStatus: maybeString(result.cacheStatus),
+        });
+      }),
+      list: Effect.fnUntraced(function* <Metadata = unknown>(options?: KvListOptions<Metadata>) {
+        const { metadataSchema, ...kvOptions } = options ?? {};
+        const result = yield* tryKvPromise(definition.binding, "list", () =>
+          kv.list<Metadata>(kvOptions),
+        );
+        const keys: Array<KvListKey<Key, Metadata>> = [];
+
+        for (const key of result.keys) {
+          const decodedName = yield* decodeKey(key.name);
+          const decodedMetadata =
+            key.metadata === undefined
+              ? Option.none<Metadata>()
+              : metadataSchema === undefined
+                ? Option.some(key.metadata as Metadata)
+                : Option.some(yield* S.decodeUnknownEffect(metadataSchema)(key.metadata));
+
+          keys.push({
+            name: decodedName,
+            expiration: maybeNumber(key.expiration),
+            metadata: decodedMetadata,
+          });
+        }
+
+        return {
+          keys,
+          listComplete: result.list_complete,
+          cursor: maybeString("cursor" in result ? result.cursor : undefined),
+          cacheStatus: maybeString(result.cacheStatus),
+        };
+      }),
+      remove: Effect.fnUntraced(function* (key: Key) {
+        const keyEncoded = yield* encodeKey(key);
+        yield* tryKvPromise(definition.binding, "delete", () => kv.delete(keyEncoded));
+      }),
+      unsafeRaw: Effect.succeed(kv),
+    });
+
+    const tag = Binding.Service<Self>()(
+      id,
+      definition.binding,
+      (value): value is KVNamespace => {
+        if (typeof value !== "object" || value === null) {
+          return false;
+        }
+
+        const resource = value as Record<string, unknown>;
+
+        return (
+          typeof resource.get === "function" &&
+          typeof resource.put === "function" &&
+          typeof resource.delete === "function" &&
+          typeof resource.getWithMetadata === "function" &&
+          typeof resource.list === "function"
+        );
+      },
+      makeClient,
+    );
+
     const put = Effect.fnUntraced(function* (key: Key, value: Value, options?: KvPutOptions) {
       const kv = yield* tag;
-      const keyEncoded = yield* encodeKey(key);
-      const valueEncoded = yield* encodeValue(value);
-      yield* tryKvPromise(definition.binding, "put", () =>
-        kv.put(keyEncoded, valueEncoded, options),
-      );
+      yield* kv.put(key, value, options);
     });
 
     const get = Effect.fnUntraced(function* (key: Key) {
       const kv = yield* tag;
-      const keyEncoded = yield* encodeKey(key);
-      const valueEncoded = yield* tryKvPromise(definition.binding, "get", () => kv.get(keyEncoded));
-
-      if (valueEncoded === null) {
-        return Option.none();
-      }
-
-      return yield* decodeValue(valueEncoded).pipe(Effect.map(Option.some));
+      return yield* kv.get(key);
     });
 
     const getWithMetadata = Effect.fnUntraced(function* <Metadata>(
@@ -255,70 +354,24 @@ export const Service =
       metadataSchema: S.Codec<Metadata, unknown>,
     ) {
       const kv = yield* tag;
-      const keyEncoded = yield* encodeKey(key);
-      const result = yield* tryKvPromise(definition.binding, "getWithMetadata", () =>
-        kv.getWithMetadata<Metadata>(keyEncoded),
-      );
-
-      if (result.value === null) {
-        return Option.none();
-      }
-
-      const value = yield* decodeValue(result.value);
-      const metadata =
-        result.metadata === null
-          ? Option.none<Metadata>()
-          : Option.some(yield* S.decodeUnknownEffect(metadataSchema)(result.metadata));
-
-      return Option.some({
-        value,
-        metadata,
-        cacheStatus: maybeString(result.cacheStatus),
-      });
+      return yield* kv.getWithMetadata(key, metadataSchema);
     });
 
     const list = Effect.fnUntraced(function* <Metadata = unknown>(
       options?: KvListOptions<Metadata>,
     ) {
       const kv = yield* tag;
-      const { metadataSchema, ...kvOptions } = options ?? {};
-      const result = yield* tryKvPromise(definition.binding, "list", () =>
-        kv.list<Metadata>(kvOptions),
-      );
-      const keys: Array<KvListKey<Key, Metadata>> = [];
-
-      for (const key of result.keys) {
-        const decodedName = yield* decodeKey(key.name);
-        const decodedMetadata =
-          key.metadata === undefined
-            ? Option.none<Metadata>()
-            : metadataSchema === undefined
-              ? Option.some(key.metadata as Metadata)
-              : Option.some(yield* S.decodeUnknownEffect(metadataSchema)(key.metadata));
-
-        keys.push({
-          name: decodedName,
-          expiration: maybeNumber(key.expiration),
-          metadata: decodedMetadata,
-        });
-      }
-
-      return {
-        keys,
-        listComplete: result.list_complete,
-        cursor: maybeString("cursor" in result ? result.cursor : undefined),
-        cacheStatus: maybeString(result.cacheStatus),
-      };
+      return yield* kv.list(options);
     });
 
     const remove = Effect.fnUntraced(function* (key: Key) {
       const kv = yield* tag;
-      const keyEncoded = yield* encodeKey(key);
-      yield* tryKvPromise(definition.binding, "delete", () => kv.delete(keyEncoded));
+      yield* kv.remove(key);
     });
 
     const unsafeRaw = Effect.fnUntraced(function* () {
-      return yield* tag;
+      const kv = yield* tag;
+      return yield* kv.unsafeRaw;
     });
 
     return Object.assign(tag, {

--- a/packages/effect-cf/src/QueueBinding.ts
+++ b/packages/effect-cf/src/QueueBinding.ts
@@ -19,6 +19,19 @@ export interface QueueBindingDefinition<Message extends RpcDefinition.ServiceFre
   readonly message: Message;
 }
 
+export interface QueueBindingClient<Message extends RpcDefinition.ServiceFreeSchema> {
+  readonly send: (
+    message: S.Schema.Type<Message>,
+    options?: QueueSendOptions,
+  ) => Effect.Effect<void, QueueOperationError | S.SchemaError>;
+  readonly sendBatch: (
+    messages: Iterable<MessageSendRequest<S.Schema.Type<Message>>>,
+    options?: QueueSendBatchOptions,
+  ) => Effect.Effect<void, QueueOperationError | S.SchemaError>;
+  readonly metrics: () => Effect.Effect<QueueMetrics, QueueOperationError>;
+  readonly unsafeRaw: Effect.Effect<globalThis.Queue<S.Codec.Encoded<Message>>>;
+}
+
 declare const QueueServiceTypeId: unique symbol;
 
 /** Nominal service marker for Queue services created with {@link make}. */
@@ -81,19 +94,45 @@ export const Service =
     type Body = S.Schema.Type<Message>;
     type EncodedBody = S.Codec.Encoded<Message>;
 
+    const encodeMessage = S.encodeEffect(definition.message);
+
+    const makeClient = (queue: globalThis.Queue<EncodedBody>): QueueBindingClient<Message> => ({
+      send: Effect.fnUntraced(function* (message: Body, options?: QueueSendOptions) {
+        const encoded = yield* encodeMessage(message);
+
+        yield* tryQueuePromise(definition.binding, "send", () => queue.send(encoded, options));
+      }),
+      sendBatch: Effect.fnUntraced(function* (
+        messages: Iterable<MessageSendRequest<Body>>,
+        options?: QueueSendBatchOptions,
+      ) {
+        const encodedMessages: Array<MessageSendRequest<EncodedBody>> = [];
+
+        for (const message of messages) {
+          encodedMessages.push({
+            ...message,
+            body: yield* encodeMessage(message.body),
+          });
+        }
+
+        yield* tryQueuePromise(definition.binding, "sendBatch", () =>
+          queue.sendBatch(encodedMessages, options),
+        );
+      }),
+      metrics: () => tryQueuePromise(definition.binding, "metrics", () => queue.metrics()),
+      unsafeRaw: Effect.succeed(queue),
+    });
+
     const tag = Binding.Service<Self>()(
       id,
       definition.binding,
       (value): value is globalThis.Queue<EncodedBody> => isQueue<EncodedBody>(value),
+      makeClient,
     );
-
-    const encodeMessage = S.encodeEffect(definition.message);
 
     const send = Effect.fnUntraced(function* (message: Body, options?: QueueSendOptions) {
       const queue = yield* tag;
-      const encoded = yield* encodeMessage(message);
-
-      return yield* tryQueuePromise(definition.binding, "send", () => queue.send(encoded, options));
+      yield* queue.send(message, options);
     });
 
     const sendBatch = Effect.fnUntraced(function* (
@@ -101,24 +140,17 @@ export const Service =
       options?: QueueSendBatchOptions,
     ) {
       const queue = yield* tag;
-      const encodedMessages: Array<MessageSendRequest<EncodedBody>> = [];
-
-      for (const message of messages) {
-        encodedMessages.push({
-          ...message,
-          body: yield* encodeMessage(message.body),
-        });
-      }
-
-      return yield* tryQueuePromise(definition.binding, "sendBatch", () =>
-        queue.sendBatch(encodedMessages, options),
-      );
+      yield* queue.sendBatch(messages, options);
     });
 
     const metrics = Effect.fnUntraced(function* () {
       const queue = yield* tag;
+      return yield* queue.metrics();
+    });
 
-      return yield* tryQueuePromise(definition.binding, "metrics", () => queue.metrics());
+    const unsafeRaw = Effect.fnUntraced(function* () {
+      const queue = yield* tag;
+      return yield* queue.unsafeRaw;
     });
 
     return Object.assign(tag, {
@@ -127,5 +159,6 @@ export const Service =
       send,
       sendBatch,
       metrics,
+      unsafeRaw,
     });
   };

--- a/packages/effect-cf/src/ServiceBinding.ts
+++ b/packages/effect-cf/src/ServiceBinding.ts
@@ -1,4 +1,4 @@
-import { Data, Effect } from "effect";
+import { Data, Effect, type Scope } from "effect";
 
 import * as Binding from "./Binding";
 import * as CloudflareRpc from "./Rpc";
@@ -75,24 +75,46 @@ type ServiceMethodSuccess<Api, Method extends keyof Api> = RpcInvocation.AsyncMe
   Method
 >;
 
-type ServiceCall<Self, Api> = <Method extends ServiceMethodKey<Api>>(
+type ServiceCall<R, Api> = <Method extends ServiceMethodKey<Api>>(
   method: Method,
   ...args: ServiceMethodArgs<Api, Method>
-) => Effect.Effect<ServiceMethodSuccess<Api, Method>, ServiceBindingRpcError, Self>;
+) => Effect.Effect<ServiceMethodSuccess<Api, Method>, ServiceBindingRpcError, R>;
 
-type DefinitionDirectMethods<Self, Definition extends WorkerDefinition.Definition.Any> = {
+type DefinitionDirectMethods<R, Definition extends WorkerDefinition.Definition.Any> = {
   readonly [Method in RpcDefinition.Definition.MethodNames<Definition>]: (
     ...args: RpcDefinition.Method.Args<Definition["methods"][Method]>
   ) => Effect.Effect<
     RpcDefinition.Method.Success<Definition["methods"][Method]>,
     ServiceBindingRpcError,
-    Self
+    R
   >;
 };
 
-type DirectMethods<Self, Definition> = Definition extends WorkerDefinition.Definition.Any
-  ? DefinitionDirectMethods<Self, Definition>
+type DirectMethods<R, Definition> = Definition extends WorkerDefinition.Definition.Any
+  ? DefinitionDirectMethods<R, Definition>
   : {};
+
+export type ServiceBindingEffectClient<
+  Api extends object,
+  Definition extends WorkerDefinition.Definition.Any | undefined = undefined,
+> = DirectMethods<never, Definition> & {
+  readonly fetch: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Effect.Effect<globalThis.Response, ServiceBindingFetchError>;
+  readonly rpc: <Method extends ServiceMethodKey<Api>>(
+    method: Method,
+    ...args: ServiceMethodArgs<Api, Method>
+  ) => Effect.Effect<ServiceMethodSuccess<Api, Method>, ServiceBindingRpcError>;
+  readonly call: <Method extends ServiceMethodKey<Api>>(
+    method: Method,
+    ...args: ServiceMethodArgs<Api, Method>
+  ) => Effect.Effect<ServiceMethodSuccess<Api, Method>, ServiceBindingRpcError>;
+  readonly scopedCall: <Method extends ServiceMethodKey<Api>>(
+    method: Method,
+    ...args: ServiceMethodArgs<Api, Method>
+  ) => Effect.Effect<Awaited<ServiceMethodSuccess<Api, Method>>, unknown, Scope.Scope>;
+};
 
 /**
  * Creates a typed Effect service for a Worker service binding.
@@ -131,21 +153,125 @@ export const Service =
   ) => {
     type ServiceApi = ApiOrDefinition<Api, Definition>;
 
+    const makeClient = (
+      service: ServiceBindingClient<ServiceApi>,
+    ): ServiceBindingEffectClient<ServiceApi, Definition> => {
+      const fetch = (input: RequestInfo | URL, init?: RequestInit) =>
+        Effect.tryPromise({
+          try: () => service.fetch(input, init),
+          catch: (cause) => new ServiceBindingFetchError({ binding: definition.binding, cause }),
+        });
+
+      const rpc = <Method extends ServiceMethodKey<ServiceApi>>(
+        method: Method,
+        ...args: ServiceMethodArgs<ServiceApi, Method>
+      ) =>
+        Effect.gen(function* () {
+          const methodName = String(method);
+          const encodedArgs =
+            definition.definition === undefined
+              ? args
+              : yield* RpcDefinition.encodeArgs(
+                  definition.definition,
+                  methodName as RpcDefinition.Definition.MethodNames<NonNullable<Definition>>,
+                  args as never,
+                ).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new ServiceBindingRpcError({
+                        binding: definition.binding,
+                        method: methodName,
+                        cause,
+                      }),
+                  ),
+                );
+
+          return yield* RpcInvocation.invokeRpcMethod(
+            service,
+            method,
+            encodedArgs as ServiceMethodArgs<ServiceApi, Method>,
+            (cause) =>
+              new ServiceBindingRpcError({
+                binding: definition.binding,
+                method: methodName,
+                cause,
+              }),
+          );
+        });
+
+      const call = <Method extends ServiceMethodKey<ServiceApi>>(
+        method: Method,
+        ...args: ServiceMethodArgs<ServiceApi, Method>
+      ) =>
+        Effect.gen(function* () {
+          const methodName = String(method);
+          const value = yield* CloudflareRpc.resolve(yield* rpc(method, ...args)).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ServiceBindingRpcError({
+                  binding: definition.binding,
+                  method: methodName,
+                  cause,
+                }),
+            ),
+          );
+
+          if (definition.definition === undefined) {
+            return value as ServiceMethodSuccess<ServiceApi, Method>;
+          }
+
+          const decoded = yield* RpcDefinition.decodeSuccess(
+            definition.definition,
+            methodName as RpcDefinition.Definition.MethodNames<NonNullable<Definition>>,
+            value,
+          ).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ServiceBindingRpcError({
+                  binding: definition.binding,
+                  method: methodName,
+                  cause,
+                }),
+            ),
+          );
+
+          return decoded as ServiceMethodSuccess<ServiceApi, Method>;
+        });
+
+      const scopedCall = <Method extends ServiceMethodKey<ServiceApi>>(
+        method: Method,
+        ...args: ServiceMethodArgs<ServiceApi, Method>
+      ) =>
+        Effect.gen(function* () {
+          const result = yield* rpc(method, ...args);
+          return yield* CloudflareRpc.scoped(result);
+        });
+
+      const directMethods = makeDirectMethods<never, ServiceApi, Definition>(
+        definition.definition,
+        call,
+      );
+
+      return Object.assign(directMethods, {
+        fetch,
+        rpc,
+        call,
+        scopedCall,
+      }) as ServiceBindingEffectClient<ServiceApi, Definition>;
+    };
+
     const tag = Binding.Service<Self>()(
       id,
       definition.binding,
       (value): value is ServiceBindingClient<ServiceApi> =>
         typeof value === "object" && value !== null && "fetch" in value,
+      makeClient,
     );
 
     const fetch = (input: RequestInfo | URL, init?: RequestInit) =>
       Effect.gen(function* () {
         const service = yield* tag;
-
-        return yield* Effect.tryPromise({
-          try: () => service.fetch(input, init),
-          catch: (cause) => new ServiceBindingFetchError({ binding: definition.binding, cause }),
-        });
+        return yield* service.fetch(input, init);
       });
 
     const rpc = <Method extends ServiceMethodKey<ServiceApi>>(
@@ -154,36 +280,7 @@ export const Service =
     ) =>
       Effect.gen(function* () {
         const service = yield* tag;
-        const methodName = String(method);
-        const encodedArgs =
-          definition.definition === undefined
-            ? args
-            : yield* RpcDefinition.encodeArgs(
-                definition.definition,
-                methodName as RpcDefinition.Definition.MethodNames<NonNullable<Definition>>,
-                args as never,
-              ).pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new ServiceBindingRpcError({
-                      binding: definition.binding,
-                      method: methodName,
-                      cause,
-                    }),
-                ),
-              );
-
-        return yield* RpcInvocation.invokeRpcMethod(
-          service,
-          method,
-          encodedArgs as ServiceMethodArgs<ServiceApi, Method>,
-          (cause) =>
-            new ServiceBindingRpcError({
-              binding: definition.binding,
-              method: methodName,
-              cause,
-            }),
-        );
+        return yield* service.rpc(method, ...args);
       });
 
     const call = <Method extends ServiceMethodKey<ServiceApi>>(
@@ -191,38 +288,8 @@ export const Service =
       ...args: ServiceMethodArgs<ServiceApi, Method>
     ) =>
       Effect.gen(function* () {
-        const methodName = String(method);
-        const value = yield* CloudflareRpc.resolve(yield* rpc(method, ...args)).pipe(
-          Effect.mapError(
-            (cause) =>
-              new ServiceBindingRpcError({
-                binding: definition.binding,
-                method: methodName,
-                cause,
-              }),
-          ),
-        );
-
-        if (definition.definition === undefined) {
-          return value as ServiceMethodSuccess<ServiceApi, Method>;
-        }
-
-        const decoded = yield* RpcDefinition.decodeSuccess(
-          definition.definition,
-          methodName as RpcDefinition.Definition.MethodNames<NonNullable<Definition>>,
-          value,
-        ).pipe(
-          Effect.mapError(
-            (cause) =>
-              new ServiceBindingRpcError({
-                binding: definition.binding,
-                method: methodName,
-                cause,
-              }),
-          ),
-        );
-
-        return decoded as ServiceMethodSuccess<ServiceApi, Method>;
+        const service = yield* tag;
+        return yield* service.call(method, ...args);
       });
 
     const scopedCall = <Method extends ServiceMethodKey<ServiceApi>>(
@@ -230,8 +297,8 @@ export const Service =
       ...args: ServiceMethodArgs<ServiceApi, Method>
     ) =>
       Effect.gen(function* () {
-        const result = yield* rpc(method, ...args);
-        return yield* CloudflareRpc.scoped(result);
+        const service = yield* tag;
+        return yield* service.scopedCall(method, ...args);
       });
 
     const directMethods = makeDirectMethods<Self, ServiceApi, Definition>(
@@ -257,14 +324,10 @@ export const Service =
       };
   };
 
-const makeDirectMethods = <
-  Self,
-  Api,
-  Definition extends WorkerDefinition.Definition.Any | undefined,
->(
+const makeDirectMethods = <R, Api, Definition extends WorkerDefinition.Definition.Any | undefined>(
   rpcDefinition: Definition | undefined,
-  call: ServiceCall<Self, Api>,
-): DirectMethods<Self, Definition> => {
+  call: ServiceCall<R, Api>,
+): DirectMethods<R, Definition> => {
   const methods = {} as Record<string, unknown>;
 
   if (rpcDefinition !== undefined) {
@@ -274,5 +337,5 @@ const makeDirectMethods = <
     }
   }
 
-  return methods as DirectMethods<Self, Definition>;
+  return methods as DirectMethods<R, Definition>;
 };

--- a/packages/effect-cf/tests/Kv.test.ts
+++ b/packages/effect-cf/tests/Kv.test.ts
@@ -128,8 +128,9 @@ const valueStyleKvBindingLayer = (kv: KVNamespace) =>
     it.effect("forwards Cloudflare KV put options", () =>
       Effect.gen(function* () {
         const metadata = { owner: "api" };
+        const kv = yield* TestKv;
 
-        yield* TestKv.put(
+        yield* kv.put(
           "user:1",
           { count: 1 },
           {

--- a/packages/effect-cf/tests/binding-ergonomics.test-d.ts
+++ b/packages/effect-cf/tests/binding-ergonomics.test-d.ts
@@ -1,0 +1,143 @@
+import { expectTypeOf } from "vitest";
+import { Effect, Layer, Option, Schema } from "effect";
+
+import {
+  DurableObject,
+  DurableObjectNamespace,
+  Kv,
+  Queue,
+  QueueBinding,
+  ServiceBinding,
+  Worker,
+  WorkerEnvironment,
+} from "../src/index";
+
+export const AvatarQueueMessagePayload = Schema.Struct({
+  requestId: Schema.String,
+  userId: Schema.String,
+});
+
+export class AvatarQueueDefinition extends Queue.Tag<AvatarQueueDefinition>()("AvatarQueue", {
+  message: AvatarQueueMessagePayload,
+}) {}
+
+export class AvatarQueue extends AvatarQueueDefinition.Binding<AvatarQueue>()("AvatarQueue", {
+  binding: "AVATAR_QUEUE",
+}) {}
+
+export const AvatarQueueLayer = AvatarQueue.layer;
+
+const queueProgram = Effect.gen(function* () {
+  const queue = yield* AvatarQueue;
+
+  expectTypeOf(queue.send({ requestId: "r1", userId: "u1" })).toEqualTypeOf<
+    Effect.Effect<void, QueueBinding.QueueOperationError | Schema.SchemaError>
+  >();
+
+  yield* queue.send({ requestId: "r1", userId: "u1" });
+  yield* queue.sendBatch([{ body: { requestId: "r2", userId: "u2" } }]);
+  yield* queue.metrics();
+
+  // @ts-expect-error queue messages use the decoded schema shape.
+  yield* queue.send({ requestId: "r1" });
+});
+
+// @ts-expect-error AvatarQueue.layer must be provided before the program can run.
+const missingQueueLayer: Effect.Effect<void, unknown, never> = queueProgram;
+
+declare const env: Cloudflare.Env;
+const providedQueueProgram: Effect.Effect<void, unknown, never> = queueProgram.pipe(
+  Effect.provide(AvatarQueue.layer.pipe(Layer.provide(Layer.succeed(WorkerEnvironment, env)))),
+);
+
+expectTypeOf(AvatarQueue.send({ requestId: "r1", userId: "u1" })).toEqualTypeOf<
+  Effect.Effect<void, QueueBinding.QueueOperationError | Schema.SchemaError, AvatarQueue>
+>();
+
+void missingQueueLayer;
+void providedQueueProgram;
+
+export class SessionKvDefinition extends Kv.Tag<SessionKvDefinition>()("SessionKv", {
+  key: Schema.String,
+  value: Schema.Struct({ count: Schema.Number }),
+}) {}
+
+export class SessionKv extends SessionKvDefinition.Binding<SessionKv>()("SessionKv", {
+  binding: "SESSION_KV",
+}) {}
+
+export const SessionKvLayer = SessionKv.layer;
+
+const kvProgram = Effect.gen(function* () {
+  const kv = yield* SessionKv;
+
+  expectTypeOf(kv.get("session-1")).toEqualTypeOf<
+    Effect.Effect<
+      Option.Option<{ readonly count: number }>,
+      Kv.KvOperationError | Schema.SchemaError
+    >
+  >();
+
+  yield* kv.put("session-1", { count: 1 });
+
+  // @ts-expect-error KV values use the decoded schema shape.
+  yield* kv.put("session-1", { count: "1" });
+});
+
+export class ApiWorkerDefinition extends Worker.Tag<ApiWorkerDefinition>()("ApiWorker", {
+  ping: Worker.method({
+    args: [Schema.String] as const,
+    success: Schema.String,
+  }),
+}) {}
+
+export class ApiWorker extends ApiWorkerDefinition.Binding<ApiWorker>()("ApiWorker", {
+  binding: "API_WORKER",
+}) {}
+
+export const ApiWorkerLayer = ApiWorker.layer;
+
+const workerProgram = Effect.gen(function* () {
+  const worker = yield* ApiWorker;
+
+  expectTypeOf(worker.ping("hello")).toEqualTypeOf<
+    Effect.Effect<string, ServiceBinding.ServiceBindingRpcError>
+  >();
+
+  yield* worker.ping("hello");
+
+  // @ts-expect-error Worker RPC arguments use the decoded schema shape.
+  yield* worker.ping(123);
+});
+
+export class CounterDurableObjectDefinition extends DurableObject.Tag<CounterDurableObjectDefinition>()(
+  "CounterDurableObject",
+  {
+    get: DurableObject.method({ success: Schema.Number }),
+  },
+) {}
+
+export class CounterDurableObjects extends CounterDurableObjectDefinition.Namespace<CounterDurableObjects>()(
+  "CounterDurableObjects",
+  { binding: "COUNTER_DURABLE_OBJECTS" },
+) {}
+
+export const CounterDurableObjectsLayer = CounterDurableObjects.layer;
+
+const durableObjectProgram = Effect.gen(function* () {
+  const namespace = yield* CounterDurableObjects;
+  const counter = namespace.byName("counter-1");
+
+  expectTypeOf(counter.get()).toEqualTypeOf<
+    Effect.Effect<number, DurableObjectNamespace.DurableObjectRpcError>
+  >();
+
+  yield* counter.get();
+
+  // @ts-expect-error Durable Object RPC method names come from the definition.
+  yield* counter.missing();
+});
+
+void kvProgram;
+void workerProgram;
+void durableObjectProgram;

--- a/packages/effect-cf/tests/definitions.test.ts
+++ b/packages/effect-cf/tests/definitions.test.ts
@@ -5,10 +5,13 @@ import {
   DurableObjectDefinition,
   DurableObjectStorage,
   Queue,
+  QueueBinding,
   WorkerDefinition,
   WorkerEnvironment,
   Workflow,
 } from "../src/index";
+
+const expectType = <T>(_value: T) => {};
 
 const TestWorker = WorkerDefinition.make("TestWorker", {
   double: WorkerDefinition.method({
@@ -63,6 +66,35 @@ test("definition-backed Worker RPC validates encoded success values", async () =
     binding: "AVATAR_QUEUE",
   }) {}
 
+  const assertQueueBindingTypes = () => {
+    const program = Effect.gen(function* () {
+      const queue = yield* AvatarQueue;
+
+      expectType<Effect.Effect<void, QueueBinding.QueueOperationError | S.SchemaError>>(
+        queue.send({ userId: "u_1", attempts: 1 }),
+      );
+
+      yield* queue.send({ userId: "u_1", attempts: 1 });
+      yield* queue.sendBatch([{ body: { userId: "u_2", attempts: 2 } }]);
+      yield* queue.metrics();
+
+      // @ts-expect-error Queue bindings accept decoded messages, not encoded wire values.
+      yield* queue.send({ userId: "u_1", attempts: "1" });
+    });
+
+    // @ts-expect-error AvatarQueue.layer must be provided before the program can run.
+    const missingLayer: Effect.Effect<void, unknown, never> = program;
+
+    const provided: Effect.Effect<void, unknown, never> = program.pipe(
+      Effect.provide(AvatarQueue.layer.pipe(Layer.provide(Layer.succeed(WorkerEnvironment, env)))),
+    );
+
+    void missingLayer;
+    void provided;
+  };
+
+  void assertQueueBindingTypes;
+
   const sent: Array<unknown> = [];
   const env = {
     AVATAR_QUEUE: {
@@ -86,12 +118,15 @@ test("definition-backed Worker RPC validates encoded success values", async () =
           sent.length = 0;
 
           yield* AvatarQueue.send({ userId: "u_1", attempts: 2 });
-          yield* AvatarQueue.sendBatch([{ body: { userId: "u_2", attempts: 3 } }]);
+          const queue = yield* AvatarQueue;
+          yield* queue.sendBatch([{ body: { userId: "u_2", attempts: 3 } }]);
+          const metrics = yield* queue.metrics();
 
           assert.deepStrictEqual(sent, [
             { userId: "u_1", attempts: "2" },
             { userId: "u_2", attempts: "3" },
           ]);
+          assert.deepStrictEqual(metrics, { backlogCount: 0, backlogBytes: 0 });
         }),
       );
     },

--- a/packages/effect-cf/tests/index.test.ts
+++ b/packages/effect-cf/tests/index.test.ts
@@ -411,8 +411,9 @@ test("Durable Object namespace binding retrieves stubs from the Worker environme
   const resolved = await Effect.runPromise(
     provideCounters(
       Effect.gen(function* () {
-        const counter = yield* Counters.getByName("counter");
-        return yield* Counters.call(counter, "get");
+        const counters = yield* Counters;
+        const counter = yield* counters.getByName("counter");
+        return yield* counters.call(counter, "get");
       }),
       {
         COUNTERS: makeNamespace(stub),
@@ -445,12 +446,18 @@ test("Service binding rpc uses the shared dynamic method validation", async () =
 
   await expect(
     Effect.runPromise(
-      provideEchoService(EchoService.call("echo", "hello"), {
-        ECHO: {
-          ...fetcher,
-          echo: (value: string) => Promise.resolve(value),
-        },
-      } as unknown as Cloudflare.Env),
+      provideEchoService(
+        Effect.gen(function* () {
+          const service = yield* EchoService;
+          return yield* service.call("echo", "hello");
+        }),
+        {
+          ECHO: {
+            ...fetcher,
+            echo: (value: string) => Promise.resolve(value),
+          },
+        } as unknown as Cloudflare.Env,
+      ),
     ),
   ).resolves.toBe("hello");
 });

--- a/packages/effect-cf/vite.config.ts
+++ b/packages/effect-cf/vite.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
           },
           exclude: [...testExcludes, "**/*.worker.test.ts"],
           include: ["**/*.test.ts"],
+          typecheck: {
+            enabled: true,
+            include: ["tests/**/*.test-d.ts"],
+          },
         },
       },
       {


### PR DESCRIPTION
## Summary

- Provide Effect-native clients from yielded Queue, KV, Worker service, and Durable Object namespace binding tags.
- Keep existing static binding helpers compatible while updating docs and examples toward the yielded-service style.
- Add Vitest typecheck coverage for yielded binding clients, missing layers, invalid schema shapes, and exported binding classes.

## Validation

- `vp check`
- `vp test`
- `vp run effect-cf#build`
- `bunx tsc -p tsconfig.json --noEmit false --emitDeclarationOnly --declaration --outDir .tmp/declaration-test --noUnusedLocals false` from `packages/effect-cf`
- `vp run queue-workflow-app#test`
- `vp run chat-api-worker#build`
- `vp run chat-analytics-worker#build`
- `vp run todos-web-worker#build`