### PR TITLE
feat: simplify Cloudflare OTEL config

### DIFF
--- a/.changeset/cloudflare-otel-beta77.md
+++ b/.changeset/cloudflare-otel-beta77.md
@@ -1,0 +1,9 @@
+---
+"effect-cf": major
+---
+
+Simplify `CloudflareOtlp` around Effect's standard OTEL configuration layers from `effect@4.0.0-beta.77`.
+
+`CloudflareOtlpSettings`, `settingsConfig`, and `settingsLayer` have been removed. Configure OTLP with standard OTEL environment variables instead, including `OTEL_TRACES_EXPORTER=otlp`, `OTEL_METRICS_EXPORTER=otlp`, or `OTEL_LOGS_EXPORTER=otlp` for the signals you want to export. Resource options now live under `resource`, so `CloudflareOtlp.workerLayer({ serviceName })` becomes `CloudflareOtlp.workerLayer({ resource: { serviceName } })`. Export intervals, batch sizes, shutdown timeouts, and metrics temporality now use Effect's OTEL env support instead of effect-cf-specific layer options.
+
+Durable Object runtimes now install the Cloudflare `env` as the default Effect `ConfigProvider`, matching Worker runtime behavior.

--- a/.changeset/cloudflare-otel-beta77.md
+++ b/.changeset/cloudflare-otel-beta77.md
@@ -1,5 +1,5 @@
 ---
-"effect-cf": major
+"effect-cf": minor
 ---
 
 Simplify `CloudflareOtlp` around Effect's standard OTEL configuration layers from `effect@4.0.0-beta.77`.

--- a/bun.lock
+++ b/bun.lock
@@ -305,11 +305,11 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.10.0",
+      "version": "0.13.1",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.15.0",
         "@cloudflare/workers-types": "^4.20260421.1",
-        "@effect/platform-node": "4.0.0-beta.70",
+        "@effect/platform-node": "4.0.0-beta.77",
         "@effect/sql-d1": "catalog:",
         "@effect/sql-pg": "catalog:",
         "@effect/sql-sqlite-do": "catalog:",
@@ -320,10 +320,10 @@
         "vitest": "catalog:",
       },
       "peerDependencies": {
-        "@effect/sql-d1": "^4.0.0-beta.70",
-        "@effect/sql-pg": "^4.0.0-beta.70",
-        "@effect/sql-sqlite-do": "^4.0.0-beta.70",
-        "effect": "^4.0.0-beta.70",
+        "@effect/sql-d1": "^4.0.0-beta.77",
+        "@effect/sql-pg": "^4.0.0-beta.77",
+        "@effect/sql-sqlite-do": "^4.0.0-beta.77",
+        "effect": "^4.0.0-beta.77",
       },
       "optionalPeers": [
         "@effect/sql-pg",
@@ -331,17 +331,17 @@
     },
   },
   "overrides": {
-    "@effect/platform-node-shared": "4.0.0-beta.70",
+    "@effect/platform-node-shared": "4.0.0-beta.77",
     "vite": "catalog:",
     "vitest": "catalog:",
   },
   "catalog": {
-    "@effect/platform-bun": "4.0.0-beta.70",
-    "@effect/sql-d1": "4.0.0-beta.70",
-    "@effect/sql-pg": "4.0.0-beta.70",
-    "@effect/sql-sqlite-do": "4.0.0-beta.70",
-    "@effect/vitest": "4.0.0-beta.70",
-    "effect": "4.0.0-beta.70",
+    "@effect/platform-bun": "4.0.0-beta.77",
+    "@effect/sql-d1": "4.0.0-beta.77",
+    "@effect/sql-pg": "4.0.0-beta.77",
+    "@effect/sql-sqlite-do": "4.0.0-beta.77",
+    "@effect/vitest": "4.0.0-beta.77",
+    "effect": "4.0.0-beta.77",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.20",
     "vite-plus": "0.1.20",
     "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.20",
@@ -417,17 +417,17 @@
 
     "@effect-cf/todos-domain": ["@effect-cf/todos-domain@workspace:examples/todos/packages/domain"],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.70", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.70" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-u8fhg9RX46034Ee5s461z680LUr2A/4AKo7kWbP7rDQsLDyNyT9Z4/WlzcYl2Oo5E4fJIQmqG6cyieWFQD1Ppg=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.77", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.77" }, "peerDependencies": { "effect": "^4.0.0-beta.77" } }, "sha512-HG9CHs5pRE7O65adWMgfX+RYvmzTl2tTHB5eNtlTVmeIwYA93x1brnGmj3BvV58OSpDqX2WRCEIf+ZnwTEd19A=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.70", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.70", "mime": "^4.1.0", "undici": "^8.2.0" }, "peerDependencies": { "effect": "^4.0.0-beta.70", "ioredis": "^5.7.0" } }, "sha512-Ls1WtLaO2CbcO8jHtZRRi6eZa4YOJZ9KXm6udMvwhjV/XhqdsT6AzmcXbc1hINbKgvRcik6qM/441YEaBMYoqw=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.77", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.77", "mime": "^4.1.0", "undici": "^8.2.0" }, "peerDependencies": { "effect": "^4.0.0-beta.77", "ioredis": "^5.7.0" } }, "sha512-AIYjJTtjwkdqccyFuKDU+wVfVylBTkx62To9UVUmgwNpBKYjJNNg30r5Q8aD1Whpm01gZFp/WNceJ8hoNYSutg=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.70", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-3VXuL63IDmq13We+ApRKn2JW3Rb9g5gj1YEmfb8u2b73norur1VsIJ/pRE4qjShevg19dQYi2JsLawSZ6gApug=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.77", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.77" } }, "sha512-JHHg/UaCUJGtGNpNJdazTIM/lwztbhWbirch0+XTFohIo19b1P13GfidasiBRN/1u5AAJV4pKzgqnCTsry75rQ=="],
 
