### PR TITLE
feat: add event-layer entrypoint instrumentation

### DIFF
--- a/.changeset/cloudflare-otlp.md
+++ b/.changeset/cloudflare-otlp.md
@@ -1,0 +1,7 @@
+---
+"effect-cf": minor
+---
+
+Add `eventLayer` options to Worker and Durable Object entrypoints for per-event
+Effect layer provisioning, and remove the Cloudflare OTLP handler instrumentation
+helper APIs.

--- a/packages/effect-cf/src/CloudflareOtlp.ts
+++ b/packages/effect-cf/src/CloudflareOtlp.ts
@@ -10,10 +10,8 @@ import {
   OtlpTracer,
 } from "effect/unstable/observability";
 
-import * as DurableObject from "./DurableObject";
 import { DurableObjectState } from "./DurableObjectState";
 import { WorkerConfig, WorkerEnvironment } from "./Environment";
-import * as Worker from "./Worker";
 
 /** Telemetry signal groups supported by the Cloudflare OTLP layers. */
 export type Signal = "logs" | "traces" | "metrics";
@@ -516,113 +514,3 @@ export const durableObjectLayer = (options: LayerOptions & DurableObjectResource
       }),
     ),
   );
-
-const provideRpcLayer = <
-  Rpc extends Record<string, (...args: Array<any>) => Effect.Effect<any, any, any>>,
-  RLayer,
->(
-  rpc: Rpc | undefined,
-  layer: Layer.Layer<never, never, RLayer>,
-): Rpc | undefined => {
-  if (rpc === undefined) {
-    return undefined;
-  }
-
-  return new Proxy(rpc, {
-    get(target, property, receiver) {
-      const handler = Reflect.get(target, property, receiver);
-      if (typeof handler !== "function") {
-        return handler;
-      }
-
-      return (...args: Array<any>) =>
-        Effect.suspend(() => Reflect.apply(handler, receiver, args)).pipe(Effect.provide(layer));
-    },
-  });
-};
-
-/**
- * Instrument Worker lifecycle handlers with event-scoped OTLP telemetry.
- *
- * Each defined handler is provided with {@link workerLayer}. Because Worker
- * handlers run inside `Effect.scoped`, the exporter scope closes and flushes at
- * the end of each Cloudflare event.
- */
-export const instrumentWorkerOptions =
-  (options?: LayerOptions & WorkerResourceOptions) =>
-  <ROut, Rpc extends Worker.WorkerRpc<ROut>>(
-    handlers: Worker.WorkerOptions<ROut, Rpc>,
-  ): Worker.WorkerOptions<ROut | WorkerEnvironment | CloudflareOtlpSettings, Rpc> => {
-    const telemetryLayer = workerLayer(options);
-    const queue = handlers.queue;
-
-    return {
-      ...handlers,
-      fetch:
-        handlers.fetch === undefined
-          ? undefined
-          : handlers.fetch.pipe(Effect.provide(telemetryLayer)),
-      queue:
-        queue === undefined
-          ? undefined
-          : (batch) => queue(batch).pipe(Effect.provide(telemetryLayer)),
-      rpc: provideRpcLayer(handlers.rpc, telemetryLayer),
-    };
-  };
-
-/**
- * Instrument Durable Object lifecycle handlers with event-scoped OTLP telemetry.
- *
- * Each defined handler is provided with {@link durableObjectLayer}. Because
- * Durable Object handlers run inside `Effect.scoped`, the exporter scope closes
- * and flushes at the end of each Cloudflare event.
- */
-export const instrumentDurableObjectOptions =
-  (options?: LayerOptions & DurableObjectResourceOptions) =>
-  <ROut, Rpc extends DurableObject.DurableObjectRpc<ROut>>(
-    handlers: DurableObject.DurableObjectOptions<ROut, Rpc>,
-  ): DurableObject.DurableObjectOptions<
-    ROut | WorkerEnvironment | DurableObjectState | CloudflareOtlpSettings,
-    Rpc
-  > => {
-    const telemetryLayer = durableObjectLayer(options);
-    const alarm = handlers.alarm;
-    const webSocketMessage = handlers.webSocketMessage;
-    const webSocketClose = handlers.webSocketClose;
-    const webSocketError = handlers.webSocketError;
-
-    return {
-      ...handlers,
-      initialize:
-        handlers.initialize === undefined
-          ? undefined
-          : handlers.initialize.pipe(Effect.provide(telemetryLayer)),
-      fetch:
-        handlers.fetch === undefined
-          ? undefined
-          : handlers.fetch.pipe(Effect.provide(telemetryLayer)),
-      alarms:
-        handlers.alarms === undefined
-          ? undefined
-          : handlers.alarms.pipe(Effect.provide(telemetryLayer)),
-      alarm:
-        alarm === undefined
-          ? undefined
-          : (alarmInfo) => alarm(alarmInfo).pipe(Effect.provide(telemetryLayer)),
-      webSocketMessage:
-        webSocketMessage === undefined
-          ? undefined
-          : (socket, message) =>
-              webSocketMessage(socket, message).pipe(Effect.provide(telemetryLayer)),
-      webSocketClose:
-        webSocketClose === undefined
-          ? undefined
-          : (socket, code, reason, wasClean) =>
-              webSocketClose(socket, code, reason, wasClean).pipe(Effect.provide(telemetryLayer)),
-      webSocketError:
-        webSocketError === undefined
-          ? undefined
-          : (socket, error) => webSocketError(socket, error).pipe(Effect.provide(telemetryLayer)),
-      rpc: provideRpcLayer(handlers.rpc, telemetryLayer),
-    };
-  };

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -27,6 +27,9 @@ type RuntimeContext<ROut> = DurableObjectState | WorkerEnvironment | ROut;
 type HandlerContext<ROut> = RuntimeContext<ROut> | Scope.Scope;
 
 type FetchContext<ROut> = HandlerContext<ROut> | NativeRequest;
