### PR TITLE
feat: add Cloudflare Send Email binding

### DIFF
--- a/.changeset/friendly-emails-cover.md
+++ b/.changeset/friendly-emails-cover.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add an Effect-native Cloudflare Send Email binding wrapper. `Email.Tag(...)` now provides a typed client for `send_email` bindings with `send(...)`, `unsafeRaw`, binding validation, and `EmailOperationError` failure mapping.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # effect-cf
 
-Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, KV, and Durable Object storage.
+Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, KV, Email, and Durable Object storage.
 
 ## Install
 

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -1,6 +1,6 @@
 # effect-cf
 
-Effect-native Cloudflare primitives for Workers, Durable Objects, bindings, KV, D1, Queues, Workflows, and Durable Object storage.
+Effect-native Cloudflare primitives for Workers, Durable Objects, bindings, KV, D1, Queues, Email, Workflows, and Durable Object storage.
 
 ## Install
 
@@ -35,6 +35,7 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `R2` - typed R2 bucket binding helper with Effect-wrapped object and multipart operations
 - `Hyperdrive` - typed Hyperdrive binding helper for connection strings and optional Postgres SQL integration
 - `Images` - typed Cloudflare Images binding helper with transformation APIs and optional hosted image operations
+- `Email` - typed Cloudflare Send Email binding helper for `send_email` bindings
 - `Queue` - typed Queue producer/consumer tags plus client and error types
 - `Workflow` - typed Workflow entrypoints, steps, starter clients, and instance types
 - `Rpc` - Cloudflare RPC type helpers and scoped disposal utilities
@@ -203,6 +204,32 @@ export const resizeAvatar = (image: Images.ImageInputValue) =>
     );
 
     return yield* result.response;
