### PR TITLE
chore: add Effect source reference setup

### DIFF
--- a/.agents/skills/pr-hygiene/SKILL.md
+++ b/.agents/skills/pr-hygiene/SKILL.md
@@ -1,3 +1,13 @@
+---
+name: pr-hygiene
+description: Use before creating or updating PRs, choosing PR titles, writing PR bodies, or adding changesets for this repository.
+tags:
+  - pull-request
+  - changeset
+  - release
+  - validation
+---
+
 # PR Hygiene
 
 Use this skill before creating or updating a pull request, adding a changeset, or choosing a PR title.

--- a/.changeset/effect-smol-setup.md
+++ b/.changeset/effect-smol-setup.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add local setup automation for the Effect source reference checkout and install-time tooling.

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ vite.config.*.mjs
 # Logs
 logs/
 prompt-exports/
-repos/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "repos/effect-smol"]
+	path = repos/effect-smol
+	url = https://github.com/Effect-TS/effect-smol.git
+	shallow = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,16 @@
 <!--VITE PLUS START-->
 
-# Vite+
+# Using Vite+, the Unified Toolchain for the Web
 
-Use Vite+ through the `vp` CLI for installs, checks, tests, builds, scripts, package-manager operations, and one-off binaries. Docs are in `node_modules/vite-plus/docs` and at https://viteplus.dev/guide/.
+This project is using Vite+, a unified toolchain built on top of Vite, Rolldown, Vitest, tsdown, Oxlint, Oxfmt, and Vite Task. Vite+ wraps runtime management, package management, and frontend tooling in a single global CLI called `vp`. Vite+ is distinct from Vite, and it invokes Vite through `vp dev` and `vp build`. Run `vp help` to print a list of commands and `vp <command> --help` for information about a specific command.
 
-## Validation
+Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.dev/guide/.
+
+## Review Checklist
 
 - [ ] Run `vp install` after pulling remote changes and before getting started.
 - [ ] Run `vp check` and `vp test` to format, lint, type check and test changes.
 - [ ] Check if there are `vite.config.ts` tasks or `package.json` scripts necessary for validation, run via `vp run <script>`.
-
-<!--VITE PLUS END-->
 
 # Package Layout
 
@@ -18,7 +18,7 @@ Use Vite+ through the `vp` CLI for installs, checks, tests, builds, scripts, pac
 - `examples/` contains consumer/example apps.
 - Reusable package code belongs under `packages/effect-cf/src` and should be exported from `packages/effect-cf/src/index.ts`.
 - Generated `worker-configuration.d.ts` files are local checks, not source-of-truth API definitions.
-- `repos/effect-smol` is a reference subtree for Effect patterns and API style; consult it when changing Effect-heavy code, but do not treat it as package source.
+- Effect source code can be referenced at `repos/effect-smol` for patterns and API style when changing Effect-heavy code. Do not edit files under `repos/effect-smol`; it is a reference checkout, not package source.
 
 # Repo-Local Skills
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,9 +8,12 @@
         "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.31.0",
         "@cloudflare/vitest-pool-workers": "^0.16.3",
+        "@effect/platform-bun": "catalog:",
         "@effect/tsgo": "0.5.1",
+        "@types/bun": "^1.3.14",
         "@types/node": "^25.6.0",
         "@typescript/native-preview": "7.0.0-dev.20260423.1",
+        "effect": "catalog:",
         "vite-plus": "catalog:",
         "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.20",
         "wrangler": "^4.84.1",
