### PR TITLE
ci: fix changesets release token

### DIFF
--- a/.changeset/release-token-input.md
+++ b/.changeset/release-token-input.md
@@ -1,0 +1,4 @@
+---
+---
+
+Use the supported Changesets release token input without publishing a package release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Let changesets/action configure git credentials with github.token.
+          # Use the release token when changesets/action pushes updates to the
+          # release branch, so CI runs on the generated release PR.
           persist-credentials: false
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -37,6 +38,7 @@ jobs:
         with:
           version: vp run changeset:version
           publish: vp run changeset:publish
-          token: ${{ github.token }}
+          github-token: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
         env:
+          GITHUB_TOKEN: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Pass `CHANGESET_GITHUB_TOKEN` via changesets/action supported `github-token` input.
- Keep `GITHUB_TOKEN` available for Changesets changelog generation.
- Add an empty changeset because this is CI-only and should not publish `effect-cf`.

## Validation

- `vp run effect-cf#build`
- `vp check`
- `vp test`