+type RunOptions = {
+  readonly eventLayer?: boolean;
+};
 
 const RunSymbol = Symbol.for("effect-cf/DurableObject/run");
 
@@ -72,7 +75,24 @@ export type RpcHandlers<ROut, Api> = {
 /**
  * Options for creating a Durable Object class backed by Effect handlers.
  */
-export interface DurableObjectOptions<ROut, Rpc extends DurableObjectRpc<ROut>> {
+export interface DurableObjectOptions<
+  RRuntime,
+  REvent = never,
+  EventLayerError = never,
+  Rpc extends DurableObjectRpc<RRuntime | REvent> = Record<never, never>,
+> {
+  /**
+   * Layer provided around each Cloudflare event handled by this Durable Object.
+   *
+   * The layer is built inside the event's Effect scope and finalized when the
+   * event effect completes. It is not applied to `initialize`, which is an
+   * instance-load lifecycle hook rather than a platform event.
+   */
+  readonly eventLayer?: Layer.Layer<
+    REvent,
+    EventLayerError,
+    DurableObjectState | WorkerEnvironment | RRuntime
+  >;
   /**
    * Effect run when Cloudflare loads this Durable Object instance into memory.
    *
@@ -81,11 +101,11 @@ export interface DurableObjectOptions<ROut, Rpc extends DurableObjectRpc<ROut>> 
    * the same Durable Object id again after eviction or restart; use Durable
    * Object storage if work must happen only once per id.
    */
-  readonly initialize?: Effect.Effect<void, unknown, HandlerContext<ROut>>;
+  readonly initialize?: Effect.Effect<void, unknown, HandlerContext<RRuntime>>;
   /** Optional RPC methods exposed as Durable Object instance methods. */
   readonly rpc?: Rpc;
   /** Optional fetch handler for HTTP/WebSocket requests. */
-  readonly fetch?: Effect.Effect<Response, unknown, FetchContext<ROut>>;
+  readonly fetch?: Effect.Effect<Response, unknown, FetchContext<RRuntime | REvent>>;
   /**
    * Optional logical alarm processing effect.
    *
@@ -93,24 +113,24 @@ export interface DurableObjectOptions<ROut, Rpc extends DurableObjectRpc<ROut>> 
    * `DurableObjectAlarm.processDue(...)` so the reusable scheduler stays inside
    * the Durable Object's single managed runtime boundary.
    */
-  readonly alarms?: Effect.Effect<unknown, unknown, HandlerContext<ROut>>;
+  readonly alarms?: Effect.Effect<unknown, unknown, HandlerContext<RRuntime | REvent>>;
   readonly alarm?: (
     alarmInfo?: globalThis.AlarmInvocationInfo,
-  ) => Effect.Effect<void, unknown, HandlerContext<ROut>>;
+  ) => Effect.Effect<void, unknown, HandlerContext<RRuntime | REvent>>;
   readonly webSocketMessage?: (
     socket: DurableWebSocket,
     message: string | ArrayBuffer,
-  ) => Effect.Effect<void, unknown, HandlerContext<ROut>>;
+  ) => Effect.Effect<void, unknown, HandlerContext<RRuntime | REvent>>;
   readonly webSocketClose?: (
     socket: DurableWebSocket,
     code: number,
     reason: string,
     wasClean: boolean,
-  ) => Effect.Effect<void, unknown, HandlerContext<ROut>>;
+  ) => Effect.Effect<void, unknown, HandlerContext<RRuntime | REvent>>;
   readonly webSocketError?: (
     socket: DurableWebSocket,
     error: unknown,
-  ) => Effect.Effect<void, unknown, HandlerContext<ROut>>;
+  ) => Effect.Effect<void, unknown, HandlerContext<RRuntime | REvent>>;
 }
 
 /**
@@ -127,11 +147,13 @@ export type DurableObjectClass<Rpc extends DurableObjectRpc<ROut>, ROut> = new (
 export const make = <
   ROut,
   LayerError,
-  const Rpc extends DurableObjectRpc<ROut> = Record<never, never>,
+  REvent = never,
+  EventLayerError = never,
+  const Rpc extends DurableObjectRpc<ROut | REvent> = Record<never, never>,
 >(
   layer: Layer.Layer<ROut, LayerError, DurableObjectState | WorkerEnvironment>,
-  options: DurableObjectOptions<ROut, Rpc> = {},
-): DurableObjectClass<Rpc, ROut> => {
+  options: DurableObjectOptions<ROut, REvent, EventLayerError, Rpc> = {},
+): DurableObjectClass<Rpc, ROut | REvent> => {
   class EffectDurableObject extends CloudflareDurableObject<WorkerEnv> {
     readonly runtime: ManagedRuntime.ManagedRuntime<RuntimeContext<ROut>, LayerError>;
 
@@ -149,12 +171,24 @@ export const make = <
 
       const initialize = options.initialize;
       if (initialize !== undefined) {
-        state.waitUntil(this[RunSymbol](initialize));
+        state.waitUntil(this[RunSymbol](initialize, { eventLayer: false }));
       }
     }
 
-    [RunSymbol]<A, E>(effect: Effect.Effect<A, E, HandlerContext<ROut>>): Promise<A> {
-      return this.runtime.runPromise(Effect.scoped(effect));
+    [RunSymbol]<A, E>(
+      effect: Effect.Effect<A, E, HandlerContext<ROut | REvent>>,
+      runOptions: RunOptions = {},
+    ): Promise<A> {
+      const effectWithEventLayer =
+        runOptions.eventLayer === false || options.eventLayer === undefined
+          ? effect
+          : effect.pipe(Effect.provide(options.eventLayer, { local: true }));
+
+      return this.runtime.runPromise(
+        Effect.scoped(
+          effectWithEventLayer as Effect.Effect<A, E | EventLayerError, HandlerContext<ROut>>,
+        ),
+      );
     }
 
     fetch(request: Request): Promise<Response> {
@@ -223,7 +257,9 @@ export const make = <
     (self, effect) => self[RunSymbol](effect),
   );
 
-  return Entrypoint.assumeEntrypointClass<DurableObjectClass<Rpc, ROut>>(EffectDurableObject);
+  return Entrypoint.assumeEntrypointClass<DurableObjectClass<Rpc, ROut | REvent>>(
+    EffectDurableObject,
+  );
 };
 
 export type ServiceFreeSchema = S.Codec<any, any, never, never>;
@@ -285,11 +321,16 @@ export type Handlers<ROut, Self extends Definition.Any> = {
   ) => DurableObjectHandler<ROut, Method.Success<Self["methods"][Key]>>;
 };
 
-export interface Options<ROut, Self extends Definition.Any> extends Omit<
-  DurableObjectOptions<ROut, Handlers<ROut, Self>>,
+export interface Options<
+  ROut,
+  Self extends Definition.Any,
+  REvent = never,
+  EventLayerError = never,
+> extends Omit<
+  DurableObjectOptions<ROut, REvent, EventLayerError, Handlers<ROut | REvent, Self>>,
   "rpc"
 > {
-  readonly rpc: Handlers<ROut, Self>;
+  readonly rpc: Handlers<ROut | REvent, Self>;
 }
 
 export type TagClass<Self, Id extends string, MethodsShape extends Methods> = Context.ServiceClass<
@@ -307,10 +348,10 @@ export type TagClass<Self, Id extends string, MethodsShape extends Methods> = Co
   > & {
     readonly id: Id;
     readonly methods: MethodsShape;
-    readonly make: <ROut, LayerError>(
+    readonly make: <ROut, LayerError, REvent = never, EventLayerError = never>(
       layer: Layer.Layer<ROut, LayerError, DurableObjectState | WorkerEnvironment>,
-      options: Options<ROut, Definition<Id, MethodsShape>>,
-    ) => DurableObjectClass<Handlers<ROut, Definition<Id, MethodsShape>>, ROut>;
+      options: Options<ROut, Definition<Id, MethodsShape>, REvent, EventLayerError>,
+    ) => DurableObjectClass<Handlers<ROut | REvent, Definition<Id, MethodsShape>>, ROut | REvent>;
     readonly layer: (
       options: LayerOptions,
     ) => Layer.Layer<

--- a/packages/effect-cf/src/DurableObjectDefinition.ts
+++ b/packages/effect-cf/src/DurableObjectDefinition.ts
@@ -115,11 +115,21 @@ type BoundaryHandlers<ROut, Self extends Definition.Any> = {
 /**
  * Durable Object constructor options for a specific RPC definition.
  */
