### PR TITLE
fix: provide epoch clock in Cloudflare runtimes

### DIFF
--- a/.changeset/cloudflare-otlp.md
+++ b/.changeset/cloudflare-otlp.md
@@ -1,0 +1,6 @@
+---
+"effect-cf": patch
+---
+
+Provide an epoch-based Effect clock in Worker and Durable Object runtimes so OTLP
+span and log timestamps are valid under Cloudflare workerd.

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -10,6 +10,7 @@ import type * as Binding from "./Binding";
 import * as DurableObjectDefinition from "./DurableObjectDefinition";
 import type * as DurableObjectNamespace from "./DurableObjectNamespace";
 import type * as Rpc from "./Rpc";
+import * as CloudflareClock from "./internal/Clock";
 import * as Entrypoint from "./internal/Entrypoint";
 
 const reservedMethodNames = new Set<string>([
@@ -161,6 +162,7 @@ export const make = <
       super(state, env);
 
       const services = Layer.mergeAll(
+        CloudflareClock.layer,
         Layer.succeed(DurableObjectState, fromDurableObjectState(state)),
         Layer.succeed(WorkerEnvironment, env),
       );

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -10,6 +10,7 @@ import type * as Rpc from "./Rpc";
 import type * as RpcDefinition from "./RpcDefinition";
 import type * as ServiceBinding from "./ServiceBinding";
 import * as WorkerDefinition from "./WorkerDefinition";
+import * as CloudflareClock from "./internal/Clock";
 import * as Entrypoint from "./internal/Entrypoint";
 import { fromExecutionContext, type RunWaitUntilEffect } from "./internal/WorkerContext";
 
@@ -241,6 +242,7 @@ export function make<
         Promise.reject(new Error("WorkerContext runtime is not initialized"));
 
       const services = Layer.mergeAll(
+        CloudflareClock.layer,
         Layer.succeed(ExecutionContext, ctx),
         ConfigProvider.layer(Effect.succeed(WorkerConfig.providerFromEnv(env))),
         Layer.succeed(

--- a/packages/effect-cf/src/internal/Clock.ts
+++ b/packages/effect-cf/src/internal/Clock.ts
@@ -1,0 +1,28 @@
+import { Clock, Duration, Effect, Layer } from "effect";
+
+const maxTimerMillis = 2 ** 31 - 1;
+const nanosPerMilli = BigInt(1_000_000);
+
+export const clock: Clock.Clock = {
+  currentTimeMillisUnsafe: () => Date.now(),
+  currentTimeMillis: Effect.sync(() => clock.currentTimeMillisUnsafe()),
+  currentTimeNanosUnsafe: () => BigInt(Date.now()) * nanosPerMilli,
+  currentTimeNanos: Effect.sync(() => clock.currentTimeNanosUnsafe()),
+  sleep: (duration) => {
+    const millis = Duration.toMillis(duration);
+    if (millis <= 0) {
+      return Effect.yieldNow;
+    }
+
+    return Effect.callback<void>((resume) => {
+      if (millis > maxTimerMillis) {
+        return;
+      }
+
+      const handle = setTimeout(() => resume(Effect.void), millis);
+      return Effect.sync(() => clearTimeout(handle));
+    });
+  },
+};
+
+export const layer = Layer.effect(Clock.Clock, Effect.succeed(clock));

--- a/packages/effect-cf/tests/CloudflareOtlp.worker.test.ts
+++ b/packages/effect-cf/tests/CloudflareOtlp.worker.test.ts
@@ -2,7 +2,7 @@
 
 import { createExecutionContext } from "cloudflare:test";
 import { expect, it } from "@effect/vitest";
-import { Effect, Layer } from "effect";
+import { Clock, Effect, Layer } from "effect";
 
 import { CloudflareOtlp, Worker } from "../src/index";
 
@@ -22,5 +22,25 @@ it.effect("CloudflareOtlp event instrumentation is compatible with the Workers r
 
     expect(response.status).toBe(200);
     yield* Effect.promise(() => expect(response.text()).resolves.toBe("ok"));
+  }),
+);
+
+it.effect("Worker handlers use epoch nanosecond timestamps in the Workers runtime", () =>
+  Effect.gen(function* () {
+    const WorkerClass = Worker.make(Layer.empty, {
+      fetch: Effect.gen(function* () {
+        const nanos = yield* Clock.currentTimeNanos;
+        return Response.json({ nanos: nanos.toString() });
+      }),
+    });
+
+    const worker = new WorkerClass(createExecutionContext(), env);
+    const response = yield* Effect.promise(() =>
+      Promise.resolve(worker.fetch(new Request("https://worker.test/clock"))),
+    );
+    const body = yield* Effect.promise(() => response.json<{ readonly nanos: string }>());
+    const minimumEpochNanos = BigInt(Date.UTC(2024, 0, 1)) * BigInt(1_000_000);
+
+    expect(BigInt(body.nanos)).toBeGreaterThan(minimumEpochNanos);
   }),
 );

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -1,4 +1,4 @@
-import { Config, ConfigProvider, Context, Effect, Layer, Stream } from "effect";
+import { Clock, Config, ConfigProvider, Context, Effect, Layer, Stream } from "effect";
 import { HttpServerResponse } from "effect/unstable/http";
 import { expect, test } from "vite-plus/test";
 
@@ -170,6 +170,29 @@ test("WorkerConfig.layerWith derives Effect config from non-scalar env bindings"
   const response = await worker.fetch(new Request("https://worker.test/"));
 
   await expect(response.text()).resolves.toBe("postgres://hyperdrive.test/app");
+});
+
+test("Worker handlers use an epoch nanosecond clock derived from wall time", async () => {
+  const originalDateNow = Date.now;
+  const fixedMillis = Date.UTC(2030, 0, 2, 3, 4, 5);
+  Date.now = () => fixedMillis;
+
+  try {
+    const WorkerClass = Worker.make(Layer.empty, {
+      fetch: Effect.gen(function* () {
+        const nanos = yield* Clock.currentTimeNanos;
+        return Response.json({ nanos: nanos.toString() });
+      }),
+    });
+    const worker = new WorkerClass(makeExecutionContext(), {} as Cloudflare.Env);
+
+    const response = await worker.fetch(new Request("https://worker.test/clock"));
+    const body = (await response.json()) as { readonly nanos: string };
+
+    expect(BigInt(body.nanos)).toBe(BigInt(fixedMillis) * BigInt(1_000_000));
+  } finally {
+    Date.now = originalDateNow;
+  }
 });
 
 test("Worker eventLayer applies to fetch, queue, and RPC events", async () => {

--- a/packages/effect-cf/tests/index.test.ts
+++ b/packages/effect-cf/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Option, Schema as S, type Scope } from "effect";
+import { Clock, Context, Effect, Layer, Option, Schema as S, type Scope } from "effect";
 import { expect, test } from "vite-plus/test";
 
 import {
@@ -282,6 +282,29 @@ test("Durable Object eventLayer applies to events but not initialize", async () 
     "acquire:6",
     "release:event:6",
   ]);
+});
+
+test("Durable Object handlers use an epoch nanosecond clock derived from wall time", async () => {
+  const originalDateNow = Date.now;
+  const fixedMillis = Date.UTC(2030, 0, 2, 3, 4, 5);
+  Date.now = () => fixedMillis;
+
+  try {
+    const Live = DurableObject.make(Layer.empty, {
+      fetch: Effect.gen(function* () {
+        const nanos = yield* Clock.currentTimeNanos;
+        return Response.json({ nanos: nanos.toString() });
+      }),
+    });
+    const object = new Live(makeDurableObjectState().raw, {} as Cloudflare.Env);
+
+    const response = await object.fetch!(new Request("https://do.test/clock"));
+    const body = (await response.json()) as { readonly nanos: string };
+
+    expect(BigInt(body.nanos)).toBe(BigInt(fixedMillis) * BigInt(1_000_000));
+  } finally {
+    Date.now = originalDateNow;
+  }
 });
 
 test("RPC-only Workers return a default 404 fetch response", async () => {


### PR DESCRIPTION
## Summary

- Provide an epoch-based Effect Clock service in Worker and Durable Object runtimes.
- Keep OTLP event-scoped instrumentation using the existing eventLayer path, but ensure spans/logs get wall-clock nanosecond timestamps under workerd.
- Add TDD coverage through public Worker.make and DurableObject.make handlers, plus a Workers-runtime timestamp smoke assertion.

## Validation

- `vp check`
- `vp test`
- `vp run effect-cf#build`