### PR TITLE
ci: use github token for changesets release

### DIFF
--- a/.changeset/use-github-token-release.md
+++ b/.changeset/use-github-token-release.md
@@ -1,0 +1,4 @@
+---
+---
+
+Use the built-in GitHub Actions token for Changesets release automation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Use the release token when changesets/action pushes updates to the
-          # release branch, so CI runs on the generated release PR.
+          # Let changesets/action configure git credentials with github.token.
           persist-credentials: false
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -38,7 +37,7 @@ jobs:
         with:
           version: vp run changeset:version
           publish: vp run changeset:publish
-          github-token: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Use the built-in `github.token` for Changesets release automation now that repository Actions PR creation is enabled.
- Avoid the expired `CHANGESET_GITHUB_TOKEN` secret that caused changelog generation to fail with 401 Bad credentials.
- Add an empty changeset because this is CI-only and should not publish `effect-cf`.

## Validation

- `vp run effect-cf#build`
- `vp check`
- `vp test`