@@ -325,10 +328,12 @@
     },
   },
   "overrides": {
+    "@effect/platform-node-shared": "4.0.0-beta.65",
     "vite": "catalog:",
     "vitest": "catalog:",
   },
   "catalog": {
+    "@effect/platform-bun": "4.0.0-beta.65",
     "@effect/sql-d1": "4.0.0-beta.65",
     "@effect/vitest": "4.0.0-beta.65",
     "effect": "4.0.0-beta.65",
@@ -406,6 +411,10 @@
     "@effect-cf/todo-rpc-ws-domain": ["@effect-cf/todo-rpc-ws-domain@workspace:examples/todo-rpc-ws/packages/domain"],
 
     "@effect-cf/todos-domain": ["@effect-cf/todos-domain@workspace:examples/todos/packages/domain"],
+
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.65", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.65" }, "peerDependencies": { "effect": "^4.0.0-beta.65" } }, "sha512-6BgEjVDibeOgGj0pvYRx+mBLSWVBPlvuqa6o4kuyrRIdgn92nbKrbglEiIRe4sn7yYmeKei4N/kd7fRzN3rEwA=="],
+
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.65", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.65" } }, "sha512-3rY8F3WLEax6Hj08GI/OvDIH+KqjfxH7RM2bAMfgR75NgRmwDtny1P49PtPkoRjH5dcdtThThtsvE4X9OTZkpQ=="],
 
     "@effect/sql-d1": ["@effect/sql-d1@4.0.0-beta.65", "", { "dependencies": { "@cloudflare/workers-types": "^4.20260412.1" }, "peerDependencies": { "effect": "^4.0.0-beta.65" } }, "sha512-tH+OMFZfiutBtGfUcW968z6tKB4yMEhlXRVkl9k6q4BnVqOYvvzy+9WfEGzIcxh8uH0hrN6QPuocLDmF/DHImQ=="],
 
@@ -671,6 +680,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -680,6 +691,8 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260423.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260423.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260423.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-9WD7TJJlGvt9PQqJI/+44dVP4oqGQFIkYrpXt7nlQ0WgNIErN52x/XhxmJ4nWft06qejgPiUbPo4aYRNOmIHXg=="],
 
