### PR TITLE
feat(durable-object): add initialize hook

### DIFF
--- a/.changeset/durable-object-initialize.md
+++ b/.changeset/durable-object-initialize.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add a Durable Object `initialize` hook for running Effect setup each time Cloudflare loads a Durable Object instance into memory.

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -240,6 +240,25 @@ In definition-backed workflows, the `payload` argument is the typed decoded payl
 
 ## Durable Object WebSockets
 
+Use `initialize` for work that should run each time Cloudflare loads a Durable
+Object instance into memory. Yield `state.blockConcurrencyWhile(...)` when
+later events should wait for initialize to finish. If work should happen only once
+for a Durable Object id, store a sentinel in Durable Object storage.
+
+```ts
+export const RoomLive = DurableObject.make(layer, {
+  initialize: Effect.gen(function* () {
+    const state = yield* DurableObjectState.DurableObjectState;
+    yield* state.blockConcurrencyWhile(
+      Effect.gen(function* () {
+        yield* state.storage.put("loadedAt", Date.now());
+      }),
+    );
+  }),
+  fetch,
+});
+```
+
 Durable Object application sockets should use the hibernation-compatible state API. Accept sockets with `DurableObjectWebSocket.acceptUpgrade(...)`; do not call `server.accept()` or attach native `message` listeners in application code.
 
 ```ts

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -73,6 +73,15 @@ export type RpcHandlers<ROut, Api> = {
  * Options for creating a Durable Object class backed by Effect handlers.
  */
 export interface DurableObjectOptions<ROut, Rpc extends DurableObjectRpc<ROut>> {
+  /**
+   * Effect run when Cloudflare loads this Durable Object instance into memory.
+   *
+   * Use `DurableObjectState.blockConcurrencyWhile` inside this hook when
+   * incoming events should wait for setup to finish. Cloudflare may construct
+   * the same Durable Object id again after eviction or restart; use Durable
+   * Object storage if work must happen only once per id.
+   */
+  readonly initialize?: Effect.Effect<void, unknown, HandlerContext<ROut>>;
   /** Optional RPC methods exposed as Durable Object instance methods. */
   readonly rpc?: Rpc;
   /** Optional fetch handler for HTTP/WebSocket requests. */
@@ -137,6 +146,11 @@ export const make = <
       const runtimeLayer = Entrypoint.provideEntrypointServices(layer, services);
 
       this.runtime = ManagedRuntime.make(runtimeLayer);
+
+      const initialize = options.initialize;
+      if (initialize !== undefined) {
+        state.waitUntil(this[RunSymbol](initialize));
+      }
     }
 
     [RunSymbol]<A, E>(effect: Effect.Effect<A, E, HandlerContext<ROut>>): Promise<A> {

--- a/packages/effect-cf/tests/index.test.ts
+++ b/packages/effect-cf/tests/index.test.ts
@@ -150,6 +150,47 @@ test("rejects direct Durable Object RPC method names reserved by Cloudflare", ()
   ).toThrow(/reserved by Cloudflare Workers RPC/);
 });
 
+test("Durable Object initialize runs when the instance is constructed", async () => {
+  const calls: Array<string> = [];
+  let initialize: Promise<unknown> | undefined;
+  const state = {
+    id: durableObjectId,
+    storage: {} as globalThis.DurableObjectStorage,
+    waitUntil: (promise: Promise<unknown>) => {
+      initialize = promise;
+    },
+    blockConcurrencyWhile: (callback: () => Promise<unknown>) => {
+      calls.push("block");
+      return callback();
+    },
+    acceptWebSocket() {},
+    getWebSockets: () => [],
+    setWebSocketAutoResponse() {},
+    getWebSocketAutoResponse: () => null,
+    getWebSocketAutoResponseTimestamp: () => null,
+    setHibernatableWebSocketEventTimeout() {},
+    getHibernatableWebSocketEventTimeout: () => null,
+    getTags: () => [],
+    abort() {},
+  } as unknown as globalThis.DurableObjectState;
+
+  const Live = DurableObject.make(Layer.empty, {
+    initialize: Effect.gen(function* () {
+      const state = yield* DurableObjectState.DurableObjectState;
+      yield* state.blockConcurrencyWhile(
+        Effect.sync(() => {
+          calls.push(`initialize:${state.id.toString()}`);
+        }),
+      );
+    }),
+  });
+
+  new Live(state, {} as Cloudflare.Env);
+
+  await initialize;
+  expect(calls).toEqual(["block", "initialize:counter-id"]);
+});
+
 test("RPC-only Workers return a default 404 fetch response", async () => {
   const WorkerClass = Worker.make(Layer.empty, {
     rpc: {
@@ -277,6 +318,9 @@ test("DurableObject preserves server, client, handler, and namespace types", () 
     );
 
     DurableObject.make(Layer.empty, {
+      initialize: Effect.gen(function* () {
+        yield* DurableObjectState.DurableObjectState;
+      }),
       webSocketMessage: (socket, message) => {
         expectType<DurableObjectWebSocket.DurableWebSocket>(socket);
         expectType<string | ArrayBuffer>(message);


### PR DESCRIPTION
## Summary

- Add an `initialize` option to `DurableObject.make` for work that should run each time a Durable Object instance is loaded into memory.
- Register initialize work with Durable Object `waitUntil`, and document yielding `state.blockConcurrencyWhile(...)` when initialization should hold later events.
- Document the initialize hook and cover constructor-time execution in tests.

## Validation

- `vp check`
- `vp test`