### PR TITLE
feat: add Durable Object SQLite SQL layer

### DIFF
--- a/.changeset/bright-sqlite-rooms.md
+++ b/.changeset/bright-sqlite-rooms.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add a Durable Object SQLite layer for providing `effect/unstable/sql` through `@effect/sql-sqlite-do`.

--- a/bun.lock
+++ b/bun.lock
@@ -305,12 +305,13 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.15.0",
         "@cloudflare/workers-types": "^4.20260421.1",
         "@effect/sql-d1": "catalog:",
         "@effect/sql-pg": "catalog:",
+        "@effect/sql-sqlite-do": "catalog:",
         "@effect/vitest": "catalog:",
         "effect": "catalog:",
         "typescript": "^6.0.2",
@@ -320,6 +321,7 @@
       "peerDependencies": {
         "@effect/sql-d1": "^4.0.0-beta.70",
         "@effect/sql-pg": "^4.0.0-beta.70",
+        "@effect/sql-sqlite-do": "^4.0.0-beta.70",
         "effect": "^4.0.0-beta.70",
       },
       "optionalPeers": [
@@ -336,6 +338,7 @@
     "@effect/platform-bun": "4.0.0-beta.70",
     "@effect/sql-d1": "4.0.0-beta.70",
     "@effect/sql-pg": "4.0.0-beta.70",
+    "@effect/sql-sqlite-do": "4.0.0-beta.70",
     "@effect/vitest": "4.0.0-beta.70",
     "effect": "4.0.0-beta.70",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.20",
@@ -420,6 +423,8 @@
     "@effect/sql-d1": ["@effect/sql-d1@4.0.0-beta.70", "", { "dependencies": { "@cloudflare/workers-types": "^4.20260511.1" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-86zuNS+j9BCB6BnUDkqbzdS0iRhuGw7+bDw+HqV7PgwYAw53/UspyH0Z+v2dLUP9e9LcFat9KJLVbsCGqmdDZQ=="],
 
     "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.70", "", { "dependencies": { "pg": "^8.20.0", "pg-connection-string": "2.12.0", "pg-cursor": "^2.19.0", "pg-pool": "^3.13.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-l1ToDca5mNLp3wB/dyDIGGKxW1BExnSmyzvZV29upzCzY7kbz8UlFqMGeWBIUYo4pUvYfZMANokQWDMIFs4PEQ=="],
+
+    "@effect/sql-sqlite-do": ["@effect/sql-sqlite-do@4.0.0-beta.70", "", { "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-BM9EjDDbTPoJ+almrR8s8mIMq8ZSgn0VAXfkovHUZ0ti3/XJM/HRXE0vK3iZ5J9MLfGq26kd+9ooBkMcqWkkPw=="],
 
     "@effect/tsgo": ["@effect/tsgo@0.5.1", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.5.1", "@effect/tsgo-darwin-x64": "0.5.1", "@effect/tsgo-linux-arm": "0.5.1", "@effect/tsgo-linux-arm64": "0.5.1", "@effect/tsgo-linux-x64": "0.5.1", "@effect/tsgo-win32-arm64": "0.5.1", "@effect/tsgo-win32-x64": "0.5.1" }, "bin": { "effect-tsgo": "dist/effect-tsgo.js" } }, "sha512-INANZ/NK9akOwSQVWpQgSDLjlegrs4gui21nuQsgN7zCjCmj4m/ixUDuVgtW2C0UfqhPWWabyFWCDntu7ryCZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@effect/platform-bun": "4.0.0-beta.70",
     "@effect/sql-d1": "4.0.0-beta.70",
     "@effect/sql-pg": "4.0.0-beta.70",
+    "@effect/sql-sqlite-do": "4.0.0-beta.70",
     "@effect/vitest": "4.0.0-beta.70",
     "effect": "4.0.0-beta.70",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.20",

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -43,6 +43,7 @@
     "@cloudflare/workers-types": "^4.20260421.1",
     "@effect/sql-d1": "catalog:",
     "@effect/sql-pg": "catalog:",
+    "@effect/sql-sqlite-do": "catalog:",
     "@effect/vitest": "catalog:",
     "effect": "catalog:",
     "typescript": "^6.0.2",
@@ -52,6 +53,7 @@
   "peerDependencies": {
     "@effect/sql-d1": "^4.0.0-beta.70",
     "@effect/sql-pg": "^4.0.0-beta.70",
+    "@effect/sql-sqlite-do": "^4.0.0-beta.70",
     "effect": "^4.0.0-beta.70"
   },
   "peerDependenciesMeta": {

--- a/packages/effect-cf/src/DurableObjectSqlite.ts
+++ b/packages/effect-cf/src/DurableObjectSqlite.ts
@@ -1,0 +1,26 @@
+import { SqliteClient } from "@effect/sql-sqlite-do";
+import { Effect, Layer } from "effect";
+
+import { DurableObjectState } from "./DurableObjectState";
+
+/** Options forwarded to `@effect/sql-sqlite-do` when building a SQL client layer. */
+export type SqliteLayerOptions = Omit<SqliteClient.SqliteClientConfig, "db">;
+
+/**
+ * Provides `effect/unstable/sql` from the current Durable Object SQLite storage.
+ *
+ * @example
+ * ```ts
+ * const RoomLayer = Layer.mergeAll(
+ *   DurableObjectSqlite.layer(),
+ *   OtherRoomServices,
+ * );
+ * ```
+ */
+export const layer = (options?: SqliteLayerOptions) =>
+  Layer.unwrap(
+    Effect.gen(function* () {
+      const state = yield* DurableObjectState;
+      return SqliteClient.layer({ ...options, db: state.raw.storage.sql });
+    }),
+  );

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -5,6 +5,7 @@ export * as DurableObjectAlarm from "./DurableObjectAlarm";
 export * as DurableObjectDefinition from "./DurableObjectDefinition";
 export * as DurableObjectNamespace from "./DurableObjectNamespace";
 export * as DurableObjectRpcWebSocket from "./DurableObjectRpcWebSocket";
+export * as DurableObjectSqlite from "./DurableObjectSqlite";
 export * as DurableObjectState from "./DurableObjectState";
 export * as DurableObjectWebSocket from "./DurableObjectWebSocket";
 export * as DurableObjectStorage from "./DurableObjectStorage";

--- a/packages/effect-cf/tests/DurableObjectSqlite.test.ts
+++ b/packages/effect-cf/tests/DurableObjectSqlite.test.ts
@@ -1,0 +1,126 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { SqlClient } from "effect/unstable/sql";
+
+import { DurableObjectSqlite, DurableObjectState } from "../src/index";
+
+it.effect("provides an Effect SQL client from Durable Object SQLite storage", () => {
+  const seen: Array<{
+    readonly query: string;
+    readonly bindings: ReadonlyArray<unknown>;
+  }> = [];
+  const state = makeRawDurableObjectState((query, bindings) => {
+    seen.push({ query, bindings });
+
+    if (query.trimStart().startsWith("SELECT")) {
+      return makeCursor(["id", "title"], [[1, "ship durable sqlite"]]);
+    }
+
+    return makeCursor([], []);
+  });
+
+  const stateLayer = Layer.succeed(
+    DurableObjectState.DurableObjectState,
+    DurableObjectState.fromDurableObjectState(state),
+  );
+  const sqlLayer = DurableObjectSqlite.layer().pipe(Layer.provide(stateLayer));
+
+  return Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+
+    yield* sql`CREATE TABLE todos (id INTEGER PRIMARY KEY, title TEXT NOT NULL)`;
+    const rows = yield* sql<{
+      readonly [key: string]: unknown;
+      readonly id: number;
+      readonly title: string;
+    }>`
+      SELECT id, title FROM todos WHERE id = ${1}
+    `;
+
+    assert.deepStrictEqual(rows, [{ id: 1, title: "ship durable sqlite" }]);
+    assert.strictEqual(seen.length, 2);
+    assert.deepStrictEqual(seen[1]?.bindings, [1]);
+  }).pipe(Effect.provide(sqlLayer));
+});
+
+function makeRawDurableObjectState(
+  exec: (
+    query: string,
+    bindings: ReadonlyArray<SqlStorageValue>,
+  ) => SqlStorageCursor<Record<string, SqlStorageValue>>,
+): globalThis.DurableObjectState {
+  return {
+    id: {} as globalThis.DurableObjectId,
+    storage: {
+      get: async () => undefined,
+      put: async () => undefined,
+      delete: async () => false,
+      getAlarm: async () => null,
+      setAlarm: async () => undefined,
+      deleteAlarm: async () => undefined,
+      sql: {
+        exec: (query: string, ...bindings: Array<SqlStorageValue>) => exec(query, bindings),
+        databaseSize: 0,
+      },
+      kv: {
+        get: () => undefined,
+        put: () => {},
+        delete: () => false,
+        list: () => [][Symbol.iterator](),
+      },
+    },
+    waitUntil: () => {},
+    blockConcurrencyWhile: (callback: () => Promise<unknown>) => callback(),
+    acceptWebSocket: () => {},
+    getWebSockets: () => [],
+    setWebSocketAutoResponse: () => {},
+    getWebSocketAutoResponse: () => null,
+    getWebSocketAutoResponseTimestamp: () => null,
+    setHibernatableWebSocketEventTimeout: () => {},
+    getHibernatableWebSocketEventTimeout: () => null,
+    getTags: () => [],
+    abort: () => {},
+  } as unknown as globalThis.DurableObjectState;
+}
+
+function makeCursor(
+  columnNames: ReadonlyArray<string>,
+  rows: Array<ReadonlyArray<SqlStorageValue>>,
+): SqlStorageCursor<Record<string, SqlStorageValue>> {
+  return {
+    next: () => {
+      const row = rows.shift();
+      if (row === undefined) {
+        return { done: true };
+      }
+
+      return {
+        done: false,
+        value: Object.fromEntries(columnNames.map((column, index) => [column, row[index]])),
+      };
+    },
+    toArray: () =>
+      rows.map((row) =>
+        Object.fromEntries(columnNames.map((column, index) => [column, row[index]])),
+      ),
+    one: () => {
+      const row = rows[0];
+      if (row === undefined) {
+        throw new Error("No rows");
+      }
+
+      return Object.fromEntries(columnNames.map((column, index) => [column, row[index]]));
+    },
+    raw: function* () {
+      yield* rows;
+    },
+    [Symbol.iterator]: function* () {
+      for (const row of rows) {
+        yield Object.fromEntries(columnNames.map((column, index) => [column, row[index]]));
+      }
+    },
+    columnNames: [...columnNames],
+    rowsRead: rows.length,
+    rowsWritten: 0,
+  } as SqlStorageCursor<Record<string, SqlStorageValue>>;
+}


### PR DESCRIPTION
## Summary

- Add a Durable Object SQLite layer that provides `effect/unstable/sql` through `@effect/sql-sqlite-do`.
- Export the new `DurableObjectSqlite` module and add package/catalog dependencies plus a minor changeset.
- Cover the layer with a unit test using mocked Durable Object SQLite storage.

## Validation

- `vp check`
- `vp test`