-export interface Options<ROut, Self extends Definition.Any> extends Omit<
-  DurableObjectEntrypoint.DurableObjectOptions<ROut, Handlers<ROut, Self>>,
+export interface Options<
+  ROut,
+  Self extends Definition.Any,
+  REvent = never,
+  EventLayerError = never,
+> extends Omit<
+  DurableObjectEntrypoint.DurableObjectOptions<
+    ROut,
+    REvent,
+    EventLayerError,
+    Handlers<ROut | REvent, Self>
+  >,
   "rpc"
 > {
-  readonly rpc: Handlers<ROut, Self>;
+  readonly rpc: Handlers<ROut | REvent, Self>;
 }
 
 export type LayerOptions = {
@@ -141,12 +151,12 @@ export type TagClass<Self, Id extends string, MethodsShape extends Methods> = Co
   > & {
     readonly id: Id;
     readonly methods: MethodsShape;
-    readonly make: <ROut, LayerError>(
+    readonly make: <ROut, LayerError, REvent = never, EventLayerError = never>(
       layer: Layer.Layer<ROut, LayerError, DurableObjectState | WorkerEnvironment>,
-      options: Options<ROut, Definition<Id, MethodsShape>>,
+      options: Options<ROut, Definition<Id, MethodsShape>, REvent, EventLayerError>,
     ) => DurableObjectEntrypoint.DurableObjectClass<
-      Handlers<ROut, Definition<Id, MethodsShape>>,
-      ROut
+      Handlers<ROut | REvent, Definition<Id, MethodsShape>>,
+      ROut | REvent
     >;
     readonly layer: (
       options: LayerOptions,
@@ -195,9 +205,9 @@ const makeDefinition = <Id extends string, const MethodsShape extends Methods>(
   const definition: SelfDefinition = RpcDefinition.make(id, methods);
 
   return Object.assign(definition, {
-    make: <ROut, LayerError>(
+    make: <ROut, LayerError, REvent = never, EventLayerError = never>(
       layer: Layer.Layer<ROut, LayerError, DurableObjectState | WorkerEnvironment>,
-      options: Options<ROut, SelfDefinition>,
+      options: Options<ROut, SelfDefinition, REvent, EventLayerError>,
     ) =>
       DurableObjectEntrypoint.make(layer, {
         ...options,

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -88,6 +88,9 @@ type WorkerFetchContext<ROut> =
 type WorkerRpcContext<ROut> = WorkerBaseContext<ROut> | Scope.Scope;
 
 type RuntimeContext<ROut> = WorkerBaseContext<ROut>;
+type RunOptions = {
+  readonly eventLayer?: boolean;
+};
 
 const RunSymbol = Symbol.for("effect-cf/Worker/run");
 
@@ -127,13 +130,33 @@ export type RpcHandlers<ROut, Api> = {
     : never;
 };
 
-export interface WorkerOptions<ROut, Rpc extends WorkerRpc<ROut>> {
-  readonly fetch?: Effect.Effect<WorkerFetchSuccess, unknown, WorkerFetchContext<ROut>>;
-  readonly queue?: QueueHandler<ROut>;
+export interface WorkerOptions<
+  RRuntime,
+  REvent = never,
+  EventLayerError = never,
+  Rpc extends WorkerRpc<RRuntime | REvent> = Record<never, never>,
+> {
+  /**
+   * Layer provided around each Cloudflare event handled by this Worker.
+   *
+   * The layer is built inside the event's Effect scope and finalized when the
+   * event effect completes. Use this for event-scoped resources such as OTLP
+   * trace/log exporters that should flush at event completion.
+   */
+  readonly eventLayer?: Layer.Layer<REvent, EventLayerError, WorkerBaseContext<RRuntime>>;
+  readonly fetch?: Effect.Effect<
+    WorkerFetchSuccess,
+    unknown,
+    WorkerFetchContext<RRuntime | REvent>
+  >;
+  readonly queue?: QueueHandler<RRuntime | REvent>;
   readonly rpc?: Rpc;
 }
 
-export type FetchWorkerOptions<ROut> = Omit<WorkerOptions<ROut, Record<never, never>>, "rpc"> & {
+export type FetchWorkerOptions<RRuntime, REvent = never, EventLayerError = never> = Omit<
+  WorkerOptions<RRuntime, REvent, EventLayerError, Record<never, never>>,
+  "rpc"
+> & {
   readonly rpc?: never;
 };
 
@@ -173,28 +196,40 @@ const renderFetchSuccess = <E, R>(
         ),
   );
 
-const isWorkerOptions = <ROut, Rpc extends WorkerRpc<ROut>>(
-  options: WorkerOptions<ROut, Rpc> | WorkerHandler<ROut>,
-): options is WorkerOptions<ROut, Rpc> =>
+const isWorkerOptions = <ROut, REvent, EventLayerError, Rpc extends WorkerRpc<ROut | REvent>>(
+  options: WorkerOptions<ROut, REvent, EventLayerError, Rpc> | WorkerHandler<ROut>,
+): options is WorkerOptions<ROut, REvent, EventLayerError, Rpc> =>
   typeof options === "object" &&
   options !== null &&
-  ("fetch" in options || "queue" in options || "rpc" in options);
+  ("eventLayer" in options || "fetch" in options || "queue" in options || "rpc" in options);
 
 export function make<ROut, LayerError>(
   layer: Layer.Layer<ROut, LayerError, ExecutionContext | WorkerContext | WorkerEnvironment>,
   fetch: WorkerHandler<ROut>,
 ): WorkerClass<Record<never, never>, ROut>;
-export function make<ROut, LayerError, const Rpc extends WorkerRpc<ROut> = Record<never, never>>(
+export function make<
+  ROut,
+  LayerError,
+  REvent = never,
+  EventLayerError = never,
+  const Rpc extends WorkerRpc<ROut | REvent> = Record<never, never>,
+>(
   layer: Layer.Layer<ROut, LayerError, ExecutionContext | WorkerContext | WorkerEnvironment>,
-  options: WorkerOptions<ROut, Rpc>,
-): WorkerClass<Rpc, ROut>;
-export function make<ROut, LayerError, const Rpc extends WorkerRpc<ROut> = Record<never, never>>(
+  options: WorkerOptions<ROut, REvent, EventLayerError, Rpc>,
+): WorkerClass<Rpc, ROut | REvent>;
+export function make<
+  ROut,
+  LayerError,
+  REvent = never,
+  EventLayerError = never,
+  const Rpc extends WorkerRpc<ROut | REvent> = Record<never, never>,
+>(
   layer: Layer.Layer<ROut, LayerError, ExecutionContext | WorkerContext | WorkerEnvironment>,
-  optionsOrFetch: WorkerOptions<ROut, Rpc> | WorkerHandler<ROut>,
-): WorkerClass<Rpc, ROut> {
+  optionsOrFetch: WorkerOptions<ROut, REvent, EventLayerError, Rpc> | WorkerHandler<ROut>,
+): WorkerClass<Rpc, ROut | REvent> {
   const options = isWorkerOptions(optionsOrFetch)
     ? optionsOrFetch
-    : ({ fetch: optionsOrFetch } as WorkerOptions<ROut, Rpc>);
+    : ({ fetch: optionsOrFetch } as WorkerOptions<ROut, REvent, EventLayerError, Rpc>);
 
   class EffectWorker extends CloudflareWorkerEntrypoint<WorkerEnv> {
     readonly runtime: ManagedRuntime.ManagedRuntime<RuntimeContext<ROut>, LayerError>;
@@ -226,8 +261,24 @@ export function make<ROut, LayerError, const Rpc extends WorkerRpc<ROut> = Recor
         this.runtime.runPromiseExit(effect as Effect.Effect<A, E, RuntimeContext<ROut>>);
     }
 
-    [RunSymbol]<A, E>(effect: Effect.Effect<A, E, RuntimeContext<ROut> | Scope.Scope>): Promise<A> {
-      return this.runtime.runPromise(Effect.scoped(effect));
+    [RunSymbol]<A, E>(
+      effect: Effect.Effect<A, E, RuntimeContext<ROut> | REvent | Scope.Scope>,
+      runOptions: RunOptions = {},
+    ): Promise<A> {
+      const effectWithEventLayer =
+        runOptions.eventLayer === false || options.eventLayer === undefined
+          ? effect
+          : effect.pipe(Effect.provide(options.eventLayer, { local: true }));
+
+      return this.runtime.runPromise(
+        Effect.scoped(
+          effectWithEventLayer as Effect.Effect<
+            A,
+            E | EventLayerError,
+            RuntimeContext<ROut> | Scope.Scope
+          >,
+        ),
+      );
     }
 
     fetch(request: Request): Promise<Response> {
@@ -246,7 +297,7 @@ export function make<ROut, LayerError, const Rpc extends WorkerRpc<ROut> = Recor
         renderFetchSuccess(fetchHandler).pipe(Effect.provide(requestServices)) as Effect.Effect<
           Response,
           unknown,
-          RuntimeContext<ROut> | Scope.Scope
+          RuntimeContext<ROut> | REvent | Scope.Scope
         >,
       );
     }
@@ -272,12 +323,18 @@ export function make<ROut, LayerError, const Rpc extends WorkerRpc<ROut> = Recor
     (self, effect) => self[RunSymbol](effect),
   );
 
-  return Entrypoint.assumeEntrypointClass<WorkerClass<Rpc, ROut>>(EffectWorker);
+  return Entrypoint.assumeEntrypointClass<WorkerClass<Rpc, ROut | REvent>>(EffectWorker);
 }
 
-export const makeFetchHandler = <ROut, LayerError, Env extends WorkerEnv = WorkerEnv>(
+export const makeFetchHandler = <
+  ROut,
+  LayerError,
+  REvent = never,
+  EventLayerError = never,
+  Env extends WorkerEnv = WorkerEnv,
+>(
   layer: Layer.Layer<ROut, LayerError, ExecutionContext | WorkerContext | WorkerEnvironment>,
-  options: FetchWorkerOptions<ROut>,
+  options: FetchWorkerOptions<ROut, REvent, EventLayerError>,
 ): FetchHandler<Env> => {
   const WorkerClass = make(layer, options);
 
@@ -341,11 +398,13 @@ export type Handlers<ROut, Self extends Definition.Any> = {
   ) => WorkerRpcHandler<ROut, Method.Success<Self["methods"][Key]>>;
 };
 
-export interface Options<ROut, Self extends Definition.Any> extends Omit<
-  WorkerOptions<ROut, Handlers<ROut, Self>>,
-  "rpc"
-> {
-  readonly rpc: Handlers<ROut, Self>;
+export interface Options<
+  ROut,
+  Self extends Definition.Any,
+  REvent = never,
+  EventLayerError = never,
+> extends Omit<WorkerOptions<ROut, REvent, EventLayerError, Handlers<ROut | REvent, Self>>, "rpc"> {
+  readonly rpc: Handlers<ROut | REvent, Self>;
 }
 
 export type LayerOptions = WorkerDefinition.LayerOptions;
@@ -365,10 +424,10 @@ export type TagClass<Self, Id extends string, MethodsShape extends Methods> = Co
   > & {
     readonly id: Id;
     readonly methods: MethodsShape;
-    readonly make: <ROut, LayerError>(
+    readonly make: <ROut, LayerError, REvent = never, EventLayerError = never>(
       layer: Layer.Layer<ROut, LayerError, ExecutionContext | WorkerContext | WorkerEnvironment>,
-      options: Options<ROut, Definition<Id, MethodsShape>>,
-    ) => WorkerClass<Handlers<ROut, Definition<Id, MethodsShape>>, ROut>;
+      options: Options<ROut, Definition<Id, MethodsShape>, REvent, EventLayerError>,
+    ) => WorkerClass<Handlers<ROut | REvent, Definition<Id, MethodsShape>>, ROut | REvent>;
     readonly layer: (
       options: LayerOptions,
     ) => Layer.Layer<

--- a/packages/effect-cf/src/WorkerDefinition.ts
+++ b/packages/effect-cf/src/WorkerDefinition.ts
@@ -118,11 +118,16 @@ type BoundaryHandlers<ROut, Self extends Definition.Any> = {
 /**
  * Worker constructor options for a specific RPC definition.
  */
-export interface Options<ROut, Self extends Definition.Any> extends Omit<
-  WorkerEntrypoint.WorkerOptions<ROut, Handlers<ROut, Self>>,
+export interface Options<
+  ROut,
+  Self extends Definition.Any,
+  REvent = never,
+  EventLayerError = never,
+> extends Omit<
+  WorkerEntrypoint.WorkerOptions<ROut, REvent, EventLayerError, Handlers<ROut | REvent, Self>>,
   "rpc"
 > {
-  readonly rpc: Handlers<ROut, Self>;
+  readonly rpc: Handlers<ROut | REvent, Self>;
 }
 
 export type LayerOptions = {
@@ -144,14 +149,17 @@ export type TagClass<Self, Id extends string, MethodsShape extends Methods> = Co
   > & {
     readonly id: Id;
     readonly methods: MethodsShape;
-    readonly make: <ROut, LayerError>(
+    readonly make: <ROut, LayerError, REvent = never, EventLayerError = never>(
       layer: Layer.Layer<
         ROut,
         LayerError,
         WorkerEntrypoint.ExecutionContext | WorkerEntrypoint.WorkerContext | WorkerEnvironment
       >,
-      options: Options<ROut, Definition<Id, MethodsShape>>,
-    ) => WorkerEntrypoint.WorkerClass<Handlers<ROut, Definition<Id, MethodsShape>>, ROut>;
+      options: Options<ROut, Definition<Id, MethodsShape>, REvent, EventLayerError>,
+    ) => WorkerEntrypoint.WorkerClass<
+      Handlers<ROut | REvent, Definition<Id, MethodsShape>>,
+      ROut | REvent
+    >;
     readonly layer: (
       options: LayerOptions,
     ) => Layer.Layer<
@@ -199,13 +207,13 @@ const makeDefinition = <Id extends string, const MethodsShape extends Methods>(
   const definition: SelfDefinition = RpcDefinition.make(id, methods);
 
   return Object.assign(definition, {
-    make: <ROut, LayerError>(
+    make: <ROut, LayerError, REvent = never, EventLayerError = never>(
       layer: Layer.Layer<
         ROut,
         LayerError,
         WorkerEntrypoint.ExecutionContext | WorkerEntrypoint.WorkerContext | WorkerEnvironment
       >,
-      options: Options<ROut, SelfDefinition>,
+      options: Options<ROut, SelfDefinition, REvent, EventLayerError>,
     ) =>
       WorkerEntrypoint.make(layer, {
         ...options,

--- a/packages/effect-cf/tests/CloudflareOtlp.test.ts
+++ b/packages/effect-cf/tests/CloudflareOtlp.test.ts
@@ -218,17 +218,15 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
     Effect.gen(function* () {
       const collector = yield* OtlpCollector;
       const handler = Worker.makeFetchHandler(Layer.empty, {
+        eventLayer: CloudflareOtlp.workerLayer({
+          signals: ["traces"],
+          serialization: "json",
+          serviceName: "effect-cf-test",
+          workerName: "api-worker",
+          tracerExportInterval: "1 hour",
+        }),
         fetch: Effect.succeed(new Response("ok")).pipe(
           Effect.withSpan("test.fetch", { attributes: { route: "/" } }),
-          Effect.provide(
-            CloudflareOtlp.workerLayer({
-              signals: ["traces"],
-              serialization: "json",
-              serviceName: "effect-cf-test",
-              workerName: "api-worker",
-              tracerExportInterval: "1 hour",
-            }),
-          ),
         ),
       });
 
@@ -273,16 +271,12 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
     Effect.gen(function* () {
       const collector = yield* OtlpCollector;
       const handler = Worker.makeFetchHandler(Layer.empty, {
-        fetch: Effect.succeed(new Response("ok")).pipe(
-          Effect.withSpan("resource.fetch"),
-          Effect.provide(
-            CloudflareOtlp.workerLayer({
-              signals: ["traces"],
-              serialization: "json",
-              tracerExportInterval: "1 hour",
-            }),
-          ),
-        ),
+        eventLayer: CloudflareOtlp.workerLayer({
+          signals: ["traces"],
+          serialization: "json",
+          tracerExportInterval: "1 hour",
+        }),
+        fetch: Effect.succeed(new Response("ok")).pipe(Effect.withSpan("resource.fetch")),
       });
 
       const response = yield* Effect.promise(() =>
@@ -343,51 +337,6 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
   );
 });
 
-it.effect("CloudflareOtlp Worker RPC instrumentation preserves method receivers", () =>
-  Effect.gen(function* () {
-    const instrumented = CloudflareOtlp.instrumentWorkerOptions()({
-      rpc: {
-        getPrefix() {
-          return Effect.succeed("rpc");
-        },
-        read(this: { readonly getPrefix: () => Effect.Effect<string> }, value: string) {
-          return Effect.map(this.getPrefix(), (prefix) => `${prefix}:${value}`);
-        },
-      },
-    });
-
-    const rpc = instrumented.rpc;
-    if (rpc === undefined) {
-      throw new Error("Expected instrumented RPC handlers");
-    }
-
-    const result = yield* rpc.read("ok");
-    expect(result).toBe("rpc:ok");
-  }),
-);
-
-it.effect("CloudflareOtlp Worker RPC instrumentation suspends synchronous throws", () =>
-  Effect.gen(function* () {
-    const explode = (): Effect.Effect<string> => {
-      throw new Error("boom");
-    };
-
-    const instrumented = CloudflareOtlp.instrumentWorkerOptions()({
-      rpc: {
-        explode,
-      },
-    });
-
-    const rpc = instrumented.rpc;
-    if (rpc === undefined) {
-      throw new Error("Expected instrumented RPC handlers");
-    }
-
-    const exit = yield* Effect.exit(rpc.explode());
-    expect(exit._tag).toBe("Failure");
-  }),
-);
-
 it.effect("CloudflareOtlp layer is disabled when no endpoint is configured", () =>
   Effect.gen(function* () {
     const originalFetch = globalThis.fetch;
@@ -399,10 +348,8 @@ it.effect("CloudflareOtlp layer is disabled when no endpoint is configured", () 
 
     try {
       const handler = Worker.makeFetchHandler(Layer.empty, {
-        fetch: Effect.succeed(new Response("ok")).pipe(
-          Effect.withSpan("test.fetch"),
-          Effect.provide(CloudflareOtlp.workerLayer({ signals: ["traces"] })),
-        ),
+        eventLayer: CloudflareOtlp.workerLayer({ signals: ["traces"] }),
+        fetch: Effect.succeed(new Response("ok")).pipe(Effect.withSpan("test.fetch")),
       });
 
       const response = yield* Effect.promise(() =>
@@ -428,16 +375,12 @@ it.effect("CloudflareOtlp layer is disabled when no endpoint is configured", () 
 mapleSmokeTest("CloudflareOtlp exports Worker spans to Maple local OTLP", () =>
   Effect.gen(function* () {
     const handler = Worker.makeFetchHandler(Layer.empty, {
-      fetch: Effect.succeed(new Response("ok")).pipe(
-        Effect.withSpan("maple.fetch"),
-        Effect.provide(
-          CloudflareOtlp.workerLayer({
-            signals: ["traces"],
-            serviceName: "effect-cf-maple-smoke",
-            tracerExportInterval: "1 hour",
-          }),
-        ),
-      ),
+      eventLayer: CloudflareOtlp.workerLayer({
+        signals: ["traces"],
+        serviceName: "effect-cf-maple-smoke",
+        tracerExportInterval: "1 hour",
+      }),
+      fetch: Effect.succeed(new Response("ok")).pipe(Effect.withSpan("maple.fetch")),
     });
 
     const response = yield* Effect.promise(() =>

--- a/packages/effect-cf/tests/CloudflareOtlp.worker.test.ts
+++ b/packages/effect-cf/tests/CloudflareOtlp.worker.test.ts
@@ -11,10 +11,8 @@ const env: Cloudflare.Env = {};
 it.effect("CloudflareOtlp event instrumentation is compatible with the Workers runtime", () =>
   Effect.gen(function* () {
     const WorkerClass = Worker.make(Layer.empty, {
-      fetch: Effect.succeed(new Response("ok")).pipe(
-        Effect.withSpan("worker.fetch"),
-        Effect.provide(CloudflareOtlp.workerLayer({ signals: ["traces"] })),
-      ),
+      eventLayer: CloudflareOtlp.workerLayer({ signals: ["traces"] }),
+      fetch: Effect.succeed(new Response("ok")).pipe(Effect.withSpan("worker.fetch")),
     });
 
     const worker = new WorkerClass(createExecutionContext(), env);

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -8,6 +8,10 @@ class RenderValue extends Context.Service<RenderValue, string>()(
   "effect-cf/test/WorkerBoundary/RenderValue",
 ) {}
 
+class EventValue extends Context.Service<EventValue, string>()(
+  "effect-cf/test/WorkerBoundary/EventValue",
+) {}
+
 const makeExecutionContext = () =>
   ({
     props: undefined,
@@ -167,3 +171,61 @@ test("WorkerConfig.layerWith derives Effect config from non-scalar env bindings"
 
   await expect(response.text()).resolves.toBe("postgres://hyperdrive.test/app");
 });
+
+test("Worker eventLayer applies to fetch, queue, and RPC events", async () => {
+  const events: Array<string> = [];
+  let nextEventId = 0;
+
+  const eventLayer = Layer.effect(
+    EventValue,
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        nextEventId++;
+        events.push(`acquire:${nextEventId}`);
+        return `event:${nextEventId}`;
+      }),
+      (value) => Effect.sync(() => events.push(`release:${value}`)),
+    ),
+  );
+
+  const WorkerClass = Worker.make(Layer.empty, {
+    eventLayer,
+    fetch: Effect.gen(function* () {
+      const value = yield* EventValue;
+      return new Response(value);
+    }),
+    queue: () =>
+      Effect.gen(function* () {
+        const value = yield* EventValue;
+        events.push(`queue:${value}`);
+      }),
+    rpc: {
+      read: () => EventValue,
+    },
+  });
+  const worker = new WorkerClass(makeExecutionContext(), {} as Cloudflare.Env);
+
+  const response = await worker.fetch(new Request("https://worker.test/"));
+  await expect(response.text()).resolves.toBe("event:1");
+  await worker.queue(makeMessageBatch("events"));
+  await expect(worker.read()).resolves.toBe("event:3");
+
+  expect(events).toEqual([
+    "acquire:1",
+    "release:event:1",
+    "acquire:2",
+    "queue:event:2",
+    "release:event:2",
+    "acquire:3",
+    "release:event:3",
+  ]);
+});
+
+const makeMessageBatch = (queue: string): globalThis.MessageBatch<unknown> =>
+  ({
+    queue,
+    messages: [],
+    metadata: { metrics: { backlogCount: 0, backlogBytes: 0 } },
+    ackAll: () => undefined,
+    retryAll: () => undefined,
+  }) as globalThis.MessageBatch<unknown>;

--- a/packages/effect-cf/tests/index.test.ts
+++ b/packages/effect-cf/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Schema as S, type Scope } from "effect";
+import { Context, Effect, Layer, Option, Schema as S, type Scope } from "effect";
 import { expect, test } from "vite-plus/test";
 
 import {
@@ -22,6 +22,10 @@ const executionContext = {
 
 class TestService extends Context.Service<TestService, { readonly value: string }>()(
   "effect-cf/test/TestService",
+) {}
+
+class DurableObjectEventValue extends Context.Service<DurableObjectEventValue, string>()(
+  "effect-cf/test/DurableObjectEventValue",
 ) {}
 
 const durableObjectId = {
@@ -191,6 +195,95 @@ test("Durable Object initialize runs when the instance is constructed", async ()
   expect(calls).toEqual(["block", "initialize:counter-id"]);
 });
 
+test("Durable Object eventLayer applies to events but not initialize", async () => {
+  const events: Array<string> = [];
+  let nextEventId = 0;
+  const state = makeDurableObjectState();
+
+  const eventLayer = Layer.effect(
+    DurableObjectEventValue,
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        nextEventId++;
+        events.push(`acquire:${nextEventId}`);
+        return `event:${nextEventId}`;
+      }),
+      (value) => Effect.sync(() => events.push(`release:${value}`)),
+    ),
+  );
+
+  const Live = DurableObject.make(Layer.empty, {
+    eventLayer,
+    initialize: Effect.gen(function* () {
+      const value = yield* Effect.serviceOption(DurableObjectEventValue);
+      events.push(Option.isSome(value) ? `initialize:${value.value}` : "initialize:none");
+    }),
+    fetch: Effect.gen(function* () {
+      const value = yield* DurableObjectEventValue;
+      return new Response(value);
+    }),
+    alarms: Effect.gen(function* () {
+      const value = yield* DurableObjectEventValue;
+      events.push(`alarms:${value}`);
+    }),
+    alarm: () =>
+      Effect.gen(function* () {
+        const value = yield* DurableObjectEventValue;
+        events.push(`alarm:${value}`);
+      }),
+    webSocketMessage: () =>
+      Effect.gen(function* () {
+        const value = yield* DurableObjectEventValue;
+        events.push(`websocket:${value}`);
+      }),
+    webSocketClose: () =>
+      Effect.gen(function* () {
+        const value = yield* DurableObjectEventValue;
+        events.push(`websocket-close:${value}`);
+      }),
+    webSocketError: () =>
+      Effect.gen(function* () {
+        const value = yield* DurableObjectEventValue;
+        events.push(`websocket-error:${value}`);
+      }),
+    rpc: {
+      read: () => DurableObjectEventValue,
+    },
+  });
+
+  const object = new Live(state.raw, {} as Cloudflare.Env);
+  await Promise.all(state.waitUntilPromises);
+
+  const response = await object.fetch!(new Request("https://do.test/"));
+  await expect(response.text()).resolves.toBe("event:1");
+  await object.alarm!();
+  await object.webSocketMessage!({} as WebSocket, "hello");
+  await object.webSocketClose!({} as WebSocket, 1000, "done", true);
+  await object.webSocketError!({} as WebSocket, new Error("boom"));
+  await expect(object.read()).resolves.toBe("event:6");
+
+  expect(events).toEqual([
+    "initialize:none",
+    "acquire:1",
+    "release:event:1",
+    "acquire:2",
+    "alarms:event:2",
+    "alarm:event:2",
+    "release:event:2",
+    "acquire:3",
+    "websocket:event:3",
+    "release:event:3",
+    "acquire:4",
+    "websocket-close:event:4",
+    "release:event:4",
+    "acquire:5",
+    "websocket-error:event:5",
+    "release:event:5",
+    "acquire:6",
+    "release:event:6",
+  ]);
+});
+
 test("RPC-only Workers return a default 404 fetch response", async () => {
   const WorkerClass = Worker.make(Layer.empty, {
     rpc: {
@@ -269,6 +362,13 @@ test("Worker.Api exposes Cloudflare RPC-style pipelining types", () => {
 
     expectType<Promise<{ readonly nested: { readonly value: string } }>>(server.getNested());
     expectType<Promise<string>>(client.getNested().nested.value);
+
+    void EchoWorker.make(Layer.empty, {
+      eventLayer: Layer.succeed(DurableObjectEventValue, "event"),
+      rpc: {
+        echo: () => DurableObjectEventValue,
+      },
+    });
   };
 
   void assertTypes;
@@ -334,6 +434,15 @@ test("DurableObject preserves server, client, handler, and namespace types", () 
         expectType<DurableObjectWebSocket.DurableWebSocket>(socket);
         expectType<unknown>(error);
         return Effect.void;
+      },
+    });
+
+    void Counter.make(Layer.empty, {
+      eventLayer: Layer.succeed(DurableObjectEventValue, "event"),
+      rpc: {
+        get: () => Effect.as(DurableObjectEventValue, 1),
+        add: (amount) => Effect.as(DurableObjectEventValue, amount),
+        resource: () => DurableObjectEventValue,
       },
     });
 
@@ -555,3 +664,26 @@ test("Service binding rpc uses the shared dynamic method validation", async () =
     ),
   ).resolves.toBe("hello");
 });
+
+const makeDurableObjectState = () => {
+  const waitUntilPromises: Array<Promise<unknown>> = [];
+  const raw = {
+    id: durableObjectId,
+    storage: {} as globalThis.DurableObjectStorage,
+    waitUntil: (promise: Promise<unknown>) => {
+      waitUntilPromises.push(promise);
+    },
+    blockConcurrencyWhile: (callback: () => Promise<unknown>) => callback(),
+    acceptWebSocket() {},
+    getWebSockets: () => [],
+    setWebSocketAutoResponse() {},
+    getWebSocketAutoResponse: () => null,
+    getWebSocketAutoResponseTimestamp: () => null,
+    setHibernatableWebSocketEventTimeout() {},
+    getHibernatableWebSocketEventTimeout: () => null,
+    getTags: () => [],
+    abort() {},
+  } as unknown as globalThis.DurableObjectState;
+
+  return { raw, waitUntilPromises };
+};


### PR DESCRIPTION
## Summary

- Add generic `eventLayer` options to Worker and Durable Object entrypoints so per-event Effect layers are provided inside each event scope.
- Remove Cloudflare OTLP handler instrumentation helpers in favor of the entrypoint-owned event boundary.
- Carry the option through definition-backed APIs and add lifecycle coverage for Worker and Durable Object events.

## Validation

- `vp check`
- `vp test`
- `vp run effect-cf#build`