@@ -742,6 +755,8 @@
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
@@ -1119,8 +1134,6 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
-    "@vitejs/plugin-react/vite": ["@voidzero-dev/vite-plus-core@0.1.19", "", { "dependencies": { "@oxc-project/runtime": "=0.126.0", "@oxc-project/types": "=0.126.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.9", "@tsdown/exe": "0.21.9", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-BTmz50juSDolIN4Vtu5iVaPONV1XSrMB5V+9IoBhhxdogfvp7PBhaHuAcPjTN2RTVowhLZXoo8mn+aHjq//bkw=="],
-
     "effect-cf/@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.15.0", "", { "dependencies": { "cjs-module-lexer": "^1.2.3", "esbuild": "0.27.3", "miniflare": "4.20260424.0", "wrangler": "4.85.0", "zod": "^3.25.76" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-RldzOt2az3mxICTxT7GTSBpm6f61lx4LWSilRHm4pJlYAGmfGu1pyinqJw3UmPZS9N/mrN7XwdZAqFV6hhmWaQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -1142,10 +1155,6 @@
     "@cloudflare/vitest-pool-workers/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
     "@cloudflare/vitest-pool-workers/wrangler/workerd": ["workerd@1.20260507.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260507.1", "@cloudflare/workerd-darwin-arm64": "1.20260507.1", "@cloudflare/workerd-linux-64": "1.20260507.1", "@cloudflare/workerd-linux-arm64": "1.20260507.1", "@cloudflare/workerd-windows-64": "1.20260507.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-z7JhsFSe6+X1b5fUHaVpo15VM1IRMJiLofEkq8iKdCo+Veqc+FUg5lIsuz8NwePxuSKrXtO4ZQpGkQLbPVXFhg=="],
-
-    "@vitejs/plugin-react/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.126.0", "", {}, "sha512-oksjxfqDNmIYMGlIgLzYgnz5YjZax27RtQezsPpKEGo9AC5LOaIGHsivCCeaAWdCtPnRyjZXM/7svreCC8kZVQ=="],
-
-    "@vitejs/plugin-react/vite/@oxc-project/types": ["@oxc-project/types@0.126.0", "", {}, "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ=="],
 
     "effect-cf/@cloudflare/vitest-pool-workers/miniflare": ["miniflare@4.20260424.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260424.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   ],
   "type": "module",
   "scripts": {
+    "postinstall": "bun scripts/postinstall.ts",
+    "sync:effect": "bun scripts/sync-effect-submodule.ts",
+    "patch:tsgo": "bun scripts/patch-tsgo.ts",
     "ready": "vp check && vp run -r test && vp run -r build",
     "changeset": "vp exec changeset",
     "changeset:version": "vp exec changeset version",
@@ -19,7 +22,6 @@
     "dev": "vp run chat-api-worker#dev",
     "dev:web": "vp run chat-web#dev",
     "cf-typegen": "vp run chat-room-do#cf-typegen && vp run chat-analytics-worker#cf-typegen && vp run chat-api-worker#cf-typegen",
-    "prepare": "vp config && effect-tsgo patch",
     "dev:todo-http-api": "vp run todo-http-api-worker#dev",
     "dev:todo-http-web": "vp run todo-http-web#dev",
     "dev:todo-http": "vp run todo-http-web#dev",
@@ -40,14 +42,18 @@
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
     "@cloudflare/vitest-pool-workers": "^0.16.3",
+    "@effect/platform-bun": "catalog:",
     "@effect/tsgo": "0.5.1",
+    "@types/bun": "^1.3.14",
     "@types/node": "^25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260423.1",
+    "effect": "catalog:",
     "vite-plus": "catalog:",
     "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.20",
     "wrangler": "^4.84.1"
   },
   "overrides": {
+    "@effect/platform-node-shared": "4.0.0-beta.65",
     "vite": "catalog:",
     "vitest": "catalog:"
   },
@@ -56,6 +62,7 @@
   },
   "packageManager": "bun@1.3.13",
   "catalog": {
+    "@effect/platform-bun": "4.0.0-beta.65",
     "@effect/sql-d1": "4.0.0-beta.65",
     "@effect/vitest": "4.0.0-beta.65",
     "effect": "4.0.0-beta.65",

--- a/scripts/patch-tsgo.ts
+++ b/scripts/patch-tsgo.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+
+import { BunRuntime, BunServices } from "@effect/platform-bun";
+import { Clock, Effect, Inspectable, Path, Result, Schema as S } from "effect";
+import { Command } from "effect/unstable/cli";
+
+import { formatTiming, startProgressBoard } from "./utils/step-progress.ts";
+
+class CommandError extends S.TaggedErrorClass<CommandError>()("CommandError", {
+  command: S.String,
+  exitCode: S.Int,
+  output: S.String,
+}) {
+  override get message() {
+    return this.output.length > 0
+      ? `${this.command} exited with code ${this.exitCode}: ${this.output}`
+      : `${this.command} exited with code ${this.exitCode}`;
+  }
+}
+
+class CommandSpawnError extends S.TaggedErrorClass<CommandSpawnError>()("CommandSpawnError", {
+  command: S.String,
+  reason: S.String,
+}) {
+  override get message() {
+    return `failed to spawn ${this.command}: ${this.reason}`;
+  }
+}
+
+const formatUnknown = (value: unknown): string =>
+  value instanceof Error ? value.message : Inspectable.toStringUnknown(value);
+
+const resolvePaths = Effect.fn("resolvePaths")(function* () {
+  const path = yield* Path.Path;
+  const scriptPath = yield* path.fromFileUrl(new URL(import.meta.url));
+  const rootDir = path.resolve(path.dirname(scriptPath), "..");
+  const binDir = path.join(rootDir, "node_modules", ".bin");
+
+  return {
+    rootDir,
+    effectTsgoBin: path.join(binDir, "effect-tsgo"),
+  };
+});
+
+const runCommand = Effect.fn("runCommand")(function* (
+  cwd: string,
+  command: string,
+  args: ReadonlyArray<string>,
+) {
+  const formatted = [command, ...args].join(" ");
+  const result = yield* Effect.tryPromise({
+    try: async () => {
+      const child = Bun.spawn([command, ...args], {
+        cwd,
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]);
+      return { exitCode, output: (stderr.trim() || stdout.trim()).trim() };
+    },
+    catch: (cause) => new CommandSpawnError({ command: formatted, reason: formatUnknown(cause) }),
+  });
+
+  if (result.exitCode !== 0) {
+    return yield* new CommandError({
+      command: formatted,
+      exitCode: result.exitCode,
+      output: result.output,
+    });
+  }
+
+  return result.output;
+});
+
+const runStep = Effect.fn("runStep")(function* (
+  progress: ReturnType<typeof startProgressBoard>,
+  index: number,
+  rootDir: string,
+  label: string,
+  command: string,
+  args: ReadonlyArray<string>,
+) {
+  const startedAt = yield* Clock.currentTimeMillis;
+  const result = yield* Effect.result(runCommand(rootDir, command, args));
+  const finishedAt = yield* Clock.currentTimeMillis;
+  const timing = formatTiming(finishedAt - startedAt);
+
+  if (result._tag === "Failure") {
+    const reason = formatUnknown(result.failure);
+    progress.setStatus(index, { kind: "fail", timing, reason });
+    return yield* Result.fail(result.failure);
+  }
+
+  progress.setStatus(index, { kind: "ok", timing, summary: label });
+});
+
+const patchTsgo = Effect.gen(function* () {
+  const paths = yield* resolvePaths();
+  const progress = startProgressBoard(["Effect tsgo patch"]);
+
+  yield* Effect.acquireUseRelease(
+    Effect.succeed(progress),
+    (board) =>
+      Effect.gen(function* () {
+        board.setRunningNote(0, "patching tsgo binary");
+        yield* runStep(board, 0, paths.rootDir, "patched", paths.effectTsgoBin, ["patch"]);
+      }),
+    (board) => Effect.sync(() => board.stop()),
+  );
+});
+
+const patchCommand = Command.make("patch-tsgo", {}, () => patchTsgo).pipe(
+  Command.withDescription("Patch tsgo for Effect projects."),
+);
+
+const program = Command.run(patchCommand, { version: "1.0.0" }).pipe(
+  Effect.provide(BunServices.layer),
+);
+
+BunRuntime.runMain(program, { disableErrorReporting: true });

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env bun
+
+import { BunRuntime, BunServices } from "@effect/platform-bun";
+import { Clock, Effect, Inspectable, Path, Result, Schema as S } from "effect";
+import { Command } from "effect/unstable/cli";
+
+import { formatTiming, startProgressBoard } from "./utils/step-progress.ts";
+
+class CommandError extends S.TaggedErrorClass<CommandError>()("CommandError", {
+  command: S.String,
+  exitCode: S.Int,
+  output: S.String,
+}) {
+  override get message() {
+    return this.output.length > 0
+      ? `${this.command} exited with code ${this.exitCode}: ${this.output}`
+      : `${this.command} exited with code ${this.exitCode}`;
+  }
+}
+
+class CommandSpawnError extends S.TaggedErrorClass<CommandSpawnError>()("CommandSpawnError", {
+  command: S.String,
+  reason: S.String,
+}) {
+  override get message() {
+    return `failed to spawn ${this.command}: ${this.reason}`;
+  }
+}
+
+const formatUnknown = (value: unknown): string =>
+  value instanceof Error ? value.message : Inspectable.toStringUnknown(value);
+
+const resolvePaths = Effect.fn("resolvePaths")(function* () {
+  const path = yield* Path.Path;
+  const scriptPath = yield* path.fromFileUrl(new URL(import.meta.url));
+  const rootDir = path.resolve(path.dirname(scriptPath), "..");
+  const binDir = path.join(rootDir, "node_modules", ".bin");
+
+  return {
+    rootDir,
+    effectTsgoBin: path.join(binDir, "effect-tsgo"),
+    syncEffectScript: path.join(rootDir, "scripts", "sync-effect-submodule.ts"),
+    vpBin: path.join(binDir, "vp"),
+  };
+});
+
+const runCommand = Effect.fn("runCommand")(function* (
+  cwd: string,
+  command: string,
+  args: ReadonlyArray<string>,
+) {
+  const formatted = [command, ...args].join(" ");
+  const result = yield* Effect.tryPromise({
+    try: async () => {
+      const child = Bun.spawn([command, ...args], {
+        cwd,
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]);
+      return { exitCode, output: (stderr.trim() || stdout.trim()).trim() };
+    },
+    catch: (cause) => new CommandSpawnError({ command: formatted, reason: formatUnknown(cause) }),
+  });
+
+  if (result.exitCode !== 0) {
+    return yield* new CommandError({
+      command: formatted,
+      exitCode: result.exitCode,
+      output: result.output,
+    });
+  }
+
+  return result.output;
+});
+
+const runStep = Effect.fn("runStep")(function* (
+  progress: ReturnType<typeof startProgressBoard>,
+  index: number,
+  rootDir: string,
+  label: string,
+  command: string,
+  args: ReadonlyArray<string>,
+) {
+  const startedAt = yield* Clock.currentTimeMillis;
+  const result = yield* Effect.result(runCommand(rootDir, command, args));
+  const finishedAt = yield* Clock.currentTimeMillis;
+  const timing = formatTiming(finishedAt - startedAt);
+
+  if (result._tag === "Failure") {
+    const reason = formatUnknown(result.failure);
+    progress.setStatus(index, { kind: "fail", timing, reason });
+    return yield* Result.fail(result.failure);
+  }
+
+  progress.setStatus(index, { kind: "ok", timing, summary: label });
+});
+
+const postinstall = Effect.gen(function* () {
+  const paths = yield* resolvePaths();
+  const progress = startProgressBoard(["Effect submodule", "Vite+ config", "Effect tsgo patch"]);
+
+  yield* Effect.acquireUseRelease(
+    Effect.succeed(progress),
+    (board) =>
+      Effect.gen(function* () {
+        board.setRunningNote(0, "syncing effect-smol");
+        yield* runStep(board, 0, paths.rootDir, "synced", "bun", [paths.syncEffectScript]);
+
+        board.setRunningNote(1, "configuring hooks and agent docs");
+        yield* runStep(board, 1, paths.rootDir, "configured", paths.vpBin, ["config"]);
+
+        board.setRunningNote(2, "patching tsgo binary");
+        yield* runStep(board, 2, paths.rootDir, "patched", paths.effectTsgoBin, ["patch"]);
+      }),
+    (board) => Effect.sync(() => board.stop()),
+  );
+});
+
+const postinstallCommand = Command.make("postinstall", {}, () => postinstall).pipe(
+  Command.withDescription("Run repository postinstall setup."),
+);
+
+const program = Command.run(postinstallCommand, { version: "1.0.0" }).pipe(
+  Effect.provide(BunServices.layer),
+);
+
+BunRuntime.runMain(program, { disableErrorReporting: true });

--- a/scripts/sync-effect-submodule.ts
+++ b/scripts/sync-effect-submodule.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env bun
+
+import { BunRuntime, BunServices } from "@effect/platform-bun";
+import { Clock, Effect, Inspectable, Path, Result, Schema as S } from "effect";
+import { Command } from "effect/unstable/cli";
+
+import { formatTiming, startProgressBoard } from "./utils/step-progress.ts";
+
+const SUBMODULE_PATH = "repos/effect-smol";
+const SENTINEL_PATH = `${SUBMODULE_PATH}/packages/effect/package.json`;
+
+type RootPackageJson = {
+  catalog?: Record<string, string>;
+  workspaces?: {
+    catalog?: Record<string, string>;
+  };
+};
+
+class GitCommandError extends S.TaggedErrorClass<GitCommandError>()("GitCommandError", {
+  command: S.String,
+  exitCode: S.Int,
+  output: S.String,
+}) {
+  override get message() {
+    return this.output.length > 0
+      ? `${this.command} exited with code ${this.exitCode}: ${this.output}`
+      : `${this.command} exited with code ${this.exitCode}`;
+  }
+}
+
+class GitSpawnError extends S.TaggedErrorClass<GitSpawnError>()("GitSpawnError", {
+  command: S.String,
+  reason: S.String,
+}) {
+  override get message() {
+    return `failed to spawn ${this.command}: ${this.reason}`;
+  }
+}
+
+class CatalogMissingPackageError extends S.TaggedErrorClass<CatalogMissingPackageError>()(
+  "CatalogMissingPackageError",
+  {
+    packageName: S.String,
+  },
+) {
+  override get message() {
+    return `package "${this.packageName}" missing from root catalog`;
+  }
+}
+
+class SubmoduleSentinelMissingError extends S.TaggedErrorClass<SubmoduleSentinelMissingError>()(
+  "SubmoduleSentinelMissingError",
+  {
+    sentinel: S.String,
+  },
+) {
+  override get message() {
+    return `expected ${this.sentinel} after submodule init`;
+  }
+}
+
+const formatUnknown = (value: unknown): string =>
+  value instanceof Error ? value.message : Inspectable.toStringUnknown(value);
+
+const resolveDirs = Effect.fn("resolveDirs")(function* () {
+  const path = yield* Path.Path;
+  const scriptPath = yield* path.fromFileUrl(new URL(import.meta.url));
+  const rootDir = path.resolve(path.dirname(scriptPath), "..");
+
+  return {
+    rootDir,
+    submoduleDir: path.resolve(rootDir, SUBMODULE_PATH),
+    sentinel: path.resolve(rootDir, SENTINEL_PATH),
+  };
+});
+
+const runGit = Effect.fn("runGit")(function* (cwd: string, args: ReadonlyArray<string>) {
+  const command = ["git", ...args].join(" ");
+
+  const result = yield* Effect.tryPromise({
+    try: async () => {
+      const child = Bun.spawn(["git", ...args], {
+        cwd,
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]);
+
+      return { exitCode, output: (stderr.trim() || stdout.trim()).trim(), stdout: stdout.trim() };
+    },
+    catch: (cause) => new GitSpawnError({ command, reason: formatUnknown(cause) }),
+  });
+
+  if (result.exitCode !== 0) {
+    return yield* new GitCommandError({
+      command,
+      exitCode: result.exitCode,
+      output: result.output,
+    });
+  }
+
+  return result.stdout;
+});
+
+const fileExists = (path: string) =>
+  Effect.tryPromise({
+    try: () => Bun.file(path).exists(),
+    catch: (cause) => new Error(formatUnknown(cause)),
+  });
+
+const readEffectVersion = Effect.fn("readEffectVersion")(function* (rootDir: string) {
+  const path = yield* Path.Path;
+  const packageJson = yield* Effect.tryPromise({
+    try: () => Bun.file(path.resolve(rootDir, "package.json")).json() as Promise<RootPackageJson>,
+    catch: (cause) => new Error(formatUnknown(cause)),
+  });
+  const version = packageJson.catalog?.effect ?? packageJson.workspaces?.catalog?.effect;
+
+  if (!version) {
+    return yield* new CatalogMissingPackageError({ packageName: "effect" });
+  }
+
+  return version;
+});
+
+const ensureSubmoduleInitialized = Effect.fn("ensureSubmoduleInitialized")(function* (
+  rootDir: string,
+  sentinel: string,
+) {
+  if (yield* fileExists(sentinel)) {
+    return;
+  }
+
+  yield* runGit(rootDir, ["submodule", "sync", "--", SUBMODULE_PATH]);
+  yield* runGit(rootDir, [
+    "submodule",
+    "update",
+    "--init",
+    "--checkout",
+    "--depth",
+    "1",
+    "--",
+    SUBMODULE_PATH,
+  ]);
+
+  if (!(yield* fileExists(sentinel))) {
+    return yield* new SubmoduleSentinelMissingError({ sentinel: SENTINEL_PATH });
+  }
+});
+
+const syncEffectSubmodule = Effect.gen(function* () {
+  const progress = startProgressBoard(["Effect submodule"]);
+
+  yield* Effect.acquireUseRelease(
+    Effect.succeed(progress),
+    (board) =>
+      Effect.gen(function* () {
+        const startedAt = yield* Clock.currentTimeMillis;
+
+        if (process.env.CI === "true") {
+          const finishedAt = yield* Clock.currentTimeMillis;
+          board.setStatus(0, {
+            kind: "skip",
+            timing: formatTiming(finishedAt - startedAt),
+            reason: "CI=true; agent docs are not used in CI",
+          });
+          return;
+        }
+
+        const result = yield* Effect.result(
+          Effect.gen(function* () {
+            board.setRunningNote(0, "reading package catalog");
+            const { rootDir, submoduleDir, sentinel } = yield* resolveDirs();
+            const version = yield* readEffectVersion(rootDir);
+            const tag = `effect@${version}`;
+
+            board.setRunningNote(0, `initializing ${SUBMODULE_PATH}`);
+            yield* ensureSubmoduleInitialized(rootDir, sentinel);
+
+            board.setRunningNote(0, `fetching ${tag}`);
+            yield* runGit(submoduleDir, [
+              "fetch",
+              "--depth",
+              "1",
+              "--force",
+              "--quiet",
+              "origin",
+              `refs/tags/${tag}:refs/tags/${tag}`,
+            ]);
+
+            board.setRunningNote(0, `resolving ${tag}`);
+            const target = yield* runGit(submoduleDir, [
+              "rev-parse",
+              "-q",
+              "--verify",
+              `${tag}^{commit}`,
+            ]);
+            const current = yield* runGit(submoduleDir, ["rev-parse", "HEAD"]);
+            const shortTarget = target.slice(0, 12);
+
+            if (current !== target) {
+              board.setRunningNote(0, `checking out ${shortTarget}`);
+              yield* runGit(submoduleDir, ["checkout", "--detach", target]);
+              return `${tag} -> ${shortTarget}`;
+            }
+
+            return `${tag} already current`;
+          }),
+        );
+        const finishedAt = yield* Clock.currentTimeMillis;
+        const timing = formatTiming(finishedAt - startedAt);
+
+        if (result._tag === "Failure") {
+          const reason = formatUnknown(result.failure);
+          board.setStatus(0, { kind: "fail", timing, reason });
+          return yield* Result.fail(result.failure);
+        }
+
+        board.setStatus(0, { kind: "ok", timing, summary: result.success });
+      }),
+    (board) => Effect.sync(() => board.stop()),
+  );
+});
+
+const syncCommand = Command.make("sync-effect-submodule", {}, () => syncEffectSubmodule).pipe(
+  Command.withDescription("Sync repos/effect-smol to the root catalog's effect version."),
+);
+
+const program = Command.run(syncCommand, { version: "1.0.0" }).pipe(
+  Effect.provide(BunServices.layer),
+);
+
+BunRuntime.runMain(program, { disableErrorReporting: true });

--- a/scripts/utils/step-progress.ts
+++ b/scripts/utils/step-progress.ts
@@ -1,0 +1,105 @@
+const STATUS_STREAM = process.stderr;
+
+export const IS_TTY = STATUS_STREAM.isTTY === true;
+
+export const GREEN = IS_TTY ? "\x1b[32m" : "";
+export const RED = IS_TTY ? "\x1b[31m" : "";
+export const YELLOW = IS_TTY ? "\x1b[33m" : "";
+export const DIM = IS_TTY ? "\x1b[90m" : "";
+export const RESET = IS_TTY ? "\x1b[0m" : "";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+const FRAME_INTERVAL_MS = 80;
+
+export type StepStatus =
+  | { readonly kind: "running"; readonly note?: string }
+  | { readonly kind: "ok"; readonly timing: string; readonly summary?: string }
+  | { readonly kind: "fail"; readonly timing: string; readonly reason: string }
+  | { readonly kind: "skip"; readonly timing: string; readonly reason: string };
+
+export interface ProgressBoard {
+  readonly setStatus: (index: number, status: StepStatus) => void;
+  readonly setRunningNote: (index: number, note: string | undefined) => void;
+  readonly stop: () => void;
+}
+
+export function formatTiming(elapsedMs: number): string {
+  const seconds = elapsedMs / 1000;
+  const value = seconds >= 10 ? seconds.toFixed(0) : seconds.toFixed(2);
+  return `${DIM}[${value}s]${RESET}`;
+}
+
+function renderRow(label: string, status: StepStatus, frame: number): string {
+  switch (status.kind) {
+    case "running": {
+      const spinner = SPINNER_FRAMES[frame % SPINNER_FRAMES.length];
+      const tail = status.note ? ` ${DIM}${status.note}${RESET}` : "";
+      return `${DIM}${spinner}${RESET} ${label}${tail}`;
+    }
+    case "ok": {
+      const tail = status.summary ? ` ${DIM}- ${status.summary}${RESET}` : "";
+      return `${GREEN}✓${RESET} ${label}${tail} ${status.timing}`;
+    }
+    case "fail":
+      return `${RED}✗${RESET} ${label} failed ${status.timing}`;
+    case "skip":
+      return `${YELLOW}!${RESET} ${label} skipped ${status.timing}`;
+  }
+}
+
+export function startProgressBoard(labels: ReadonlyArray<string>): ProgressBoard {
+  const statuses: Array<StepStatus> = labels.map(() => ({ kind: "running" }));
+  let frame = 0;
+
+  if (IS_TTY) {
+    for (let i = 0; i < labels.length; i += 1) {
+      STATUS_STREAM.write(`${renderRow(labels[i]!, statuses[i]!, 0)}\n`);
+    }
+  }
+
+  const repaint = () => {
+    if (!IS_TTY) return;
+    STATUS_STREAM.write(`\x1b[${labels.length}A`);
+    for (let i = 0; i < labels.length; i += 1) {
+      STATUS_STREAM.write(`\r\x1b[2K${renderRow(labels[i]!, statuses[i]!, frame)}\n`);
+    }
+  };
+
+  const timer: ReturnType<typeof setInterval> | null = IS_TTY
+    ? setInterval(() => {
+        frame += 1;
+        repaint();
+      }, FRAME_INTERVAL_MS)
+    : null;
+
+  return {
+    setStatus(index, status) {
+      statuses[index] = status;
+      if (IS_TTY) {
+        repaint();
+        return;
+      }
+      if (status.kind !== "running") {
+        STATUS_STREAM.write(`${renderRow(labels[index]!, status, 0)}\n`);
+      }
+    },
+    setRunningNote(index, note) {
+      const current = statuses[index];
+      if (!current || current.kind !== "running") return;
+      statuses[index] = { kind: "running", note };
+      if (IS_TTY) repaint();
+    },
+    stop() {
+      if (timer) clearInterval(timer);
+      if (IS_TTY) repaint();
+      for (let i = 0; i < statuses.length; i += 1) {
+        const status = statuses[i]!;
+        if (status.kind === "fail") {
+          STATUS_STREAM.write(`${RED}error${RESET} (${labels[i]}): ${status.reason}\n`);
+        } else if (status.kind === "skip") {
+          STATUS_STREAM.write(`${YELLOW}reason${RESET} (${labels[i]}): ${status.reason}\n`);
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add `repos/effect-smol` as a shallow reference submodule synced to the root Effect catalog version.
- Add install-time setup with pretty progress output for Effect source sync, Vite+ config, and Effect tsgo patching.
- Document that `repos/effect-smol` is reference-only and should not be edited.

## Validation

- `vp install`
- `vp check`
- `vp test`