-    "@effect/sql-d1": ["@effect/sql-d1@4.0.0-beta.70", "", { "dependencies": { "@cloudflare/workers-types": "^4.20260511.1" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-86zuNS+j9BCB6BnUDkqbzdS0iRhuGw7+bDw+HqV7PgwYAw53/UspyH0Z+v2dLUP9e9LcFat9KJLVbsCGqmdDZQ=="],
+    "@effect/sql-d1": ["@effect/sql-d1@4.0.0-beta.77", "", { "dependencies": { "@cloudflare/workers-types": "^4.20260511.1" }, "peerDependencies": { "effect": "^4.0.0-beta.77" } }, "sha512-ElNIRV87j+LTbba63QKikcZeFbuh11Q/7c18/aqn64lPuRex98SLYsNc4H5YDtexzQFRIbm57oCO/QQTlDKXwg=="],
 
-    "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.70", "", { "dependencies": { "pg": "^8.20.0", "pg-connection-string": "2.12.0", "pg-cursor": "^2.19.0", "pg-pool": "^3.13.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-l1ToDca5mNLp3wB/dyDIGGKxW1BExnSmyzvZV29upzCzY7kbz8UlFqMGeWBIUYo4pUvYfZMANokQWDMIFs4PEQ=="],
+    "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.77", "", { "dependencies": { "pg": "^8.20.0", "pg-connection-string": "2.12.0", "pg-cursor": "^2.19.0", "pg-pool": "^3.13.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.77" } }, "sha512-dHolqQ9mzeiQ4HBEafdkXqeoT10OcDej4CaiIwkLQa7GuuUPYn0dOvoRtiOGIQ3byGad+M54Lw+snmG/Zhck5A=="],
 
-    "@effect/sql-sqlite-do": ["@effect/sql-sqlite-do@4.0.0-beta.70", "", { "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-BM9EjDDbTPoJ+almrR8s8mIMq8ZSgn0VAXfkovHUZ0ti3/XJM/HRXE0vK3iZ5J9MLfGq26kd+9ooBkMcqWkkPw=="],
+    "@effect/sql-sqlite-do": ["@effect/sql-sqlite-do@4.0.0-beta.77", "", { "peerDependencies": { "effect": "^4.0.0-beta.77" } }, "sha512-SIZWWW+sMcnx/Ugvz/Jml0oFzId0YBnX6DKR6MVTMZN7fQRyu3DRZiXtoeW6wbh99OUQk7wmFCYrN8inG06R2Q=="],
 
     "@effect/tsgo": ["@effect/tsgo@0.5.1", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.5.1", "@effect/tsgo-darwin-x64": "0.5.1", "@effect/tsgo-linux-arm": "0.5.1", "@effect/tsgo-linux-arm64": "0.5.1", "@effect/tsgo-linux-x64": "0.5.1", "@effect/tsgo-win32-arm64": "0.5.1", "@effect/tsgo-win32-x64": "0.5.1" }, "bin": { "effect-tsgo": "dist/effect-tsgo.js" } }, "sha512-INANZ/NK9akOwSQVWpQgSDLjlegrs4gui21nuQsgN7zCjCmj4m/ixUDuVgtW2C0UfqhPWWabyFWCDntu7ryCZQ=="],
 
@@ -445,7 +445,7 @@
 
     "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-dfyXhmVQkxncSnujjSXsOMwzqFIBNDViXiD3Uj9DPDNLSxyg0ybBNxYJTpvJhqHxqseA9wE2aCIMu/pfpac+0Q=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.70", "", { "peerDependencies": { "effect": "^4.0.0-beta.70", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-XDteNN0xfOgoMauAVoN5iylxVgEjp7kFsGFq18tZ5XYjek0eOZa0nOoes5s7Bs71VvwjnCeCbFMD7IhxswEt8A=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.77", "", { "peerDependencies": { "effect": "^4.0.0-beta.77", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-47zGyckxRD1VqpP+YHpouOjRObK9EtTdO4tsBdQl3GKWv3uYnK2fBqUYmEnBRcVczyMzva96x+fJnd2yOnnhQQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
@@ -805,7 +805,7 @@
 
     "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
 
-    "effect": ["effect@4.0.0-beta.70", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg=="],
+    "effect": ["effect@4.0.0-beta.77", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-10+9eR8v3whrsS1o05zSPsmo0bNN/gjEvFKngF9/yS8ppM5f25Hs7wbfKXTtOrPpY5mdDvhx3rn7Ehvxb/HKbQ=="],
 
     "effect-cf": ["effect-cf@workspace:packages/effect-cf"],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "wrangler": "^4.93.1"
   },
   "overrides": {
-    "@effect/platform-node-shared": "4.0.0-beta.70",
+    "@effect/platform-node-shared": "4.0.0-beta.77",
     "vite": "catalog:",
     "vitest": "catalog:"
   },
@@ -62,12 +62,12 @@
   },
   "packageManager": "bun@1.3.13",
   "catalog": {
-    "@effect/platform-bun": "4.0.0-beta.70",
-    "@effect/sql-d1": "4.0.0-beta.70",
-    "@effect/sql-pg": "4.0.0-beta.70",
-    "@effect/sql-sqlite-do": "4.0.0-beta.70",
-    "@effect/vitest": "4.0.0-beta.70",
-    "effect": "4.0.0-beta.70",
+    "@effect/platform-bun": "4.0.0-beta.77",
+    "@effect/sql-d1": "4.0.0-beta.77",
+    "@effect/sql-pg": "4.0.0-beta.77",
+    "@effect/sql-sqlite-do": "4.0.0-beta.77",
+    "@effect/vitest": "4.0.0-beta.77",
+    "effect": "4.0.0-beta.77",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.20",
     "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.20",
     "vite-plus": "0.1.20"

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.15.0",
     "@cloudflare/workers-types": "^4.20260421.1",
-    "@effect/platform-node": "4.0.0-beta.70",
+    "@effect/platform-node": "4.0.0-beta.77",
     "@effect/sql-d1": "catalog:",
     "@effect/sql-pg": "catalog:",
     "@effect/sql-sqlite-do": "catalog:",
@@ -52,10 +52,10 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@effect/sql-d1": "^4.0.0-beta.70",
-    "@effect/sql-pg": "^4.0.0-beta.70",
-    "@effect/sql-sqlite-do": "^4.0.0-beta.70",
-    "effect": "^4.0.0-beta.70"
+    "@effect/sql-d1": "^4.0.0-beta.77",
+    "@effect/sql-pg": "^4.0.0-beta.77",
+    "@effect/sql-sqlite-do": "^4.0.0-beta.77",
+    "effect": "^4.0.0-beta.77"
   },
   "peerDependenciesMeta": {
     "@effect/sql-pg": {

--- a/packages/effect-cf/src/CloudflareOtlp.ts
+++ b/packages/effect-cf/src/CloudflareOtlp.ts
@@ -1,9 +1,7 @@
-import { Config, ConfigProvider, Context, Effect, Layer, Option, Schema } from "effect";
-import type * as Duration from "effect/Duration";
+import { ConfigProvider, Effect, Layer, Option } from "effect";
 import type * as Tracer from "effect/Tracer";
 import { FetchHttpClient, type Headers } from "effect/unstable/http";
 import {
-  Otlp,
   OtlpLogger,
   OtlpMetrics,
   OtlpSerialization,
@@ -19,122 +17,52 @@ export type Signal = "logs" | "traces" | "metrics";
 /** OTLP payload serialization used by the Effect OTLP exporters. */
 export type Serialization = "json" | "protobuf";
 
-/**
- * Resolved OpenTelemetry settings used by the Cloudflare OTLP layers.
- *
- * The default {@link settingsLayer} reads the standard OpenTelemetry
- * environment variable names from `WorkerEnvironment`. Applications that use
- * different binding names can provide {@link CloudflareOtlpSettings} directly
- * with a custom layer.
- */
-export interface Settings {
-  /** Generic OTLP base endpoint, read from `OTEL_EXPORTER_OTLP_ENDPOINT`. */
-  readonly endpoint: Option.Option<string>;
-  /** Logs-specific OTLP endpoint, read from `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`. */
-  readonly logsEndpoint: Option.Option<string>;
-  /** Traces-specific OTLP endpoint, read from `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. */
-  readonly tracesEndpoint: Option.Option<string>;
-  /** Metrics-specific OTLP endpoint, read from `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`. */
-  readonly metricsEndpoint: Option.Option<string>;
-  /** Comma-separated OTLP headers, read from `OTEL_EXPORTER_OTLP_HEADERS`. */
-  readonly headers: Option.Option<string>;
-  /** Logs-specific OTLP headers, read from `OTEL_EXPORTER_OTLP_LOGS_HEADERS`. */
-  readonly logsHeaders: Option.Option<string>;
-  /** Traces-specific OTLP headers, read from `OTEL_EXPORTER_OTLP_TRACES_HEADERS`. */
-  readonly tracesHeaders: Option.Option<string>;
-  /** Metrics-specific OTLP headers, read from `OTEL_EXPORTER_OTLP_METRICS_HEADERS`. */
-  readonly metricsHeaders: Option.Option<string>;
-  /** Service name, read from `OTEL_SERVICE_NAME`. */
-  readonly serviceName: Option.Option<string>;
-  /** Service version, read from the effect-cf convenience alias `OTEL_SERVICE_VERSION`. */
-  readonly serviceVersion: Option.Option<string>;
-  /** Resource attributes, read from `OTEL_RESOURCE_ATTRIBUTES`. */
-  readonly resourceAttributes: Option.Option<Record<string, string>>;
-}
-
-/**
- * Supported OpenTelemetry environment configuration for Cloudflare OTLP export.
- *
- * This config intentionally uses the conventional `OTEL_*` variable names so
- * deployments can share the same settings used by other OpenTelemetry SDKs.
- * It covers the OTLP HTTP settings supported by the Effect OTLP layers:
- *
- * - `OTEL_EXPORTER_OTLP_ENDPOINT`
- * - `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`
- * - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
- * - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
- * - `OTEL_EXPORTER_OTLP_HEADERS`
- * - `OTEL_EXPORTER_OTLP_LOGS_HEADERS`
- * - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`
- * - `OTEL_EXPORTER_OTLP_METRICS_HEADERS`
- * - `OTEL_SERVICE_NAME`
- * - `OTEL_RESOURCE_ATTRIBUTES`
- *
- * `OTEL_SERVICE_VERSION` is also accepted as an effect-cf convenience alias.
- * The standard OpenTelemetry way to configure service version is
- * `OTEL_RESOURCE_ATTRIBUTES=service.version=...`.
- *
- * Consumers with non-standard binding names should map those names into
- * {@link CloudflareOtlpSettings} rather than changing this config globally.
- */
-export const settingsConfig = Config.all({
-  endpoint: Config.string("OTEL_EXPORTER_OTLP_ENDPOINT").pipe(Config.option),
-  logsEndpoint: Config.string("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT").pipe(Config.option),
-  tracesEndpoint: Config.string("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT").pipe(Config.option),
-  metricsEndpoint: Config.string("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT").pipe(Config.option),
-  headers: Config.string("OTEL_EXPORTER_OTLP_HEADERS").pipe(Config.option),
-  logsHeaders: Config.string("OTEL_EXPORTER_OTLP_LOGS_HEADERS").pipe(Config.option),
-  tracesHeaders: Config.string("OTEL_EXPORTER_OTLP_TRACES_HEADERS").pipe(Config.option),
-  metricsHeaders: Config.string("OTEL_EXPORTER_OTLP_METRICS_HEADERS").pipe(Config.option),
-  serviceName: Config.string("OTEL_SERVICE_NAME").pipe(Config.option),
-  serviceVersion: Config.string("OTEL_SERVICE_VERSION").pipe(Config.option),
-  resourceAttributes: Config.schema(
-    Config.Record(Schema.String, Schema.String),
-    "OTEL_RESOURCE_ATTRIBUTES",
-  ).pipe(Config.option),
-});
-
-/**
- * Service carrying already-resolved Cloudflare OTLP settings.
- *
- * Provide this service directly when an application needs to map custom
- * Cloudflare binding names, compute settings dynamically, or override settings
- * in tests. When this service is present, the OTLP layers use it instead of
- * reading {@link settingsConfig}.
- *
- * @example
- * ```ts
- * const CustomOtlpSettings = Layer.effect(
- *   CloudflareOtlp.CloudflareOtlpSettings,
- *   Config.all({
- *     ...CloudflareOtlp.settingsConfig,
- *     endpoint: Config.string("MY_OTLP_ENDPOINT").pipe(Config.option),
- *   }),
- * ).pipe(Layer.provide(WorkerConfig.layer));
- * ```
- */
-export class CloudflareOtlpSettings extends Context.Service<CloudflareOtlpSettings, Settings>()(
-  "effect-cf/CloudflareOtlpSettings",
-) {}
-
 /** Resource metadata shared by Worker and Durable Object OTLP layers. */
 export interface ResourceOptions {
-  /** Explicit service name. Overrides `OTEL_SERVICE_NAME` when provided. */
+  /** Explicit service name. OTEL resource environment variables take precedence. */
   readonly serviceName?: string;
-  /** Explicit service version. Overrides `OTEL_SERVICE_VERSION` when provided. */
+  /** Explicit service version. OTEL resource environment variables take precedence. */
   readonly serviceVersion?: string;
-  /** Additional resource attributes attached to all exported telemetry. */
+  /** Additional resource attributes attached to exported telemetry. */
   readonly attributes?: Record<string, unknown>;
 }
 
+/** Options shared by all Cloudflare OTLP telemetry layers. */
+export interface LayerOptions {
+  /**
+   * Telemetry signals to export. Defaults to logs, traces, and metrics.
+   *
+   * Each selected signal is still controlled by standard OTEL exporter config,
+   * such as `OTEL_TRACES_EXPORTER=otlp`.
+   */
+  readonly signals?: ReadonlyArray<Signal>;
+  /** OTLP payload serialization. Defaults to protobuf. */
+  readonly serialization?: Serialization;
+  /** Resource metadata forwarded to Effect's OTLP resource resolver. */
+  readonly resource?: ResourceOptions;
+  /**
+   * Explicit headers for every selected signal.
+   *
+   * When omitted, Effect reads `OTEL_EXPORTER_OTLP_HEADERS` and the
+   * signal-specific `OTEL_EXPORTER_OTLP_*_HEADERS` variables.
+   */
+  readonly headers?: Headers.Input;
+  /** Exclude log records emitted for spans when exporting logs. */
+  readonly loggerExcludeLogSpans?: boolean;
+  /** Merge the OTLP logger with existing loggers instead of replacing them. */
+  readonly loggerMergeWithExisting?: boolean;
+  /** Custom trace context lookup used by the Effect OTLP tracer. */
+  readonly tracerContext?: <X>(primitive: Tracer.EffectPrimitive<X>, span: Tracer.AnySpan) => X;
+}
+
 /** Resource metadata specific to Cloudflare Workers. */
-export interface WorkerResourceOptions extends ResourceOptions {
+export interface WorkerLayerOptions extends LayerOptions {
   /** Cloudflare Worker name to attach as `cloudflare.worker.name`. */
   readonly workerName?: string;
 }
 
 /** Resource metadata specific to Cloudflare Durable Objects. */
-export interface DurableObjectResourceOptions extends ResourceOptions {
+export interface DurableObjectLayerOptions extends LayerOptions {
   /** Durable Object class name to attach as `cloudflare.durable_object.class`. */
   readonly className?: string;
   /**
@@ -145,76 +73,15 @@ export interface DurableObjectResourceOptions extends ResourceOptions {
   readonly includeObjectId?: boolean;
 }
 
-/** Options shared by all Cloudflare OTLP telemetry layers. */
-export interface LayerOptions extends ResourceOptions {
-  /** Telemetry signals to export. Defaults to logs, traces, and metrics. */
-  readonly signals?: ReadonlyArray<Signal>;
-  /** OTLP payload serialization. Defaults to protobuf. */
-  readonly serialization?: Serialization;
-  /** Maximum batch size for log and trace exporters. */
-  readonly maxBatchSize?: number;
-  /** Maximum time to wait for exporter shutdown/flush when a scope closes. */
-  readonly shutdownTimeout?: Duration.Input;
-  /** Export interval for the logs exporter. */
-  readonly loggerExportInterval?: Duration.Input;
-  /** Exclude log records emitted for spans when exporting logs. */
-  readonly loggerExcludeLogSpans?: boolean;
-  /** Merge the OTLP logger with existing loggers instead of replacing them. */
-  readonly loggerMergeWithExisting?: boolean;
-  /** Export interval for the traces exporter. */
-  readonly tracerExportInterval?: Duration.Input;
-  /** Custom trace context lookup used by the Effect OTLP tracer. */
-  readonly tracerContext?: <X>(primitive: Tracer.EffectPrimitive<X>, span: Tracer.AnySpan) => X;
-  /** Export interval for the metrics exporter. */
-  readonly metricsExportInterval?: Duration.Input;
-  /** Aggregation temporality for exported metrics. */
-  readonly metricsTemporality?: OtlpMetrics.AggregationTemporality;
-}
-
 const allSignals: ReadonlyArray<Signal> = ["logs", "traces", "metrics"];
 
-const optionToUndefined = <A>(option: Option.Option<A>): A | undefined =>
-  Option.isSome(option) ? option.value : undefined;
+const emptyConfigProvider = ConfigProvider.fromUnknown({});
 
-const nonEmptyStringOption = (option: Option.Option<string>): Option.Option<string> =>
-  Option.flatMap(option, (value) => {
-    const trimmed = value.trim();
-    return trimmed === "" ? Option.none() : Option.some(trimmed);
-  });
-
-const nonEmptyRecordOption = (
-  option: Option.Option<Record<string, string>>,
-): Option.Option<Record<string, string>> =>
-  Option.filter(option, (value) => Object.keys(value).length > 0);
-
-const normalizeSettings = (settings: Settings): Settings => ({
-  endpoint: nonEmptyStringOption(settings.endpoint),
-  logsEndpoint: nonEmptyStringOption(settings.logsEndpoint),
-  tracesEndpoint: nonEmptyStringOption(settings.tracesEndpoint),
-  metricsEndpoint: nonEmptyStringOption(settings.metricsEndpoint),
-  headers: nonEmptyStringOption(settings.headers),
-  logsHeaders: nonEmptyStringOption(settings.logsHeaders),
-  tracesHeaders: nonEmptyStringOption(settings.tracesHeaders),
-  metricsHeaders: nonEmptyStringOption(settings.metricsHeaders),
-  serviceName: nonEmptyStringOption(settings.serviceName),
-  serviceVersion: nonEmptyStringOption(settings.serviceVersion),
-  resourceAttributes: nonEmptyRecordOption(settings.resourceAttributes),
-});
-
-/**
- * Layer that reads standard OpenTelemetry settings from the current Cloudflare
- * `env` object.
- *
- * The layer depends on {@link WorkerEnvironment} and installs a
- * Cloudflare-backed Effect `ConfigProvider`, so `settingsConfig` reads from
- * Worker vars/secrets instead of Node process environment variables.
- */
-export const settingsLayer: Layer.Layer<
-  CloudflareOtlpSettings,
-  Config.ConfigError,
-  WorkerEnvironment
-> = Layer.effect(CloudflareOtlpSettings, settingsConfig.pipe(Config.map(normalizeSettings))).pipe(
-  Layer.provide(WorkerConfig.layer),
+const cloudflareConfigProviderLayer = ConfigProvider.layerAdd(
+  Effect.map(Effect.serviceOption(WorkerEnvironment), (env) =>
+    Option.isSome(env) ? WorkerConfig.providerFromEnv(env.value) : emptyConfigProvider,
+  ),
+  { asPrimary: true },
 );
 
 const selectedSignals = (signals: ReadonlyArray<Signal> | undefined): ReadonlySet<Signal> =>
@@ -230,109 +97,24 @@ const withDefinedAttributes = (attributes: Record<string, unknown>): Record<stri
   return out;
 };
 
-const parseHeaders = (input: Option.Option<string>): Record<string, string> | undefined => {
-  if (Option.isNone(input) || input.value.trim() === "") {
-    return undefined;
-  }
-
-  const headers: Record<string, string> = {};
-  for (const part of input.value.split(",")) {
-    const index = part.indexOf("=");
-    if (index <= 0) {
-      continue;
-    }
-
-    const key = part.slice(0, index).trim();
-    const value = part.slice(index + 1).trim();
-    if (key !== "") {
-      headers[decodeHeaderComponent(key)] = decodeHeaderComponent(value);
-    }
-  }
-
-  return headers;
-};
-
-const mergeHeaders = (
-  common: Option.Option<string>,
-  signalSpecific: Option.Option<string>,
-): Headers.Input | undefined => {
-  const commonHeaders = parseHeaders(common);
-  const signalHeaders = parseHeaders(signalSpecific);
-  if (commonHeaders === undefined && signalHeaders === undefined) {
-    return undefined;
-  }
-
-  return {
-    ...commonHeaders,
-    ...signalHeaders,
-  };
-};
-
-const decodeHeaderComponent = (value: string): string => {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-};
-
-const appendOtlpPath = (baseUrl: string, path: "/v1/logs" | "/v1/traces" | "/v1/metrics") =>
-  `${baseUrl.replace(/\/+$/, "")}${path}`;
-
 const makeResource = (
-  settings: Settings,
   options: LayerOptions,
   runtimeAttributes: Record<string, unknown>,
-) => ({
-  serviceName: options.serviceName ?? optionToUndefined(settings.serviceName),
-  serviceVersion: options.serviceVersion ?? optionToUndefined(settings.serviceVersion),
+): ResourceOptions => ({
+  serviceName: options.resource?.serviceName,
+  serviceVersion: options.resource?.serviceVersion,
   attributes: {
-    ...optionToUndefined(settings.resourceAttributes),
     ...withDefinedAttributes(runtimeAttributes),
-    ...options.attributes,
+    ...options.resource?.attributes,
   },
-});
-
-const commonOtlpOptions = (
-  settings: Settings,
-  options: LayerOptions,
-  runtimeAttributes: Record<string, unknown>,
-) => ({
-  resource: makeResource(settings, options, runtimeAttributes),
-  maxBatchSize: options.maxBatchSize,
-  loggerExportInterval: options.loggerExportInterval,
-  loggerExcludeLogSpans: options.loggerExcludeLogSpans,
-  loggerMergeWithExisting: options.loggerMergeWithExisting,
-  tracerExportInterval: options.tracerExportInterval,
-  tracerContext: options.tracerContext,
-  metricsExportInterval: options.metricsExportInterval,
-  metricsTemporality: options.metricsTemporality,
-  shutdownTimeout: options.shutdownTimeout,
 });
 
 const serializationLayer = (serialization: Serialization | undefined) =>
   serialization === "json" ? OtlpSerialization.layerJson : OtlpSerialization.layerProtobuf;
 
-const resolveSettings: Effect.Effect<Settings, Config.ConfigError> = Effect.gen(function* () {
-  const settings = yield* Effect.serviceOption(CloudflareOtlpSettings);
-  if (Option.isSome(settings)) {
-    return normalizeSettings(settings.value);
-  }
+type SignalLayer = ReturnType<typeof OtlpLogger.layerFromConfig>;
 
-  const env = yield* Effect.serviceOption(WorkerEnvironment);
-  if (Option.isSome(env)) {
-    const settings = yield* settingsConfig.pipe(
-      Effect.provide(ConfigProvider.layer(Effect.succeed(WorkerConfig.providerFromEnv(env.value)))),
-    );
-    return normalizeSettings(settings);
-  }
-
-  return normalizeSettings(yield* settingsConfig);
-});
-
-const mergeSignalLayers = (
-  layers: ReadonlyArray<Layer.Layer<never, never, never>>,
-): Layer.Layer<never, never, never> => {
+const mergeSignalLayers = (layers: ReadonlyArray<SignalLayer>): SignalLayer => {
   if (layers.length === 0) {
     return Layer.empty;
   }
@@ -344,136 +126,58 @@ const mergeSignalLayers = (
   return merged;
 };
 
-const emptyLayer: Layer.Layer<never, never, never> = Layer.empty;
-
-const makeLayerFromSettings = (
-  options: LayerOptions = {},
-  runtimeAttributes: Record<string, unknown> = {},
-): Layer.Layer<never, never, never> =>
-  Layer.unwrap(
-    Effect.map(resolveSettings, (settings) => {
-      const signals = selectedSignals(options.signals);
-      const endpoint = optionToUndefined(settings.endpoint);
-      const logsEndpoint = optionToUndefined(settings.logsEndpoint);
-      const tracesEndpoint = optionToUndefined(settings.tracesEndpoint);
-      const metricsEndpoint = optionToUndefined(settings.metricsEndpoint);
-      const hasSpecificEndpoint =
-        logsEndpoint !== undefined || tracesEndpoint !== undefined || metricsEndpoint !== undefined;
-      const hasSpecificHeaders =
-        Option.isSome(settings.logsHeaders) ||
-        Option.isSome(settings.tracesHeaders) ||
-        Option.isSome(settings.metricsHeaders);
-      const common = commonOtlpOptions(settings, options, runtimeAttributes);
-
-      if (
-        endpoint !== undefined &&
-        !hasSpecificEndpoint &&
-        !hasSpecificHeaders &&
-        signals.size === 3
-      ) {
-        return Otlp.layer({
-          baseUrl: endpoint,
-          headers: parseHeaders(settings.headers),
-          ...common,
-        }).pipe(
-          Layer.provide(serializationLayer(options.serialization)),
-          Layer.provide(FetchHttpClient.layer),
-        );
-      }
-
-      const layers: Array<Layer.Layer<never, never, never>> = [];
-      if (signals.has("logs")) {
-        const url =
-          logsEndpoint ??
-          (endpoint === undefined ? undefined : appendOtlpPath(endpoint, "/v1/logs"));
-        if (url !== undefined) {
-          layers.push(
-            OtlpLogger.layer({
-              url,
-              resource: common.resource,
-              headers: mergeHeaders(settings.headers, settings.logsHeaders),
-              exportInterval: common.loggerExportInterval,
-              maxBatchSize: common.maxBatchSize,
-              shutdownTimeout: common.shutdownTimeout,
-              excludeLogSpans: common.loggerExcludeLogSpans,
-              mergeWithExisting: common.loggerMergeWithExisting,
-            }).pipe(
-              Layer.provide(serializationLayer(options.serialization)),
-              Layer.provide(FetchHttpClient.layer),
-            ),
-          );
-        }
-      }
-
-      if (signals.has("traces")) {
-        const url =
-          tracesEndpoint ??
-          (endpoint === undefined ? undefined : appendOtlpPath(endpoint, "/v1/traces"));
-        if (url !== undefined) {
-          layers.push(
-            OtlpTracer.layer({
-              url,
-              resource: common.resource,
-              headers: mergeHeaders(settings.headers, settings.tracesHeaders),
-              exportInterval: common.tracerExportInterval,
-              maxBatchSize: common.maxBatchSize,
-              context: common.tracerContext,
-              shutdownTimeout: common.shutdownTimeout,
-            }).pipe(
-              Layer.provide(serializationLayer(options.serialization)),
-              Layer.provide(FetchHttpClient.layer),
-            ),
-          );
-        }
-      }
-
-      if (signals.has("metrics")) {
-        const url =
-          metricsEndpoint ??
-          (endpoint === undefined ? undefined : appendOtlpPath(endpoint, "/v1/metrics"));
-        if (url !== undefined) {
-          layers.push(
-            OtlpMetrics.layer({
-              url,
-              resource: common.resource,
-              headers: mergeHeaders(settings.headers, settings.metricsHeaders),
-              exportInterval: common.metricsExportInterval,
-              shutdownTimeout: common.shutdownTimeout,
-              temporality: common.metricsTemporality,
-            }).pipe(
-              Layer.provide(serializationLayer(options.serialization)),
-              Layer.provide(FetchHttpClient.layer),
-            ),
-          );
-        }
-      }
-
-      return mergeSignalLayers(layers);
-    }).pipe(
-      Effect.catch((error: Config.ConfigError) =>
-        Effect.logWarning("CloudflareOtlp disabled because OTLP configuration is invalid", {
-          error: String(error),
-        }).pipe(Effect.as(emptyLayer)),
-      ),
-    ),
-  );
-
 const makeLayer = (
   options: LayerOptions = {},
   runtimeAttributes: Record<string, unknown> = {},
-): Layer.Layer<never, never, never> => makeLayerFromSettings(options, runtimeAttributes);
+): Layer.Layer<never, never, never> => {
+  const signals = selectedSignals(options.signals);
+  const resource = makeResource(options, runtimeAttributes);
+  const layers: Array<SignalLayer> = [];
+
+  if (signals.has("logs")) {
+    layers.push(
+      OtlpLogger.layerFromConfig({
+        resource,
+        headers: options.headers,
+        excludeLogSpans: options.loggerExcludeLogSpans,
+        mergeWithExisting: options.loggerMergeWithExisting,
+      }),
+    );
+  }
+
+  if (signals.has("traces")) {
+    layers.push(
+      OtlpTracer.layerFromConfig({
+        resource,
+        headers: options.headers,
+        context: options.tracerContext,
+      }),
+    );
+  }
+
+  if (signals.has("metrics")) {
+    layers.push(
+      OtlpMetrics.layerFromConfig({
+        resource,
+        headers: options.headers,
+      }),
+    );
+  }
+
+  return mergeSignalLayers(layers).pipe(
+    Layer.provide(cloudflareConfigProviderLayer),
+    Layer.provide(serializationLayer(options.serialization)),
+    Layer.provide(FetchHttpClient.layer),
+  );
+};
 
 /**
  * Base OTLP telemetry layer for Cloudflare-compatible runtimes.
  *
- * The layer reads {@link CloudflareOtlpSettings} when provided. Otherwise it
- * reads standard OpenTelemetry config from `WorkerEnvironment` when available,
- * then falls back to the ambient Effect `ConfigProvider`.
- *
- * When only `OTEL_EXPORTER_OTLP_ENDPOINT` is configured, per-signal paths are
- * derived by appending `/v1/logs`, `/v1/traces`, and `/v1/metrics`. Signal
- * specific endpoints are used as-is, matching the OpenTelemetry OTLP exporter
- * convention.
+ * Standard OpenTelemetry environment variables are resolved by Effect's OTLP
+ * layers. In Cloudflare Workers and Durable Objects, the current `env` object is
+ * installed as the primary `ConfigProvider`; outside Cloudflare, the ambient
+ * Effect `ConfigProvider` remains the fallback.
  */
 export const layer = (options: LayerOptions = {}) => makeLayer(options);
 
@@ -491,7 +195,7 @@ export const layerProtobuf = (options: Omit<LayerOptions, "serialization"> = {})
  * Provide this layer at runtime scope for long-lived metrics aggregation, or at
  * handler scope when traces/logs should flush as the Cloudflare event finishes.
  */
-export const workerLayer = (options: LayerOptions & WorkerResourceOptions = {}) =>
+export const workerLayer = (options: WorkerLayerOptions = {}) =>
   makeLayer(options, {
     "cloudflare.resource_type": "worker",
     "cloudflare.worker.name": options.workerName,
@@ -504,7 +208,7 @@ export const workerLayer = (options: LayerOptions & WorkerResourceOptions = {}) 
  * Durable Object id. Prefer leaving `includeObjectId` disabled unless the
  * backend can tolerate high-cardinality resource attributes.
  */
-export const durableObjectLayer = (options: LayerOptions & DurableObjectResourceOptions = {}) =>
+export const durableObjectLayer = (options: DurableObjectLayerOptions = {}) =>
   Layer.unwrap(
     Effect.map(DurableObjectState, (state) =>
       makeLayer(options, {

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -1,9 +1,9 @@
 import { DurableObject as CloudflareDurableObject } from "cloudflare:workers";
-import { Effect, Layer, ManagedRuntime, type Context, type Scope } from "effect";
+import { ConfigProvider, Effect, Layer, ManagedRuntime, type Context, type Scope } from "effect";
 import type { Schema as S } from "effect";
 
 import { NativeRequest } from "./Worker";
-import { WorkerEnvironment, type WorkerEnv } from "./Environment";
+import { WorkerConfig, WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { DurableObjectState, fromDurableObjectState } from "./DurableObjectState";
 import { fromWebSocket, type DurableWebSocket } from "./DurableObjectWebSocket";
 import type * as Binding from "./Binding";
@@ -163,6 +163,7 @@ export const make = <
 
       const services = Layer.mergeAll(
         CloudflareClock.layer,
+        ConfigProvider.layer(Effect.succeed(WorkerConfig.providerFromEnv(env))),
         Layer.succeed(DurableObjectState, fromDurableObjectState(state)),
         Layer.succeed(WorkerEnvironment, env),
       );

--- a/packages/effect-cf/tests/CloudflareOtlp.test.ts
+++ b/packages/effect-cf/tests/CloudflareOtlp.test.ts
@@ -1,10 +1,10 @@
 import { NodeHttpServer } from "@effect/platform-node";
 import { expect, it, layer } from "@effect/vitest";
-import { Context, Effect, Layer, Option, Queue } from "effect";
+import { ConfigProvider, Context, Effect, Layer, Queue } from "effect";
 import { HttpServer, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import process from "node:process";
 
-import { CloudflareOtlp, Worker, WorkerEnvironment } from "../src/index";
+import { CloudflareOtlp, Worker } from "../src/index";
 
 const makeExecutionContext = (): globalThis.ExecutionContext => ({
   props: undefined,
@@ -17,23 +17,6 @@ const processEnv = process.env;
 const mapleSmokeTest = processEnv?.MAPLE_OTLP_SMOKE === "1" ? it.effect : it.effect.skip;
 
 const makeEnv = (env: Record<string, string> = {}): Cloudflare.Env => env;
-
-const makeSettings = (
-  settings: Partial<CloudflareOtlp.Settings> = {},
-): CloudflareOtlp.Settings => ({
-  endpoint: Option.none(),
-  logsEndpoint: Option.none(),
-  tracesEndpoint: Option.none(),
-  metricsEndpoint: Option.none(),
-  headers: Option.none(),
-  logsHeaders: Option.none(),
-  tracesHeaders: Option.none(),
-  metricsHeaders: Option.none(),
-  serviceName: Option.none(),
-  serviceVersion: Option.none(),
-  resourceAttributes: Option.none(),
-  ...settings,
-});
 
 const getTcpPort = (address: HttpServer.Address): number => {
   if (address._tag === "TcpAddress") {
@@ -148,69 +131,33 @@ class OtlpCollector extends Context.Service<
   ).pipe(Layer.provide(NodeHttpServer.layerTest));
 }
 
-it.effect("CloudflareOtlp settings read standard OTEL config from WorkerEnvironment", () =>
-  Effect.gen(function* () {
-    const env = makeEnv({
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:4318",
-      OTEL_SERVICE_NAME: "effect-cf-test",
-    });
-
-    const settings = yield* CloudflareOtlp.CloudflareOtlpSettings.pipe(
-      Effect.provide(CloudflareOtlp.settingsLayer),
-      Effect.provide(Layer.succeed(WorkerEnvironment, env)),
-    );
-
-    expect(Option.getOrUndefined(settings.endpoint)).toBe("http://127.0.0.1:4318");
-    expect(Option.getOrUndefined(settings.serviceName)).toBe("effect-cf-test");
-  }),
-);
-
-it.effect("CloudflareOtlp settings treat empty OTEL env values as unset", () =>
-  Effect.gen(function* () {
-    const env = makeEnv({
-      OTEL_EXPORTER_OTLP_ENDPOINT: "",
-      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: " ",
-      OTEL_EXPORTER_OTLP_HEADERS: "",
-      OTEL_EXPORTER_OTLP_TRACES_HEADERS: " ",
-      OTEL_SERVICE_NAME: "",
-      OTEL_SERVICE_VERSION: " ",
-      OTEL_RESOURCE_ATTRIBUTES: "",
-    });
-
-    const settings = yield* CloudflareOtlp.CloudflareOtlpSettings.pipe(
-      Effect.provide(CloudflareOtlp.settingsLayer),
-      Effect.provide(Layer.succeed(WorkerEnvironment, env)),
-    );
-
-    expect(Option.isNone(settings.endpoint)).toBe(true);
-    expect(Option.isNone(settings.tracesEndpoint)).toBe(true);
-    expect(Option.isNone(settings.headers)).toBe(true);
-    expect(Option.isNone(settings.tracesHeaders)).toBe(true);
-    expect(Option.isNone(settings.serviceName)).toBe(true);
-    expect(Option.isNone(settings.serviceVersion)).toBe(true);
-    expect(Option.isNone(settings.resourceAttributes)).toBe(true);
-  }),
-);
-
 layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
-  it.effect("accepts direct settings service overrides", () =>
+  it.effect("reads standard OTEL config from the ambient ConfigProvider", () =>
     Effect.gen(function* () {
       const collector = yield* OtlpCollector;
-      const settings = makeSettings({
-        tracesEndpoint: Option.some(`${collector.endpoint}/v1/traces`),
-        serviceName: Option.some("direct-settings-service"),
-      });
 
       yield* Effect.succeed("ok").pipe(
-        Effect.withSpan("direct.settings"),
-        Effect.provide(CloudflareOtlp.layerJson({ signals: ["traces"] })),
-        Effect.provide(Layer.succeed(CloudflareOtlp.CloudflareOtlpSettings, settings)),
+        Effect.withSpan("ambient.config"),
+        Effect.provide(
+          CloudflareOtlp.layerJson({
+            signals: ["traces"],
+            resource: { serviceName: "ambient-provider-test" },
+          }),
+        ),
+        Effect.provide(
+          ConfigProvider.layer(
+            ConfigProvider.fromUnknown({
+              OTEL_TRACES_EXPORTER: "otlp",
+              OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: `${collector.endpoint}/v1/traces`,
+            }),
+          ),
+        ),
       );
 
       const request = yield* collector.nextRequest;
       expect(request.path).toBe("/v1/traces");
-      expect(request.body).toContain("direct-settings-service");
-      expect(request.body).toContain("direct.settings");
+      expect(request.body).toContain("ambient-provider-test");
+      expect(request.body).toContain("ambient.config");
     }),
   );
 
@@ -221,9 +168,8 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
         eventLayer: CloudflareOtlp.workerLayer({
           signals: ["traces"],
           serialization: "json",
-          serviceName: "effect-cf-test",
+          resource: { serviceName: "effect-cf-test" },
           workerName: "api-worker",
-          tracerExportInterval: "1 hour",
         }),
         fetch: Effect.succeed(new Response("ok")).pipe(
           Effect.withSpan("test.fetch", { attributes: { route: "/" } }),
@@ -234,8 +180,9 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
         handler.fetch(
           new Request("https://worker.test/"),
           makeEnv({
+            OTEL_TRACES_EXPORTER: "otlp",
             OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: `${collector.endpoint}/v1/traces`,
-            OTEL_EXPORTER_OTLP_HEADERS: "x-api-key=test-secret",
+            OTEL_EXPORTER_OTLP_HEADERS: "x-api-key=test-secret,x-shared=common",
             OTEL_EXPORTER_OTLP_TRACES_HEADERS: "x-api-key=trace-secret,x-trace-key=trace-only",
           }),
           makeExecutionContext(),
@@ -248,6 +195,7 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
       expect(request.path).toBe("/v1/traces");
       expect(request.headers["x-api-key"]).toBe("trace-secret");
       expect(request.headers["x-trace-key"]).toBe("trace-only");
+      expect(request.headers["x-shared"]).toBeUndefined();
 
       const payload: unknown = JSON.parse(request.body);
       const resourceSpans = getArray(payload, "resourceSpans");
@@ -267,14 +215,20 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
     }),
   );
 
-  it.effect("parses resource attributes and lets OTEL_SERVICE_NAME take precedence", () =>
+  it.effect("uses OTEL resource variables before explicit resource options", () =>
     Effect.gen(function* () {
       const collector = yield* OtlpCollector;
       const handler = Worker.makeFetchHandler(Layer.empty, {
         eventLayer: CloudflareOtlp.workerLayer({
           signals: ["traces"],
           serialization: "json",
-          tracerExportInterval: "1 hour",
+          resource: {
+            serviceName: "explicit-service",
+            serviceVersion: "explicit-version",
+            attributes: {
+              "deployment.environment": "explicit",
+            },
+          },
         }),
         fetch: Effect.succeed(new Response("ok")).pipe(Effect.withSpan("resource.fetch")),
       });
@@ -283,6 +237,7 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
         handler.fetch(
           new Request("https://worker.test/resource"),
           makeEnv({
+            OTEL_TRACES_EXPORTER: "otlp",
             OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: `${collector.endpoint}/v1/traces`,
             OTEL_SERVICE_NAME: "env-service",
             OTEL_RESOURCE_ATTRIBUTES:
@@ -316,15 +271,14 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
           CloudflareOtlp.workerLayer({
             signals: ["traces"],
             serialization: "json",
-            tracerExportInterval: "1 hour",
+            resource: { serviceName: "generic-endpoint-test" },
           }),
         ),
         Effect.provide(
-          Layer.succeed(
-            CloudflareOtlp.CloudflareOtlpSettings,
-            makeSettings({
-              endpoint: Option.some(`${collector.endpoint}/base/`),
-              serviceName: Option.some("generic-endpoint-test"),
+          ConfigProvider.layer(
+            ConfigProvider.fromUnknown({
+              OTEL_TRACES_EXPORTER: "otlp",
+              OTEL_EXPORTER_OTLP_ENDPOINT: `${collector.endpoint}/base/`,
             }),
           ),
         ),
@@ -337,6 +291,43 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
   );
 });
 
+it.effect("CloudflareOtlp layer is disabled when the OTEL signal exporter is unset", () =>
+  Effect.gen(function* () {
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (...args: Parameters<typeof fetch>) => {
+      fetchCalls += 1;
+      return originalFetch(...args);
+    };
+
+    try {
+      const handler = Worker.makeFetchHandler(Layer.empty, {
+        eventLayer: CloudflareOtlp.workerLayer({
+          signals: ["traces"],
+          resource: { serviceName: "disabled-test" },
+        }),
+        fetch: Effect.succeed(new Response("ok")).pipe(Effect.withSpan("test.fetch")),
+      });
+
+      const response = yield* Effect.promise(() =>
+        handler.fetch(
+          new Request("https://worker.test/"),
+          makeEnv({
+            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://127.0.0.1:4318/v1/traces",
+          }),
+          makeExecutionContext(),
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      yield* Effect.promise(() => expect(response.text()).resolves.toBe("ok"));
+      expect(fetchCalls).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }),
+);
+
 it.effect("CloudflareOtlp layer is disabled when no endpoint is configured", () =>
   Effect.gen(function* () {
     const originalFetch = globalThis.fetch;
@@ -348,7 +339,10 @@ it.effect("CloudflareOtlp layer is disabled when no endpoint is configured", () 
 
     try {
       const handler = Worker.makeFetchHandler(Layer.empty, {
-        eventLayer: CloudflareOtlp.workerLayer({ signals: ["traces"] }),
+        eventLayer: CloudflareOtlp.workerLayer({
+          signals: ["traces"],
+          resource: { serviceName: "disabled-test" },
+        }),
         fetch: Effect.succeed(new Response("ok")).pipe(Effect.withSpan("test.fetch")),
       });
 
@@ -356,8 +350,47 @@ it.effect("CloudflareOtlp layer is disabled when no endpoint is configured", () 
         handler.fetch(
           new Request("https://worker.test/"),
           makeEnv({
+            OTEL_TRACES_EXPORTER: "otlp",
             OTEL_EXPORTER_OTLP_ENDPOINT: "",
-            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: " ",
+          }),
+          makeExecutionContext(),
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      yield* Effect.promise(() => expect(response.text()).resolves.toBe("ok"));
+      expect(fetchCalls).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }),
+);
+
+it.effect("CloudflareOtlp layer honors OTEL_SDK_DISABLED", () =>
+  Effect.gen(function* () {
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (...args: Parameters<typeof fetch>) => {
+      fetchCalls += 1;
+      return originalFetch(...args);
+    };
+
+    try {
+      const handler = Worker.makeFetchHandler(Layer.empty, {
+        eventLayer: CloudflareOtlp.workerLayer({
+          signals: ["traces"],
+          resource: { serviceName: "disabled-test" },
+        }),
+        fetch: Effect.succeed(new Response("ok")).pipe(Effect.withSpan("test.fetch")),
+      });
+
+      const response = yield* Effect.promise(() =>
+        handler.fetch(
+          new Request("https://worker.test/"),
+          makeEnv({
+            OTEL_SDK_DISABLED: "true",
+            OTEL_TRACES_EXPORTER: "otlp",
+            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://127.0.0.1:4318/v1/traces",
           }),
           makeExecutionContext(),
         ),
@@ -377,8 +410,7 @@ mapleSmokeTest("CloudflareOtlp exports Worker spans to Maple local OTLP", () =>
     const handler = Worker.makeFetchHandler(Layer.empty, {
       eventLayer: CloudflareOtlp.workerLayer({
         signals: ["traces"],
-        serviceName: "effect-cf-maple-smoke",
-        tracerExportInterval: "1 hour",
+        resource: { serviceName: "effect-cf-maple-smoke" },
       }),
       fetch: Effect.succeed(new Response("ok")).pipe(Effect.withSpan("maple.fetch")),
     });
@@ -387,6 +419,7 @@ mapleSmokeTest("CloudflareOtlp exports Worker spans to Maple local OTLP", () =>
       handler.fetch(
         new Request("https://worker.test/maple"),
         makeEnv({
+          OTEL_TRACES_EXPORTER: "otlp",
           OTEL_EXPORTER_OTLP_ENDPOINT:
             processEnv?.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://127.0.0.1:4318",
           OTEL_SERVICE_NAME: "effect-cf-maple-smoke",

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -2,7 +2,7 @@ import { Clock, Config, ConfigProvider, Context, Effect, Layer, Stream } from "e
 import { HttpServerResponse } from "effect/unstable/http";
 import { expect, test } from "vite-plus/test";
 
-import { Worker, WorkerConfig } from "../src/index";
+import { DurableObject, Worker, WorkerConfig } from "../src/index";
 
 class RenderValue extends Context.Service<RenderValue, string>()(
   "effect-cf/test/WorkerBoundary/RenderValue",
@@ -18,6 +18,14 @@ const makeExecutionContext = () =>
     waitUntil: () => undefined,
     passThroughOnException: () => undefined,
   }) as unknown as globalThis.ExecutionContext;
+
+const makeDurableObjectState = () =>
+  ({
+    id: { toString: () => "durable-object:test" },
+    storage: {},
+    waitUntil: () => undefined,
+    blockConcurrencyWhile: async <T>(callback: () => Promise<T>) => callback(),
+  }) as unknown as globalThis.DurableObjectState;
 
 test("Worker.makeFetchHandler returns an ExportedHandler-compatible fetch object", async () => {
   const handler = Worker.makeFetchHandler(Layer.empty, {
@@ -143,6 +151,23 @@ test("Worker fetch handlers read Effect config from env by default", async () =>
   } as Cloudflare.Env);
 
   const response = await worker.fetch(new Request("https://worker.test/"));
+
+  await expect(response.text()).resolves.toBe("effect-cf");
+});
+
+test("Durable Object fetch handlers read Effect config from env by default", async () => {
+  const Live = DurableObject.make(Layer.empty, {
+    fetch: Effect.gen(function* () {
+      const value = yield* Config.string("APP_NAME");
+
+      return new Response(value);
+    }),
+  });
+  const durableObject = new Live(makeDurableObjectState(), {
+    APP_NAME: "effect-cf",
+  } as Cloudflare.Env);
+
+  const response = await durableObject.fetch!(new Request("https://worker.test/"));
 
   await expect(response.text()).resolves.toBe("effect-cf");
 });


### PR DESCRIPTION
## Summary

- Simplify `CloudflareOtlp` around Effect beta.77 OTEL `layerFromConfig` APIs and remove the custom settings service/config parser.
- Move resource metadata under `resource`, rely on standard `OTEL_*_EXPORTER=otlp` activation, and bump Effect packages/submodule to beta.77.
- Install Cloudflare `env` as the default Effect `ConfigProvider` for Durable Objects, matching Worker behavior.

## Validation

- `vp check`
- `vp test`