### PR TITLE
fix: support local queue producer bindings

### DIFF
--- a/.changeset/quiet-queues.md
+++ b/.changeset/quiet-queues.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": patch
+---
+
+Accept local queue producer bindings that only expose `send`, including Wrangler local dev bindings. Binding validation errors now include the binding name, expected shape, and actual resource shape in pretty output across Cloudflare bindings.

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "effect": "catalog:",
         "vite-plus": "catalog:",
         "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.20",
-        "wrangler": "^4.84.1",
+        "wrangler": "^4.93.1",
       },
     },
     "examples/chat/durable-objects/chat-room": {
@@ -305,7 +305,7 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.7.0",
+      "version": "0.9.1",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.15.0",
         "@cloudflare/workers-types": "^4.20260421.1",
@@ -382,21 +382,21 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
-    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
-    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg=="],
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
     "@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.16.3", "", { "dependencies": { "cjs-module-lexer": "^1.2.3", "esbuild": "0.27.3", "miniflare": "4.20260507.1", "wrangler": "4.90.0", "zod": "^3.25.76" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-cnxtKBWoP5uhO78Z9zlCexj7oIs6zYoIH4GCEFS0Z6bepFDdnxtuMGxmWaDg84cy9teoh5CLA/OEN6XLSKcnWA=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260421.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-DLU5ZTZ1VHeZZnj0PuVJEMHKGisfLe2XShyImP5P/PPj/m/t7CLEJmPiI7FMxvT7ynArkckJl7m+Z5x7u4Kkdw=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260520.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-7ilR8QUWpFO2RdulPuYkrwRYZxi7iuX8+11G9z97bdS7wCSFuetBsgsr2ISK7l/qzCiG5zshnfIwcdlYWD01Ag=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260421.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Trotq3xRAkIcpC505WoxM8+kIH4JIvOJCNuRatyHcz9uF5S+ukgiVUFUlM+GIjw1uCM/Bda2St+vSniX1RZdpw=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260520.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6LVIEI0Tx3hfcXiEM+eHsIQVsOz1IAAoAMMsRlrx+7YaNiuHMib7yWfyzAlZPhiAg1BgiS5oB8iDn7Ws1amG+Q=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260421.1", "", { "os": "linux", "cpu": "x64" }, "sha512-938QjUv0z+QqK6BAvgwX/lCIZ2b224ZXoXtGTbhyNVMhB+mt4Dj24cj9qca4ekNXjVM7uTKp1yOHZO97fVSacw=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260520.1", "", { "os": "linux", "cpu": "x64" }, "sha512-7oV9YK7o63aiHnpBeKlxOIA3nK4sKxuwhnklCwJFb0LirkSemSG1LQlVvtVInoWSYDCTCoUeGkiPsS8WsZqcEw=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260421.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-YI4+mLfwnJcKJ+iPyxzx+tp2Jy4o29BxBPSQGZxl/AZyvZ9eTKsmNZmtjEiT4i3O/M0tdO/B/d9ESDHbRCs2rQ=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260520.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-hzc/UKzw1/z+iTptBZVX7XYZTmJXsgn6RC9uKtQGUQxENxkoO1teba8qxVlKZT0AbPCQs5rg63Lsk0/eQhteqQ=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260421.1", "", { "os": "win32", "cpu": "x64" }, "sha512-q1SFgwlNH9lFmw74vh7EJbJtduo92Nx51mNOfd3/u6pux6AldcwRviYzKEEv3FEbtv6OBB7J8D5f8vtZj7Z6Sg=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260520.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BjMBhXqlEPaVc68tXihFI+YcU/5T4Jmj4ELDJaEa6NuCcbUMORESgO4OJZIDS4+rC2Lkv37telOktQxEOkqY3g=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260423.1", "", {}, "sha512-SHIc0NeJMtn0sW043eWtMxYFbJ9VPSLkcx+FEqCk0uZLD3HrWT+5xWhm6EYiOYDg0vnrlXNHcu2ly/01zDh3bw=="],
 
@@ -1108,9 +1108,9 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "workerd": ["workerd@1.20260421.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260421.1", "@cloudflare/workerd-darwin-arm64": "1.20260421.1", "@cloudflare/workerd-linux-64": "1.20260421.1", "@cloudflare/workerd-linux-arm64": "1.20260421.1", "@cloudflare/workerd-windows-64": "1.20260421.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-zTYD+xFR4d7TUCxsyl7FTPth9a8CDgk8pM7xUWbJxo0SGUx+2e5C7Q5LrramBZwmuAErtzXmOjlQ15PtkPAhZA=="],
+    "workerd": ["workerd@1.20260520.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260520.1", "@cloudflare/workerd-darwin-arm64": "1.20260520.1", "@cloudflare/workerd-linux-64": "1.20260520.1", "@cloudflare/workerd-linux-arm64": "1.20260520.1", "@cloudflare/workerd-windows-64": "1.20260520.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-mwW6H/NEKObeBVd0qkq91EGyOIC3TaNJBxp7kj5uChif/+qYD7nM5HE8ZYruwvEd15pRwUet+V8r21DCXCGDQQ=="],
 
-    "wrangler": ["wrangler@4.84.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260421.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260421.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260421.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-Xe1S/Bik7pNdtdJ+asHsEZC2dX9k3WxYn2BbxFtOrrLVxN/LKi750zsrjX41jSAk00M/O1l7jzyQV4sQqw8ftg=="],
+    "wrangler": ["wrangler@4.93.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260520.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260520.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260520.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-vV2GyKNWORysoJtryo45N2Tkk8wCnt/MTyW7wsevAAY+MiUArfJGvMiCb6SRB7pV5uWvEyIly1/rslehEjV32g=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
@@ -1148,11 +1148,7 @@
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
-    "wrangler/miniflare": ["miniflare@4.20260421.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260421.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-7ZkNQ7brgQ2hh5ha9iQCDUjxBkLvuiG2VdDns9esRL8O8lXg+MoP6E0dO1rtp+ZY2I+vV1tPWr6td5IojkewLw=="],
-
-    "@cloudflare/vitest-pool-workers/wrangler/@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
-
-    "@cloudflare/vitest-pool-workers/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+    "wrangler/miniflare": ["miniflare@4.20260520.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260520.1", "ws": "8.20.1", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-krgebvYME9k7CjxiveTzx89kAMeIstfK3KfTqtzLb/4mtLMD74KHtU009h/I0CTDSVIYtXm0JzJ40OtiVRGmOA=="],
 
     "@cloudflare/vitest-pool-workers/wrangler/workerd": ["workerd@1.20260507.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260507.1", "@cloudflare/workerd-darwin-arm64": "1.20260507.1", "@cloudflare/workerd-linux-64": "1.20260507.1", "@cloudflare/workerd-linux-arm64": "1.20260507.1", "@cloudflare/workerd-windows-64": "1.20260507.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-z7JhsFSe6+X1b5fUHaVpo15VM1IRMJiLofEkq8iKdCo+Veqc+FUg5lIsuz8NwePxuSKrXtO4ZQpGkQLbPVXFhg=="],
 
@@ -1180,7 +1176,7 @@
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
-    "wrangler/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "wrangler/miniflare/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260507.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-S85aMwcaPJUjKWDiG6iMMnioKWtPLACa6m0j/EhHR1GYfVpnxb974cBc6d25L+sf7jHWHJI2u5hGp0UTJ7MtXQ=="],
 
@@ -1196,7 +1192,7 @@
 
     "effect-cf/@cloudflare/vitest-pool-workers/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
-    "effect-cf/@cloudflare/vitest-pool-workers/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+    "effect-cf/@cloudflare/vitest-pool-workers/wrangler/@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
 
     "effect-cf/@cloudflare/vitest-pool-workers/wrangler/workerd": ["workerd@1.20260424.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260424.1", "@cloudflare/workerd-darwin-arm64": "1.20260424.1", "@cloudflare/workerd-linux-64": "1.20260424.1", "@cloudflare/workerd-linux-arm64": "1.20260424.1", "@cloudflare/workerd-windows-64": "1.20260424.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "effect": "catalog:",
     "vite-plus": "catalog:",
     "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.20",
-    "wrangler": "^4.84.1"
+    "wrangler": "^4.93.1"
   },
   "overrides": {
     "@effect/platform-node-shared": "4.0.0-beta.65",

--- a/packages/effect-cf/src/Binding.ts
+++ b/packages/effect-cf/src/Binding.ts
@@ -9,34 +9,150 @@ export const TypeId = "effect-cf/Binding" as const;
 /** Error raised when a configured binding does not exist on `env`. */
 export class BindingNotFoundError extends Data.TaggedError("BindingNotFoundError")<{
   readonly binding: string;
+  readonly message: string;
 }> {}
 
 /** Error raised when a binding exists but does not match the expected shape. */
 export class BindingValidationError extends Data.TaggedError("BindingValidationError")<{
   readonly binding: string;
+  readonly expected: string;
+  readonly actual: string;
+  readonly message: string;
 }> {}
+
+export interface ValidationOptions {
+  readonly expected?: string;
+}
+
+const defaultExpected = "Cloudflare binding resource";
 
 const isPropertyTarget = (value: unknown): value is object =>
   (typeof value === "object" || typeof value === "function") && value !== null;
+
+const getObjectName = (value: object | Function): string => {
+  const tag = (() => {
+    try {
+      return Object.prototype.toString.call(value).slice("[object ".length, -1);
+    } catch {
+      return typeof value;
+    }
+  })();
+  const constructorName = (() => {
+    try {
+      return "constructor" in value &&
+        typeof value.constructor === "function" &&
+        typeof value.constructor.name === "string"
+        ? value.constructor.name
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  })();
+
+  if (tag !== "Object") {
+    return tag;
+  }
+
+  if (constructorName !== undefined && constructorName !== "" && constructorName !== "Object") {
+    return constructorName;
+  }
+
+  return tag;
+};
+
+const propertyNames = (value: object | Function): ReadonlyArray<string> => {
+  const names = new Set<string>();
+
+  for (const target of [value, Object.getPrototypeOf(value)] as const) {
+    if (target === null || target === Object.prototype || target === Function.prototype) {
+      continue;
+    }
+
+    try {
+      for (const name of Object.getOwnPropertyNames(target)) {
+        names.add(name);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return [...names].filter((name) => name !== "constructor").sort();
+};
+
+const isMethod = (value: object | Function, name: string): boolean => {
+  try {
+    return typeof Reflect.get(value, name) === "function";
+  } catch {
+    return false;
+  }
+};
+
+const describeActual = (value: unknown): string => {
+  if (value === null) {
+    return "null";
+  }
+
+  if (typeof value !== "object" && typeof value !== "function") {
+    return typeof value;
+  }
+
+  const names = propertyNames(value);
+  const methods = names.filter((name) => isMethod(value, name));
+  const properties = names.filter((name) => !methods.includes(name));
+  const details = [
+    methods.length > 0 ? `methods ${methods.join(", ")}` : undefined,
+    properties.length > 0 ? `properties ${properties.join(", ")}` : undefined,
+  ].filter((detail) => detail !== undefined);
+
+  if (details.length === 0) {
+    return getObjectName(value);
+  }
+
+  return `${getObjectName(value)} with ${details.join("; ")}`;
+};
 
 const getBinding = <Resource>(
   env: WorkerEnv,
   binding: string,
   isResource: (value: unknown) => value is Resource,
+  options?: ValidationOptions,
 ): Effect.Effect<Resource, BindingNotFoundError | BindingValidationError> =>
   Effect.gen(function* () {
     if (!isPropertyTarget(env)) {
-      return yield* Effect.fail(new BindingValidationError({ binding }));
+      const actual = describeActual(env);
+      return yield* Effect.fail(
+        new BindingValidationError({
+          binding,
+          expected: "WorkerEnvironment object",
+          actual,
+          message: `Cloudflare binding "${binding}" failed validation. Expected WorkerEnvironment object; got ${actual}`,
+        }),
+      );
     }
 
     const resource = Reflect.get(env, binding);
 
     if (resource === undefined) {
-      return yield* Effect.fail(new BindingNotFoundError({ binding }));
+      return yield* Effect.fail(
+        new BindingNotFoundError({
+          binding,
+          message: `Cloudflare binding "${binding}" was not found in WorkerEnvironment`,
+        }),
+      );
     }
 
     if (!isResource(resource)) {
-      return yield* Effect.fail(new BindingValidationError({ binding }));
+      const expected = options?.expected ?? defaultExpected;
+      const actual = describeActual(resource);
+      return yield* Effect.fail(
+        new BindingValidationError({
+          binding,
+          expected,
+          actual,
+          message: `Cloudflare binding "${binding}" failed validation. Expected ${expected}; got ${actual}`,
+        }),
+      );
     }
 
     return resource;
@@ -64,12 +180,13 @@ export const layer = <Self, Resource, Service = Resource>(
   binding: string,
   isResource: (value: unknown) => value is Resource,
   wrap?: (resource: Resource) => Service,
+  options?: ValidationOptions,
 ): Layer.Layer<Self, BindingNotFoundError | BindingValidationError, WorkerEnvironment> =>
   Layer.effect(
     tag,
     Effect.gen(function* () {
       const env = yield* WorkerEnvironment;
-      const resource = yield* getBinding(env, binding, isResource);
+      const resource = yield* getBinding(env, binding, isResource, options);
       return wrap === undefined ? (resource as unknown as Service) : wrap(resource);
     }),
   );
@@ -81,9 +198,10 @@ export const Service =
     binding: string,
     isResource: (value: unknown) => value is Resource,
     wrap?: (resource: Resource) => Service,
+    options?: ValidationOptions,
   ): BindingService<Self, Id, Service> => {
     const tag = Context.Service<Self, Service>()(id);
-    const serviceLayer = layer(tag, binding, isResource, wrap);
+    const serviceLayer = layer(tag, binding, isResource, wrap, options);
 
     return Object.assign(tag, {
       [TypeId]: TypeId,

--- a/packages/effect-cf/src/D1.ts
+++ b/packages/effect-cf/src/D1.ts
@@ -4,6 +4,7 @@ import { Effect, Layer } from "effect";
 import * as Binding from "./Binding";
 
 const TypeId = "effect-cf/D1" as const;
+const expectedD1Database = "D1 database binding with prepare(), batch(), and exec()";
 
 /** Typed D1 binding definition. */
 export interface D1Definition {
@@ -61,7 +62,9 @@ export const make = <Id extends string>(id: Id, definition: D1Definition) =>
 export const Service =
   <Self>() =>
   <Id extends string>(id: Id, definition: D1Definition) => {
-    const tag = Binding.Service<Self>()(id, definition.binding, isD1Database);
+    const tag = Binding.Service<Self>()(id, definition.binding, isD1Database, undefined, {
+      expected: expectedD1Database,
+    });
 
     const sqlLayer = (options?: D1SqlLayerOptions) =>
       Layer.unwrap(

--- a/packages/effect-cf/src/DurableObjectNamespace.ts
+++ b/packages/effect-cf/src/DurableObjectNamespace.ts
@@ -6,6 +6,9 @@ import type * as DurableObjectDefinition from "./DurableObjectDefinition";
 import * as RpcDefinition from "./RpcDefinition";
 import * as RpcInvocation from "./internal/RpcInvocation";
 
+const expectedDurableObjectNamespace =
+  "Durable Object namespace binding with getByName(), get(), idFromName(), idFromString(), newUniqueId(), and jurisdiction()";
+
 interface DurableObjectFetcher {
   fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
 }
@@ -548,6 +551,7 @@ export const layer = <
     (value): value is DurableObjectNamespaceClient<Api> =>
       isDurableObjectNamespaceClient<Api>(value),
     makeClient<Api, Definition>(definition),
+    { expected: expectedDurableObjectNamespace },
   );
 
 export const makeDirectMethods = <

--- a/packages/effect-cf/src/Hyperdrive.ts
+++ b/packages/effect-cf/src/Hyperdrive.ts
@@ -3,6 +3,8 @@ import { Context, Effect, type Layer } from "effect";
 import * as Binding from "./Binding";
 import type { WorkerEnvironment } from "./Environment";
 
+const expectedHyperdrive = "Hyperdrive binding with connectionString";
+
 /** Typed Hyperdrive binding definition. */
 export interface HyperdriveDefinition {
   /** Binding name as configured in `wrangler.jsonc`. */
@@ -64,7 +66,10 @@ export const makeClient =
 export const layer = <Self>(
   tag: Context.Service<Self, HyperdriveClient>,
   definition: HyperdriveDefinition,
-) => Binding.layer(tag, definition.binding, isHyperdrive, makeClient(definition));
+) =>
+  Binding.layer(tag, definition.binding, isHyperdrive, makeClient(definition), {
+    expected: expectedHyperdrive,
+  });
 
 export const make = <Id extends string>(id: Id) => Tag<HyperdriveService<Id>>()<Id>(id);
 

--- a/packages/effect-cf/src/Images.ts
+++ b/packages/effect-cf/src/Images.ts
@@ -4,6 +4,7 @@ import * as Binding from "./Binding";
 import type { WorkerEnvironment } from "./Environment";
 
 const TypeId = "effect-cf/Images/Steps" as const;
+const expectedImagesBinding = "Images binding with info() and input()";
 
 /** Error raised when a Cloudflare Images operation fails. */
 export class ImagesOperationError extends Data.TaggedError("ImagesOperationError")<{
@@ -314,7 +315,10 @@ export const makeClient =
 export const layer = <Self>(
   tag: Context.Service<Self, ImagesClient>,
   definition: ImagesDefinition,
-) => Binding.layer(tag, definition.binding, isImagesBinding, makeClient(definition));
+) =>
+  Binding.layer(tag, definition.binding, isImagesBinding, makeClient(definition), {
+    expected: expectedImagesBinding,
+  });
 
 export const make = <Id extends string>(id: Id) => Tag<ImagesService<Id>>()<Id>(id);
 

--- a/packages/effect-cf/src/Kv.ts
+++ b/packages/effect-cf/src/Kv.ts
@@ -3,6 +3,9 @@ import { Context, Data, Effect, Option, Schema as S, type Layer } from "effect";
 import * as Binding from "./Binding";
 import type { WorkerEnvironment } from "./Environment";
 
+const expectedKvNamespace =
+  "KV namespace binding with get(), put(), delete(), getWithMetadata(), and list()";
+
 /** Error raised when a KV operation fails. */
 export class KvOperationError extends Data.TaggedError("KvOperationError")<{
   readonly binding: string;
@@ -250,6 +253,7 @@ export const layer = <Self, Key, Value, EncodedValue>(
     definition.binding,
     isKvNamespace,
     makeClient<Key, Value, EncodedValue>(definition),
+    { expected: expectedKvNamespace },
   );
 
 const makeDefinition = <Id extends string, Key, Value, EncodedValue>(

--- a/packages/effect-cf/src/QueueBinding.ts
+++ b/packages/effect-cf/src/QueueBinding.ts
@@ -10,6 +10,11 @@ export type QueueSendBatchResponse = globalThis.QueueSendBatchResponse;
 export type QueueMetrics = globalThis.QueueMetrics;
 export type MessageSendRequest<Body> = globalThis.MessageSendRequest<Body>;
 
+export type QueueProducer<Body> = Pick<globalThis.Queue<Body>, "send"> &
+  Partial<Pick<globalThis.Queue<Body>, "sendBatch" | "metrics">>;
+
+const expectedQueueProducer = "Queue producer binding with send(); optional sendBatch()/metrics()";
+
 export interface QueueBindingDefinition<Message extends RpcDefinition.ServiceFreeSchema> {
   /** Binding name as configured in `wrangler.jsonc`. */
   readonly binding: string;
@@ -34,10 +39,8 @@ export class QueueOperationError extends Data.TaggedError("QueueOperationError")
   readonly binding: string;
   readonly operation: string;
   readonly cause: unknown;
+  readonly message: string;
 }> {}
-
-const queueError = (binding: string, operation: string, cause: unknown) =>
-  new QueueOperationError({ binding, operation, cause });
 
 const tryQueuePromise = <A>(
   binding: string,
@@ -46,26 +49,28 @@ const tryQueuePromise = <A>(
 ): Effect.Effect<A, QueueOperationError> =>
   Effect.tryPromise({
     try: evaluate,
-    catch: (cause) => queueError(binding, operation, cause),
+    catch: (cause) =>
+      new QueueOperationError({
+        binding,
+        operation,
+        cause,
+        message: `Cloudflare queue binding "${binding}" operation "${operation}" failed`,
+      }),
   });
 
-export const isQueue = <Body>(value: unknown): value is globalThis.Queue<Body> => {
+export const isQueue = <Body>(value: unknown): value is QueueProducer<Body> => {
   if (typeof value !== "object" || value === null) {
     return false;
   }
 
   const resource = value as Record<string, unknown>;
 
-  return (
-    typeof resource.send === "function" &&
-    typeof resource.sendBatch === "function" &&
-    typeof resource.metrics === "function"
-  );
+  return typeof resource.send === "function";
 };
 
 export const makeClient = <Message extends RpcDefinition.ServiceFreeSchema>(
   definition: QueueBindingDefinition<Message>,
-): ((queue: globalThis.Queue<S.Codec.Encoded<Message>>) => QueueBindingClient<Message>) => {
+): ((queue: QueueProducer<S.Codec.Encoded<Message>>) => QueueBindingClient<Message>) => {
   type Body = S.Schema.Type<Message>;
   type EncodedBody = S.Codec.Encoded<Message>;
 
@@ -90,12 +95,41 @@ export const makeClient = <Message extends RpcDefinition.ServiceFreeSchema>(
         });
       }
 
-      yield* tryQueuePromise(definition.binding, "sendBatch", () =>
-        queue.sendBatch(encodedMessages, options),
-      );
+      const sendBatch = queue.sendBatch;
+
+      if (sendBatch !== undefined) {
+        yield* tryQueuePromise(definition.binding, "sendBatch", () =>
+          sendBatch.call(queue, encodedMessages, options),
+        );
+        return;
+      }
+
+      yield* tryQueuePromise(definition.binding, "sendBatch", async () => {
+        for (const message of encodedMessages) {
+          await queue.send(message.body, {
+            contentType: message.contentType,
+            delaySeconds: message.delaySeconds ?? options?.delaySeconds,
+          });
+        }
+      });
     }),
-    metrics: () => tryQueuePromise(definition.binding, "metrics", () => queue.metrics()),
-    unsafeRaw: Effect.succeed(queue),
+    metrics: () => {
+      const metrics = queue.metrics;
+
+      if (metrics === undefined) {
+        return Effect.fail(
+          new QueueOperationError({
+            binding: definition.binding,
+            operation: "metrics",
+            cause: new Error(`Queue binding "${definition.binding}" does not provide metrics()`),
+            message: `Cloudflare queue binding "${definition.binding}" does not provide metrics()`,
+          }),
+        );
+      }
+
+      return tryQueuePromise(definition.binding, "metrics", () => metrics.call(queue));
+    },
+    unsafeRaw: Effect.succeed(queue as globalThis.Queue<EncodedBody>),
   });
 };
 
@@ -106,7 +140,8 @@ export const layer = <Self, Message extends RpcDefinition.ServiceFreeSchema>(
   Binding.layer(
     tag,
     definition.binding,
-    (value): value is globalThis.Queue<S.Codec.Encoded<Message>> =>
+    (value): value is QueueProducer<S.Codec.Encoded<Message>> =>
       isQueue<S.Codec.Encoded<Message>>(value),
     makeClient(definition),
+    { expected: expectedQueueProducer },
   );

--- a/packages/effect-cf/src/R2.ts
+++ b/packages/effect-cf/src/R2.ts
@@ -3,6 +3,9 @@ import { Context, Data, Effect, Option, type Layer } from "effect";
 import * as Binding from "./Binding";
 import type { WorkerEnvironment } from "./Environment";
 
+const expectedR2Bucket =
+  "R2 bucket binding with head(), get(), put(), createMultipartUpload(), resumeMultipartUpload(), delete(), and list()";
+
 /** Error raised when an R2 operation fails. */
 export class R2OperationError extends Data.TaggedError("R2OperationError")<{
   readonly binding: string;
@@ -272,7 +275,9 @@ export const makeClient = (
 };
 
 export const layer = <Self>(tag: Context.Service<Self, R2Client>, definition: R2Definition) =>
-  Binding.layer(tag, definition.binding, isR2Bucket, makeClient(definition));
+  Binding.layer(tag, definition.binding, isR2Bucket, makeClient(definition), {
+    expected: expectedR2Bucket,
+  });
 
 export const make = <Id extends string>(id: Id) => Tag<R2Service<Id>>()<Id>(id);
 

--- a/packages/effect-cf/src/ServiceBinding.ts
+++ b/packages/effect-cf/src/ServiceBinding.ts
@@ -7,6 +7,7 @@ import type * as WorkerDefinition from "./WorkerDefinition";
 import * as RpcInvocation from "./internal/RpcInvocation";
 
 const TypeId = "effect-cf/ServiceBinding" as const;
+const expectedServiceBinding = "Worker service binding with fetch()";
 
 /**
  * Minimum shape for a Cloudflare service binding.
@@ -359,6 +360,7 @@ export const layer = <
     definition.binding,
     (value): value is ServiceBindingClient<Api> => isServiceBindingClient<Api>(value),
     makeClient<Api, Definition>(definition),
+    { expected: expectedServiceBinding },
   );
 
 /**

--- a/packages/effect-cf/src/WorkflowBinding.ts
+++ b/packages/effect-cf/src/WorkflowBinding.ts
@@ -3,6 +3,8 @@ import { Context, Data, Effect, Option, Schema as S } from "effect";
 import * as Binding from "./Binding";
 import type * as RpcDefinition from "./RpcDefinition";
 
+const expectedWorkflow = "Workflow binding with create(), createBatch(), and get()";
+
 export type WorkflowInstanceCreateOptions<Payload> = Omit<
   globalThis.WorkflowInstanceCreateOptions<Payload>,
   "params"
@@ -242,4 +244,5 @@ export const layer = <
     (value): value is globalThis.Workflow<S.Codec.Encoded<Payload>> =>
       isWorkflow<S.Codec.Encoded<Payload>>(value),
     makeClient(definition),
+    { expected: expectedWorkflow },
   );

--- a/packages/effect-cf/tests/R2.test.ts
+++ b/packages/effect-cf/tests/R2.test.ts
@@ -1,7 +1,7 @@
 import { assert, expect, layer, test } from "@effect/vitest";
 import { Effect, Layer, Option } from "effect";
 
-import { Binding, R2, WorkerEnvironment } from "../src/index";
+import { R2, WorkerEnvironment } from "../src/index";
 
 class TestBucket extends R2.Tag<TestBucket>()("test/TestBucket") {}
 
@@ -201,5 +201,11 @@ test("R2 layer validates the binding shape", async () => {
         ),
       ),
     ),
-  ).rejects.toBeInstanceOf(Binding.BindingValidationError);
+  ).rejects.toMatchObject({
+    _tag: "BindingValidationError",
+    binding: "TEST_BUCKET",
+    expected:
+      "R2 bucket binding with head(), get(), put(), createMultipartUpload(), resumeMultipartUpload(), delete(), and list()",
+    actual: "Object",
+  });
 });

--- a/packages/effect-cf/tests/definitions.test.ts
+++ b/packages/effect-cf/tests/definitions.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, it, layer, test } from "@effect/vitest";
-import { Effect, Layer, Option, Schema as S, type Scope } from "effect";
+import { Cause, Effect, Exit, Layer, Option, Schema as S, type Scope } from "effect";
 
 import {
   DurableObjectDefinition,
@@ -134,6 +134,94 @@ test("definition-backed Worker RPC validates encoded success values", async () =
         assert.deepStrictEqual(metrics, { backlogCount: 0, backlogBytes: 0 });
       }),
     );
+  });
+
+  test("definition-backed Queue bindings accept local producer shape", async () => {
+    const sent: Array<unknown> = [];
+    const localEnv = {
+      AVATAR_QUEUE: {
+        send: async (message: unknown, options?: QueueBinding.QueueSendOptions) => {
+          sent.push({ message, options });
+          return { metadata: { metrics: { backlogCount: sent.length, backlogBytes: 0 } } };
+        },
+      },
+    } as unknown as Cloudflare.Env;
+    const provided = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.provide(
+          AvatarQueue.layer({ binding: "AVATAR_QUEUE" }).pipe(
+            Layer.provide(Layer.succeed(WorkerEnvironment, localEnv)),
+          ),
+        ),
+      );
+
+    await Effect.runPromise(
+      provided(
+        Effect.gen(function* () {
+          yield* AvatarQueue.send({ userId: "u_1", attempts: 2 });
+
+          const queue = yield* AvatarQueue;
+          yield* queue.sendBatch(
+            [
+              { body: { userId: "u_2", attempts: 3 }, contentType: "json" },
+              { body: { userId: "u_3", attempts: 4 }, delaySeconds: 7 },
+            ],
+            { delaySeconds: 5 },
+          );
+        }),
+      ),
+    );
+
+    assert.deepStrictEqual(sent, [
+      { message: { userId: "u_1", attempts: "2" }, options: undefined },
+      {
+        message: { userId: "u_2", attempts: "3" },
+        options: { contentType: "json", delaySeconds: 5 },
+      },
+      {
+        message: { userId: "u_3", attempts: "4" },
+        options: { contentType: undefined, delaySeconds: 7 },
+      },
+    ]);
+
+    const missingMetrics = await Effect.runPromiseExit(provided(AvatarQueue.metrics()));
+
+    assert.ok(Exit.isFailure(missingMetrics));
+    expect(Cause.pretty(missingMetrics.cause)).toContain(
+      'QueueOperationError: Cloudflare queue binding "AVATAR_QUEUE" does not provide metrics()',
+    );
+    await expect(Effect.runPromise(provided(AvatarQueue.metrics()))).rejects.toMatchObject({
+      _tag: "QueueOperationError",
+      binding: "AVATAR_QUEUE",
+      operation: "metrics",
+    });
+  });
+
+  test("definition-backed Queue validation errors include binding and expected shape", async () => {
+    const invalidEnv = {
+      AVATAR_QUEUE: {
+        metrics: async () => ({ backlogCount: 0, backlogBytes: 0 }),
+      },
+    } as unknown as Cloudflare.Env;
+
+    const exit = await Effect.runPromiseExit(
+      AvatarQueue.send({ userId: "u_1", attempts: 2 }).pipe(
+        Effect.provide(
+          AvatarQueue.layer({ binding: "AVATAR_QUEUE" }).pipe(
+            Layer.provide(Layer.succeed(WorkerEnvironment, invalidEnv)),
+          ),
+        ),
+      ),
+    );
+
+    assert.ok(Exit.isFailure(exit));
+    const pretty = Cause.pretty(exit.cause);
+
+    expect(pretty).toContain(
+      'BindingValidationError: Cloudflare binding "AVATAR_QUEUE" failed validation',
+    );
+    expect(pretty).toContain("Expected Queue producer binding with send()");
+    expect(pretty).toContain("got Object with methods metrics");
   });
 
   test("definition-backed Queue consumers decode messages", async () => {


### PR DESCRIPTION
## Summary

- Accept local queue producer bindings that expose `send()` without requiring `metrics()` during layer construction.
- Add richer binding validation diagnostics with binding name, expected shape, and actual shape across Cloudflare bindings.
- Update local Wrangler dev dependency to `^4.93.1`.

## Validation

- `vp check`
- `vp test run`
- `vp run effect-cf#build`