### PR TITLE
feat: update to Effect beta 70

### DIFF
--- a/.changeset/effect-beta-70.md
+++ b/.changeset/effect-beta-70.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Raise the minimum supported Effect beta to `4.0.0-beta.70` and update service tag access to use beta 70's direct yieldable tags instead of the removed `.asEffect()` helper.

--- a/bun.lock
+++ b/bun.lock
@@ -305,12 +305,12 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.15.0",
         "@cloudflare/workers-types": "^4.20260421.1",
         "@effect/sql-d1": "catalog:",
-        "@effect/sql-pg": "4.0.0-beta.65",
+        "@effect/sql-pg": "catalog:",
         "@effect/vitest": "catalog:",
         "effect": "catalog:",
         "typescript": "^6.0.2",
@@ -318,9 +318,9 @@
         "vitest": "catalog:",
       },
       "peerDependencies": {
-        "@effect/sql-d1": "^4.0.0-beta.65",
-        "@effect/sql-pg": "^4.0.0-beta.65",
-        "effect": "^4.0.0-beta.65",
+        "@effect/sql-d1": "^4.0.0-beta.70",
+        "@effect/sql-pg": "^4.0.0-beta.70",
+        "effect": "^4.0.0-beta.70",
       },
       "optionalPeers": [
         "@effect/sql-pg",
@@ -328,15 +328,16 @@
     },
   },
   "overrides": {
-    "@effect/platform-node-shared": "4.0.0-beta.65",
+    "@effect/platform-node-shared": "4.0.0-beta.70",
     "vite": "catalog:",
     "vitest": "catalog:",
   },
   "catalog": {
-    "@effect/platform-bun": "4.0.0-beta.65",
-    "@effect/sql-d1": "4.0.0-beta.65",
-    "@effect/vitest": "4.0.0-beta.65",
-    "effect": "4.0.0-beta.65",
+    "@effect/platform-bun": "4.0.0-beta.70",
+    "@effect/sql-d1": "4.0.0-beta.70",
+    "@effect/sql-pg": "4.0.0-beta.70",
+    "@effect/vitest": "4.0.0-beta.70",
+    "effect": "4.0.0-beta.70",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.20",
     "vite-plus": "0.1.20",
     "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.20",
@@ -398,7 +399,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260520.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BjMBhXqlEPaVc68tXihFI+YcU/5T4Jmj4ELDJaEa6NuCcbUMORESgO4OJZIDS4+rC2Lkv37telOktQxEOkqY3g=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260423.1", "", {}, "sha512-SHIc0NeJMtn0sW043eWtMxYFbJ9VPSLkcx+FEqCk0uZLD3HrWT+5xWhm6EYiOYDg0vnrlXNHcu2ly/01zDh3bw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260523.1", "", {}, "sha512-Kr66Jip2K3t0srdoLLImzblTTx2T409Zk2J6AHANmlB950rlHr2henMQx7+cdQOLm2p1CttuBcYB1UVjdiFN8Q=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -412,13 +413,13 @@
 
     "@effect-cf/todos-domain": ["@effect-cf/todos-domain@workspace:examples/todos/packages/domain"],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.65", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.65" }, "peerDependencies": { "effect": "^4.0.0-beta.65" } }, "sha512-6BgEjVDibeOgGj0pvYRx+mBLSWVBPlvuqa6o4kuyrRIdgn92nbKrbglEiIRe4sn7yYmeKei4N/kd7fRzN3rEwA=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.70", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.70" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-u8fhg9RX46034Ee5s461z680LUr2A/4AKo7kWbP7rDQsLDyNyT9Z4/WlzcYl2Oo5E4fJIQmqG6cyieWFQD1Ppg=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.65", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.65" } }, "sha512-3rY8F3WLEax6Hj08GI/OvDIH+KqjfxH7RM2bAMfgR75NgRmwDtny1P49PtPkoRjH5dcdtThThtsvE4X9OTZkpQ=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.70", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-3VXuL63IDmq13We+ApRKn2JW3Rb9g5gj1YEmfb8u2b73norur1VsIJ/pRE4qjShevg19dQYi2JsLawSZ6gApug=="],
 
