### PR TITLE
ci: use github token for releases

### DIFF
--- a/.changeset/fix-release-token.md
+++ b/.changeset/fix-release-token.md
@@ -1,0 +1,4 @@
+---
+---
+
+Use the built-in GitHub token for Changesets release automation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Use the token provided to changesets/action when it pushes updates to
-          # the release branch, so CI runs on the generated release PR.
+          # Let changesets/action configure git credentials with github.token.
           persist-credentials: false
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -38,6 +37,6 @@ jobs:
         with:
           version: vp run changeset:version
           publish: vp run changeset:publish
+          token: ${{ github.token }}
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Use the built-in GitHub token for Changesets release automation instead of the stale CHANGESET_GITHUB_TOKEN secret.
- Add an empty changeset for CI-only workflow maintenance.

## Validation

- vp check
- vp test