+  });
+```
+
+## Email Example
+
+Email tags expose Cloudflare Send Email bindings as Effect-wrapped `send(...)` operations.
+
+```ts
+import { Effect } from "effect";
+import { Email } from "effect-cf";
+
+class TransactionalEmail extends Email.Tag<TransactionalEmail>()("TransactionalEmail") {}
+
+export const TransactionalEmailLayer = TransactionalEmail.layer({ binding: "EMAIL" });
+
+export const sendWelcomeEmail = (to: string) =>
+  Effect.gen(function* () {
+    const email = yield* TransactionalEmail;
+
+    return yield* email.send({
+      from: { name: "Example", email: "team@example.com" },
+      to,
+      subject: "Welcome to Example",
+      text: "Welcome to Example",
+      html: "<p>Welcome to Example</p>",
+    });
   });
 ```
 

--- a/packages/effect-cf/src/Email.ts
+++ b/packages/effect-cf/src/Email.ts
@@ -1,0 +1,134 @@
+import type {
+  EmailAddress as CloudflareEmailAddress,
+  EmailAttachment as CloudflareEmailAttachment,
+  EmailMessage as CloudflareEmailMessage,
+  EmailSendResult as CloudflareEmailSendResult,
+  SendEmail as CloudflareSendEmail,
+} from "@cloudflare/workers-types";
+import { Context, Data, Effect, type Layer } from "effect";
+
+import * as Binding from "./Binding";
+import type { WorkerEnvironment } from "./Environment";
+
+const expectedSendEmailBinding = "Send Email binding with send()";
+
+/** Error raised when a Cloudflare Send Email operation fails. */
+export class EmailOperationError extends Data.TaggedError("EmailOperationError")<{
+  readonly binding: string;
+  readonly operation: string;
+  readonly cause: unknown;
+}> {}
+
+/** Typed Cloudflare Send Email binding definition. */
+export interface EmailDefinition {
+  /** Binding name as configured in `wrangler.jsonc`. */
+  readonly binding: string;
+}
+
+export type EmailAddress = CloudflareEmailAddress;
+export type EmailAttachment = CloudflareEmailAttachment;
+export type EmailMessage = CloudflareEmailMessage;
+export type EmailMessageBuilder = Parameters<CloudflareSendEmail["send"]>[0];
+export type EmailSendInput = EmailMessage | EmailMessageBuilder;
+export type EmailSendResult = CloudflareEmailSendResult;
+export type EmailBinding = CloudflareSendEmail;
+
+interface EmailRuntimeBinding {
+  readonly send: (message: EmailSendInput) => Promise<EmailSendResult>;
+}
+
+export interface EmailClient {
+  readonly send: {
+    (message: EmailMessage): Effect.Effect<EmailSendResult, EmailOperationError>;
+    (builder: EmailMessageBuilder): Effect.Effect<EmailSendResult, EmailOperationError>;
+  };
+  readonly unsafeRaw: Effect.Effect<EmailBinding>;
+  readonly definition: EmailDefinition;
+}
+
+declare const EmailServiceTypeId: unique symbol;
+
+/** Nominal service marker for Send Email services created with {@link make}. */
+export interface EmailService<Id extends string> {
+  readonly [EmailServiceTypeId]: {
+    readonly id: Id;
+  };
+}
+
+export type LayerOptions = {
+  readonly binding: string;
+};
+
+export interface TagClass<Self, Id extends string> extends Context.ServiceClass<
+  Self,
+  Id,
+  EmailClient
+> {
+  readonly id: Id;
+  readonly layer: (
+    options: LayerOptions,
+  ) => Layer.Layer<
+    Self,
+    Binding.BindingNotFoundError | Binding.BindingValidationError,
+    WorkerEnvironment
+  >;
+}
+
+const emailError = (binding: string, operation: string, cause: unknown) =>
+  new EmailOperationError({ binding, operation, cause });
+
+const tryEmailPromise = <A>(
+  binding: string,
+  operation: string,
+  evaluate: () => Promise<A>,
+): Effect.Effect<A, EmailOperationError> =>
+  Effect.tryPromise({
+    try: evaluate,
+    catch: (cause) => emailError(binding, operation, cause),
+  });
+
+export const isEmailBinding = (value: unknown): value is EmailBinding => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const resource = value as Record<string, unknown>;
+
+  return typeof resource.send === "function";
+};
+
+export const makeClient =
+  (definition: EmailDefinition) =>
+  (email: EmailBinding): EmailClient => {
+    const runtime = email as EmailRuntimeBinding;
+    const send = ((message: EmailSendInput) =>
+      tryEmailPromise(definition.binding, "send", () =>
+        runtime.send(message),
+      )) as EmailClient["send"];
+
+    return {
+      definition,
+      send,
+      unsafeRaw: Effect.succeed(email),
+    };
+  };
+
+export const layer = <Self>(tag: Context.Service<Self, EmailClient>, definition: EmailDefinition) =>
+  Binding.layer(tag, definition.binding, isEmailBinding, makeClient(definition), {
+    expected: expectedSendEmailBinding,
+  });
+
+export const make = <Id extends string>(id: Id) => Tag<EmailService<Id>>()<Id>(id);
+
+export const Tag =
+  <Self>() =>
+  <Id extends string>(id: Id) => {
+    const tag = Context.Service<Self, EmailClient>()(id);
+
+    const makeLayer = (definition: LayerOptions) => layer(tag, definition);
+
+    return Object.assign(tag, {
+      id,
+      layer: makeLayer,
+    }) as TagClass<Self, Id>;
+  };

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -12,6 +12,7 @@ export * as DurableObjectSqlite from "./DurableObjectSqlite";
 export * as DurableObjectState from "./DurableObjectState";
 export * as DurableObjectWebSocket from "./DurableObjectWebSocket";
 export * as DurableObjectStorage from "./DurableObjectStorage";
+export * as Email from "./Email";
 export * as Hyperdrive from "./Hyperdrive";
 export * as Images from "./Images";
 export * as Kv from "./Kv";

--- a/packages/effect-cf/tests/Email.test.ts
+++ b/packages/effect-cf/tests/Email.test.ts
@@ -1,0 +1,144 @@
+import { assert, expect, layer, test } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import { Binding, Email, WorkerEnvironment } from "../src/index";
+
+class TestEmail extends Email.Tag<TestEmail>()("test/TestEmail") {}
+
+interface SendCall {
+  readonly message: Email.EmailSendInput;
+}
+
+interface FakeEmailOptions {
+  readonly send?: (message: Email.EmailSendInput) => Promise<Email.EmailSendResult>;
+}
+
+const makeFakeEmail = (options: FakeEmailOptions = {}) =>
+  ({
+    send:
+      options.send ??
+      (async () => ({
+        messageId: "email-1",
+      })),
+  }) as SendEmail;
+
+const emailLayer = (email: SendEmail) =>
+  TestEmail.layer({ binding: "EMAIL" }).pipe(
+    Layer.provide(Layer.succeed(WorkerEnvironment, { EMAIL: email })),
+  );
+
+{
+  const calls: Array<SendCall> = [];
+  const email = makeFakeEmail({
+    send: async (message) => {
+      calls.push({ message });
+      return { messageId: "email-builder-1" };
+    },
+  });
+
+  layer(emailLayer(email))("Send Email builder messages", (it) => {
+    it.effect("wraps builder sends", () =>
+      Effect.gen(function* () {
+        const email = yield* TestEmail;
+        const result = yield* email.send({
+          from: { name: "Example", email: "team@example.com" },
+          to: ["user@example.com"],
+          subject: "Welcome",
+          text: "Welcome to Example",
+          headers: { "X-Template": "welcome" },
+        });
+
+        assert.strictEqual(result.messageId, "email-builder-1");
+        assert.deepStrictEqual(calls[0]?.message, {
+          from: { name: "Example", email: "team@example.com" },
+          to: ["user@example.com"],
+          subject: "Welcome",
+          text: "Welcome to Example",
+          headers: { "X-Template": "welcome" },
+        });
+      }),
+    );
+  });
+}
+
+{
+  const calls: Array<SendCall> = [];
+  const email = makeFakeEmail({
+    send: async (message) => {
+      calls.push({ message });
+      return { messageId: "email-message-1" };
+    },
+  });
+
+  layer(emailLayer(email))("Send Email native messages", (it) => {
+    it.effect("wraps native EmailMessage sends", () =>
+      Effect.gen(function* () {
+        const email = yield* TestEmail;
+        const message = {
+          from: "team@example.com",
+          to: "user@example.com",
+        } satisfies Email.EmailMessage;
+
+        const result = yield* email.send(message);
+
+        assert.strictEqual(result.messageId, "email-message-1");
+        assert.deepStrictEqual(calls[0]?.message, message);
+      }),
+    );
+  });
+}
+
+test("Send Email layer validates the binding shape", async () => {
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const email = yield* TestEmail;
+        yield* email.send({
+          from: "team@example.com",
+          to: "user@example.com",
+          subject: "Welcome",
+          text: "Welcome to Example",
+        });
+      }).pipe(
+        Effect.provide(
+          TestEmail.layer({ binding: "EMAIL" }).pipe(
+            Layer.provide(Layer.succeed(WorkerEnvironment, { EMAIL: {} as SendEmail })),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toBeInstanceOf(Binding.BindingValidationError);
+});
+
+test("Send Email operations map rejected sends", async () => {
+  const cause = new Error("smtp rejected");
+
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const email = yield* TestEmail;
+        yield* email.send({
+          from: "team@example.com",
+          to: "user@example.com",
+          subject: "Welcome",
+          text: "Welcome to Example",
+        });
+      }).pipe(
+        Effect.provide(
+          emailLayer(
+            makeFakeEmail({
+              send: async () => {
+                throw cause;
+              },
+            }),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "EmailOperationError",
+    binding: "EMAIL",
+    operation: "send",
+    cause,
+  });
+});

--- a/packages/effect-cf/tests/binding-ergonomics.test-d.ts
+++ b/packages/effect-cf/tests/binding-ergonomics.test-d.ts
@@ -9,6 +9,7 @@ import {
   BrowserRendering,
   DurableObject,
   DurableObjectNamespace,
+  Email,
   Hyperdrive,
   Images,
   Kv,
@@ -196,6 +197,50 @@ const imagesProgram = Effect.gen(function* () {
     expectTypeOf(hosted.upload(new ArrayBuffer(0), { id: "avatar-1" })).toEqualTypeOf<
       Effect.Effect<Images.ImageMetadata, Images.ImagesOperationError>
     >();
+  });
+});
+
+export class TransactionalEmail extends Email.Tag<TransactionalEmail>()("TransactionalEmail") {}
+
+export const TransactionalEmailLayer = TransactionalEmail.layer({ binding: "EMAIL" });
+
+const emailProgram = Effect.gen(function* () {
+  const email = yield* TransactionalEmail;
+
+  expectTypeOf(
+    email.send({
+      from: { name: "Example", email: "team@example.com" },
+      to: "user@example.com",
+      subject: "Welcome",
+      text: "Welcome to Example",
+    }),
+  ).toEqualTypeOf<Effect.Effect<Email.EmailSendResult, Email.EmailOperationError>>();
+
+  yield* email.send({
+    from: "team@example.com",
+    to: "user@example.com",
+    subject: "Welcome",
+    html: "<p>Welcome to Example</p>",
+    attachments: [
+      {
+        disposition: "attachment",
+        filename: "welcome.txt",
+        type: "text/plain",
+        content: "Welcome",
+      },
+    ],
+  });
+
+  yield* email.send({
+    from: "team@example.com",
+    to: "user@example.com",
+  } satisfies Email.EmailMessage);
+
+  // @ts-expect-error builder messages require a subject.
+  yield* email.send({
+    from: "team@example.com",
+    to: "user@example.com",
+    text: "Welcome to Example",
   });
 });
 
@@ -414,6 +459,7 @@ void kvProgram;
 void r2Program;
 void hyperdriveProgram;
 void imagesProgram;
+void emailProgram;
 void workersAiProgram;
 void vectorizeProgram;
 void aiGatewayProgram;

--- a/packages/effect-cf/tests/env.d.ts
+++ b/packages/effect-cf/tests/env.d.ts
@@ -9,6 +9,7 @@ declare global {
       TEST_KV?: KVNamespace;
       TEST_DB?: D1Database;
       TEST_BUCKET?: R2Bucket;
+      EMAIL?: SendEmail;
       HYPERDRIVE?: Hyperdrive;
       IMAGES?: ImagesBinding;
       AI?: Ai;


### PR DESCRIPTION
## Summary

- Add an Effect-native `Email` binding wrapper for Cloudflare `send_email` bindings.
- Export `Email` from the package root and document the tag/layer/send usage.
- Cover builder-style sends, native `EmailMessage` sends, binding validation, send error mapping, and type ergonomics.

## Validation

- `bunx vp run effect-cf#build`
- `bunx vp check`
- `bunx vp test`