-    "@effect/sql-d1": ["@effect/sql-d1@4.0.0-beta.65", "", { "dependencies": { "@cloudflare/workers-types": "^4.20260412.1" }, "peerDependencies": { "effect": "^4.0.0-beta.65" } }, "sha512-tH+OMFZfiutBtGfUcW968z6tKB4yMEhlXRVkl9k6q4BnVqOYvvzy+9WfEGzIcxh8uH0hrN6QPuocLDmF/DHImQ=="],
+    "@effect/sql-d1": ["@effect/sql-d1@4.0.0-beta.70", "", { "dependencies": { "@cloudflare/workers-types": "^4.20260511.1" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-86zuNS+j9BCB6BnUDkqbzdS0iRhuGw7+bDw+HqV7PgwYAw53/UspyH0Z+v2dLUP9e9LcFat9KJLVbsCGqmdDZQ=="],
 
-    "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.65", "", { "dependencies": { "pg": "^8.20.0", "pg-connection-string": "2.12.0", "pg-cursor": "^2.19.0", "pg-pool": "^3.13.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.65" } }, "sha512-Gno+2d2NQ7Ythfv9aIwieSkuE8lA3dMpa1Y0n2bOF0CPL9txNEOJIq98QvmQwADPTxDATLxOTUoLf1oRCnGPhg=="],
+    "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.70", "", { "dependencies": { "pg": "^8.20.0", "pg-connection-string": "2.12.0", "pg-cursor": "^2.19.0", "pg-pool": "^3.13.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-l1ToDca5mNLp3wB/dyDIGGKxW1BExnSmyzvZV29upzCzY7kbz8UlFqMGeWBIUYo4pUvYfZMANokQWDMIFs4PEQ=="],
 
     "@effect/tsgo": ["@effect/tsgo@0.5.1", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.5.1", "@effect/tsgo-darwin-x64": "0.5.1", "@effect/tsgo-linux-arm": "0.5.1", "@effect/tsgo-linux-arm64": "0.5.1", "@effect/tsgo-linux-x64": "0.5.1", "@effect/tsgo-win32-arm64": "0.5.1", "@effect/tsgo-win32-x64": "0.5.1" }, "bin": { "effect-tsgo": "dist/effect-tsgo.js" } }, "sha512-INANZ/NK9akOwSQVWpQgSDLjlegrs4gui21nuQsgN7zCjCmj4m/ixUDuVgtW2C0UfqhPWWabyFWCDntu7ryCZQ=="],
 
@@ -436,7 +437,7 @@
 
     "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-dfyXhmVQkxncSnujjSXsOMwzqFIBNDViXiD3Uj9DPDNLSxyg0ybBNxYJTpvJhqHxqseA9wE2aCIMu/pfpac+0Q=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.65", "", { "peerDependencies": { "effect": "^4.0.0-beta.65", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-dJdZlQhB+AtMlSgrJ0QiprRhDnGVTcKmPe699+f5qkQjCKauogaAKekWV3xEM1envAMntwqeFUD4QHVnE+cFPg=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.70", "", { "peerDependencies": { "effect": "^4.0.0-beta.70", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-XDteNN0xfOgoMauAVoN5iylxVgEjp7kFsGFq18tZ5XYjek0eOZa0nOoes5s7Bs71VvwjnCeCbFMD7IhxswEt8A=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
@@ -788,7 +789,7 @@
 
     "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
 
-    "effect": ["effect@4.0.0-beta.65", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-QYKvQPAj3CmtsvWkHQww15wX4KG2gNsszDWEcOO5sZCMknp66u6Si/Opmt3wwWCwsyvRmDAdIg+JIz5qzbbFIw=="],
+    "effect": ["effect@4.0.0-beta.70", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg=="],
 
     "effect-cf": ["effect-cf@workspace:packages/effect-cf"],
 
@@ -804,7 +805,7 @@
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
 
-    "fast-check": ["fast-check@4.7.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ=="],
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -834,7 +835,7 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -898,7 +899,7 @@
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
-    "msgpackr": ["msgpackr@1.11.10", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA=="],
+    "msgpackr": ["msgpackr@2.0.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-9J+tqTEsbHqY8YohazYgty7LgerFIWxvMLpUjqETSmjHojtJm2WnX2kK/2a1fLI7CO7ERP1YSEUXMucz4j+yBA=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
 
@@ -1094,7 +1095,7 @@
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
-    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "vite": ["@voidzero-dev/vite-plus-core@0.1.20", "", { "dependencies": { "@oxc-project/runtime": "=0.127.0", "@oxc-project/types": "=0.127.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.10", "@tsdown/exe": "0.21.10", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-4KmzRfzwTeG3JuvDijrdqWusSgRvLMKDPrVsDdtbDVVjEMq0VnM8lSH+Nvepd6Pg+SuSVUP212OIfH/3Yn1bfA=="],
 
@@ -1116,7 +1117,7 @@
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
-    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
@@ -1125,6 +1126,8 @@
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@cloudflare/vitest-pool-workers/wrangler": ["wrangler@4.90.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260507.1", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260507.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260507.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-bmNIykl59TfCUn5xQgU7IWylSsPx3LQaPLMSAq2VQHt89CBrcj9qXQ0eYfjBCWA5XTBVgten391evt7xxtXwcA=="],
+
+    "@effect/platform-node-shared/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "wrangler": "^4.93.1"
   },
   "overrides": {
-    "@effect/platform-node-shared": "4.0.0-beta.65",
+    "@effect/platform-node-shared": "4.0.0-beta.70",
     "vite": "catalog:",
     "vitest": "catalog:"
   },
@@ -62,10 +62,11 @@
   },
   "packageManager": "bun@1.3.13",
   "catalog": {
-    "@effect/platform-bun": "4.0.0-beta.65",
-    "@effect/sql-d1": "4.0.0-beta.65",
-    "@effect/vitest": "4.0.0-beta.65",
-    "effect": "4.0.0-beta.65",
+    "@effect/platform-bun": "4.0.0-beta.70",
+    "@effect/sql-d1": "4.0.0-beta.70",
+    "@effect/sql-pg": "4.0.0-beta.70",
+    "@effect/vitest": "4.0.0-beta.70",
+    "effect": "4.0.0-beta.70",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.20",
     "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.20",
     "vite-plus": "0.1.20"

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -42,7 +42,7 @@
     "@cloudflare/vitest-pool-workers": "^0.15.0",
     "@cloudflare/workers-types": "^4.20260421.1",
     "@effect/sql-d1": "catalog:",
-    "@effect/sql-pg": "4.0.0-beta.65",
+    "@effect/sql-pg": "catalog:",
     "@effect/vitest": "catalog:",
     "effect": "catalog:",
     "typescript": "^6.0.2",
@@ -50,9 +50,9 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@effect/sql-d1": "^4.0.0-beta.65",
-    "@effect/sql-pg": "^4.0.0-beta.65",
-    "effect": "^4.0.0-beta.65"
+    "@effect/sql-d1": "^4.0.0-beta.70",
+    "@effect/sql-pg": "^4.0.0-beta.70",
+    "effect": "^4.0.0-beta.70"
   },
   "peerDependenciesMeta": {
     "@effect/sql-pg": {

--- a/packages/effect-cf/src/Environment.ts
+++ b/packages/effect-cf/src/Environment.ts
@@ -80,7 +80,7 @@ export namespace WorkerConfig {
    * conversion function.
    */
   export const providerWith = (makeProvider: (env: WorkerEnv) => ConfigProvider.ConfigProvider) =>
-    Effect.map(WorkerEnvironment.asEffect(), makeProvider);
+    Effect.map(WorkerEnvironment, makeProvider);
 
   /** Build a `ConfigProvider` from the current `WorkerEnvironment`. */
   export const provider = providerWith(providerFromEnv);

--- a/packages/effect-cf/src/Workflow.ts
+++ b/packages/effect-cf/src/Workflow.ts
@@ -223,7 +223,7 @@ export const step = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
   config?: WorkflowStepConfig,
 ): Effect.Effect<A, unknown, WorkflowStep | Exclude<R, WorkflowStepContext>> =>
-  Effect.flatMap(WorkflowStep.asEffect(), (workflowStep) =>
+  Effect.flatMap(WorkflowStep, (workflowStep) =>
     workflowStep.do(name, effect, config),
   ) as Effect.Effect<A, unknown, WorkflowStep | Exclude<R, WorkflowStepContext>>;
 
@@ -231,15 +231,13 @@ export const sleep = (
   name: string,
   duration: WorkflowSleepDuration,
 ): Effect.Effect<void, unknown, WorkflowStep> =>
-  Effect.flatMap(WorkflowStep.asEffect(), (workflowStep) => workflowStep.sleep(name, duration));
+  Effect.flatMap(WorkflowStep, (workflowStep) => workflowStep.sleep(name, duration));
 
 export const sleepUntil = (
   name: string,
   timestamp: Date | number,
 ): Effect.Effect<void, unknown, WorkflowStep> =>
-  Effect.flatMap(WorkflowStep.asEffect(), (workflowStep) =>
-    workflowStep.sleepUntil(name, timestamp),
-  );
+  Effect.flatMap(WorkflowStep, (workflowStep) => workflowStep.sleepUntil(name, timestamp));
 
 export const waitForEvent = <Payload>(
   name: string,
@@ -248,9 +246,7 @@ export const waitForEvent = <Payload>(
     readonly timeout?: WorkflowTimeoutDuration | number;
   },
 ): Effect.Effect<WorkflowStepEvent<Payload>, unknown, WorkflowStep> =>
-  Effect.flatMap(WorkflowStep.asEffect(), (workflowStep) =>
-    workflowStep.waitForEvent<Payload>(name, options),
-  );
+  Effect.flatMap(WorkflowStep, (workflowStep) => workflowStep.waitForEvent<Payload>(name, options));
 
 export type Definition<
   Id extends string = string,

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -74,7 +74,7 @@ test("Worker.fetch renders Effect HttpServerResponse values", async () => {
       }
 
       if (path === "/context-stream") {
-        const stream = RenderValue.asEffect().pipe(Stream.fromEffect, Stream.encodeText);
+        const stream = RenderValue.pipe(Stream.fromEffect, Stream.encodeText);
         return HttpServerResponse.stream(stream as Stream.Stream<Uint8Array, never, never>);
       }
 

--- a/scripts/patch-tsgo.ts
+++ b/scripts/patch-tsgo.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { BunRuntime, BunServices } from "@effect/platform-bun";
-import { Clock, Effect, Inspectable, Path, Result, Schema as S } from "effect";
+import { Clock, Effect, Inspectable, Path, Schema as S } from "effect";
 import { Command } from "effect/unstable/cli";
 
 import { formatTiming, startProgressBoard } from "./utils/step-progress.ts";
@@ -93,7 +93,7 @@ const runStep = Effect.fn("runStep")(function* (
   if (result._tag === "Failure") {
     const reason = formatUnknown(result.failure);
     progress.setStatus(index, { kind: "fail", timing, reason });
-    return yield* Result.fail(result.failure);
+    return yield* Effect.fail(result.failure);
   }
 
   progress.setStatus(index, { kind: "ok", timing, summary: label });

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { BunRuntime, BunServices } from "@effect/platform-bun";
-import { Clock, Effect, Inspectable, Path, Result, Schema as S } from "effect";
+import { Clock, Effect, Inspectable, Path, Schema as S } from "effect";
 import { Command } from "effect/unstable/cli";
 
 import { formatTiming, startProgressBoard } from "./utils/step-progress.ts";
@@ -95,7 +95,7 @@ const runStep = Effect.fn("runStep")(function* (
   if (result._tag === "Failure") {
     const reason = formatUnknown(result.failure);
     progress.setStatus(index, { kind: "fail", timing, reason });
-    return yield* Result.fail(result.failure);
+    return yield* Effect.fail(result.failure);
   }
 
   progress.setStatus(index, { kind: "ok", timing, summary: label });

--- a/scripts/sync-effect-submodule.ts
+++ b/scripts/sync-effect-submodule.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { BunRuntime, BunServices } from "@effect/platform-bun";
-import { Clock, Effect, Inspectable, Path, Result, Schema as S } from "effect";
+import { Clock, Effect, Inspectable, Path, Schema as S } from "effect";
 import { Command } from "effect/unstable/cli";
 
 import { formatTiming, startProgressBoard } from "./utils/step-progress.ts";
@@ -219,7 +219,7 @@ const syncEffectSubmodule = Effect.gen(function* () {
         if (result._tag === "Failure") {
           const reason = formatUnknown(result.failure);
           board.setStatus(0, { kind: "fail", timing, reason });
-          return yield* Result.fail(result.failure);
+          return yield* Effect.fail(result.failure);
         }
 
         board.setStatus(0, { kind: "ok", timing, summary: result.success });


### PR DESCRIPTION
## Summary

- Upgrade Effect-family dependencies and peers to `4.0.0-beta.70`.
- Replace removed `.asEffect()` service tag access with direct yieldable service tags.
- Update repo helper scripts for beta 70 generator typing and document the upgrade impact.

## Validation

- `vp install`
- `vp check`
- `vp test`
- `vp run effect-cf#build`
- `vp run -r build`