### PR TITLE
feat: add Analytics Engine helpers

### DIFF
--- a/.changeset/native-analytics-engines.md
+++ b/.changeset/native-analytics-engines.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add Effect-native Cloudflare Analytics Engine helpers. `AnalyticsEngine.Tag(...)` now provides dataset writes, and `AnalyticsEngine.QueryTag(...)` / `makeQueryClient(...)` provide SQL API querying backed by Effect `HttpClient`, config and redacted API token support, typed result envelopes, and row decoding through Effect schemas.

--- a/.changeset/native-analytics-engines.md
+++ b/.changeset/native-analytics-engines.md
@@ -2,4 +2,4 @@
 "effect-cf": minor
 ---
 
-Add Effect-native Cloudflare Analytics Engine helpers. `AnalyticsEngine.Tag(...)` now provides dataset writes, and `AnalyticsEngine.QueryTag(...)` / `makeQueryClient(...)` provide SQL API querying backed by Effect `HttpClient`, config and redacted API token support, typed result envelopes, and row decoding through Effect schemas.
+Add Effect-native Cloudflare Analytics Engine helpers. `AnalyticsEngine.Tag(...)` now provides validated dataset writes, configurable invalid-write policy, and batch write helpers. `AnalyticsEngine.QueryTag(...)` / `makeQueryClient(...)` provide SQL API querying backed by Effect `HttpClient`, config and redacted API token support, typed result envelopes, and row decoding through Effect schemas.

--- a/README.md
+++ b/README.md
@@ -188,8 +188,18 @@ const program = Effect.gen(function* () {
     blobs: ["/home", "US"],
     doubles: [1],
   });
+
+  yield* analytics.writeBatch(
+    [
+      { indexes: ["example.com"], blobs: ["/pricing", "US"], doubles: [1] },
+      { indexes: ["example.com"], blobs: ["/docs", "CA"], doubles: [1] },
+    ],
+    { onInvalid: "drop", batchSize: 100 },
+  );
 });
 ```
+
+Writes validate the Cloudflare Analytics Engine field, byte, and per-invocation limits before calling the native binding. Invalid writes fail with `AnalyticsEngineWriteValidationError` by default, or can be dropped with `onInvalid: "drop"` on the layer or per call.
 
 Analytics Engine SQL queries with schema-decoded rows:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # effect-cf
 
-Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, KV, Email, and Durable Object storage.
+Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, KV, Email, Analytics Engine, and Durable Object storage.
 
 ## Install
 
@@ -170,6 +170,53 @@ const program = Effect.gen(function* () {
   yield* browser.close;
   return { content, screenshot };
 });
+```
+
+Analytics Engine event writes:
+
+```ts
+import { Effect } from "effect";
+import { AnalyticsEngine } from "effect-cf";
+
+class RequestAnalytics extends AnalyticsEngine.Tag<RequestAnalytics>()("RequestAnalytics") {}
+
+const program = Effect.gen(function* () {
+  const analytics = yield* RequestAnalytics;
+
+  yield* analytics.writeDataPoint({
+    indexes: ["example.com"],
+    blobs: ["/home", "US"],
+    doubles: [1],
+  });
+});
+```
+
+Analytics Engine SQL queries with schema-decoded rows:
+
+```ts
+import { Effect, Layer, Schema as S } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { AnalyticsEngine, WorkerConfig } from "effect-cf";
+
+class AnalyticsQuery extends AnalyticsEngine.QueryTag<AnalyticsQuery>()("AnalyticsQuery") {}
+
+const PageView = S.Struct({ path: S.String, views: S.Number });
+
+const program = Effect.gen(function* () {
+  const analytics = yield* AnalyticsQuery;
+
+  return yield* analytics.queryRows(
+    PageView,
+    "SELECT blob1 AS path, SUM(_sample_interval) AS views FROM request_metrics GROUP BY path",
+  );
+});
+
+const layer = AnalyticsQuery.layerConfig(
+  AnalyticsEngine.queryConfig({
+    accountId: WorkerConfig.string("CLOUDFLARE_ACCOUNT_ID"),
+    apiToken: WorkerConfig.redacted("CLOUDFLARE_API_TOKEN"),
+  }),
+).pipe(Layer.provide(FetchHttpClient.layer));
 ```
 
 ## Changelog

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -1,6 +1,6 @@
 # effect-cf
 
-Effect-native Cloudflare primitives for Workers, Durable Objects, bindings, KV, D1, Queues, Email, Workflows, and Durable Object storage.
+Effect-native Cloudflare primitives for Workers, Durable Objects, bindings, KV, D1, Queues, Email, Analytics Engine, Workflows, and Durable Object storage.
 
 ## Install
 
@@ -36,6 +36,7 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `Hyperdrive` - typed Hyperdrive binding helper for connection strings and optional Postgres SQL integration
 - `Images` - typed Cloudflare Images binding helper with transformation APIs and optional hosted image operations
 - `Email` - typed Cloudflare Send Email binding helper for `send_email` bindings
+- `AnalyticsEngine` - typed Cloudflare Analytics Engine write bindings and SQL API query helpers
 - `Queue` - typed Queue producer/consumer tags plus client and error types
 - `Workflow` - typed Workflow entrypoints, steps, starter clients, and instance types
 - `Rpc` - Cloudflare RPC type helpers and scoped disposal utilities
@@ -231,6 +232,72 @@ export const sendWelcomeEmail = (to: string) =>
       html: "<p>Welcome to Example</p>",
     });
   });
+```
+
+## Analytics Engine Example
+
+Analytics Engine tags expose Cloudflare dataset bindings as Effect-wrapped `writeDataPoint(...)` operations. Writes use Cloudflare's native non-blocking runtime API.
+
+```ts
+import { Effect } from "effect";
+import { AnalyticsEngine } from "effect-cf";
+
+class RequestAnalytics extends AnalyticsEngine.Tag<RequestAnalytics>()("RequestAnalytics") {}
+
+export const RequestAnalyticsLayer = RequestAnalytics.layer({
+  binding: "REQUEST_ANALYTICS",
+});
+
+export const recordPageView = (request: Request) =>
+  Effect.gen(function* () {
+    const analytics = yield* RequestAnalytics;
+    const url = new URL(request.url);
+
+    yield* analytics.writeDataPoint({
+      indexes: [url.hostname],
+      blobs: [url.pathname, request.headers.get("cf-connecting-country") ?? "unknown"],
+      doubles: [1],
+    });
+  });
+```
+
+Define the dataset binding in the consuming Worker's `wrangler.jsonc` with `analytics_engine_datasets`, then provide `RequestAnalytics.layer({ binding: "REQUEST_ANALYTICS" })` from the Worker layer.
+
+Analytics Engine query tags wrap Cloudflare's HTTP SQL API. Configuration can stay in Effect `Config`, including a redacted API token, the outbound transport is an Effect `HttpClient` dependency, and rows can be decoded with Effect schemas at the query boundary. Use `fetchLayerConfig(...)` as shorthand when the platform fetch-backed client is enough.
+
+```ts
+import { Effect, Layer, Schema as S } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { AnalyticsEngine, WorkerConfig } from "effect-cf";
+
+class AnalyticsQuery extends AnalyticsEngine.QueryTag<AnalyticsQuery>()("AnalyticsQuery") {}
+
+export const AnalyticsQueryLayer = AnalyticsQuery.layerConfig(
+  AnalyticsEngine.queryConfig({
+    accountId: WorkerConfig.string("CLOUDFLARE_ACCOUNT_ID"),
+    apiToken: WorkerConfig.redacted("CLOUDFLARE_API_TOKEN"),
+  }),
+).pipe(Layer.provide(FetchHttpClient.layer));
+
+const PageView = S.Struct({
+  path: S.String,
+  views: S.Number,
+});
+
+export const topPages = Effect.gen(function* () {
+  const analytics = yield* AnalyticsQuery;
+
+  return yield* analytics.queryRows(
+    PageView,
+    `
+      SELECT blob1 AS path, SUM(_sample_interval) AS views
+      FROM request_metrics
+      GROUP BY path
+      ORDER BY views DESC
+      LIMIT 10
+    `,
+  );
+});
 ```
 
 ## Workflow Example

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -236,7 +236,7 @@ export const sendWelcomeEmail = (to: string) =>
 
 ## Analytics Engine Example
 
-Analytics Engine tags expose Cloudflare dataset bindings as Effect-wrapped `writeDataPoint(...)` operations. Writes use Cloudflare's native non-blocking runtime API.
+Analytics Engine tags expose Cloudflare dataset bindings as Effect-wrapped `writeDataPoint(...)` operations. Writes use Cloudflare's native non-blocking runtime API and are validated against Workers Analytics Engine limits before reaching the binding.
 
 ```ts
 import { Effect } from "effect";
@@ -246,6 +246,10 @@ class RequestAnalytics extends AnalyticsEngine.Tag<RequestAnalytics>()("RequestA
 
 export const RequestAnalyticsLayer = RequestAnalytics.layer({
   binding: "REQUEST_ANALYTICS",
+  write: {
+    onInvalid: "error",
+    batchSize: 100,
+  },
 });
 
 export const recordPageView = (request: Request) =>
@@ -258,10 +262,21 @@ export const recordPageView = (request: Request) =>
       blobs: [url.pathname, request.headers.get("cf-connecting-country") ?? "unknown"],
       doubles: [1],
     });
+
+    yield* analytics.writeBatch(
+      [
+        {
+          indexes: [url.hostname],
+          blobs: [url.pathname, "page-view"],
+          doubles: [1],
+        },
+      ],
+      { onInvalid: "drop" },
+    );
   });
 ```
 
-Define the dataset binding in the consuming Worker's `wrangler.jsonc` with `analytics_engine_datasets`, then provide `RequestAnalytics.layer({ binding: "REQUEST_ANALYTICS" })` from the Worker layer.
+Define the dataset binding in the consuming Worker's `wrangler.jsonc` with `analytics_engine_datasets`, then provide `RequestAnalytics.layer({ binding: "REQUEST_ANALYTICS" })` from the Worker layer. Invalid writes fail with `AnalyticsEngineWriteValidationError` by default. Use `write: { onInvalid: "drop" }` on the layer or `{ onInvalid: "drop" }` per call when dropping invalid points is preferable.
 
 Analytics Engine query tags wrap Cloudflare's HTTP SQL API. Configuration can stay in Effect `Config`, including a redacted API token, the outbound transport is an Effect `HttpClient` dependency, and rows can be decoded with Effect schemas at the query boundary. Use `fetchLayerConfig(...)` as shorthand when the platform fetch-backed client is enough.
 

--- a/packages/effect-cf/src/AnalyticsEngine.ts
+++ b/packages/effect-cf/src/AnalyticsEngine.ts
@@ -55,9 +55,9 @@ export const AnalyticsEngineFieldValueSchema = S.NullOr(
 );
 
 export const AnalyticsEngineDataPointSchema = S.Struct({
-  indexes: S.optionalKey(S.Array(AnalyticsEngineFieldValueSchema)),
-  doubles: S.optionalKey(S.Array(S.Finite)),
-  blobs: S.optionalKey(S.Array(AnalyticsEngineFieldValueSchema)),
+  indexes: S.optional(S.Array(AnalyticsEngineFieldValueSchema)),
+  doubles: S.optional(S.Array(S.Finite)),
+  blobs: S.optional(S.Array(AnalyticsEngineFieldValueSchema)),
 });
 
 const decodeQueryResponse = S.decodeUnknownEffect(queryResponseSchema);

--- a/packages/effect-cf/src/AnalyticsEngine.ts
+++ b/packages/effect-cf/src/AnalyticsEngine.ts
@@ -2,7 +2,17 @@ import type {
   AnalyticsEngineDataPoint as CloudflareAnalyticsEngineDataPoint,
   AnalyticsEngineDataset as CloudflareAnalyticsEngineDataset,
 } from "@cloudflare/workers-types";
-import { Config, Context, Data, Effect, Layer, Option, Redacted, Schema as S } from "effect";
+import {
+  Config,
+  Context,
+  Data,
+  Effect,
+  Layer,
+  Option,
+  Redacted,
+  Result,
+  Schema as S,
+} from "effect";
 import {
   FetchHttpClient,
   type Headers,
@@ -16,6 +26,16 @@ import type { WorkerEnvironment } from "./Environment";
 
 const expectedAnalyticsEngineDataset = "Analytics Engine dataset binding with writeDataPoint()";
 const defaultQueryApiBaseUrl = "https://api.cloudflare.com/client/v4";
+const textEncoder = new TextEncoder();
+
+export const writeLimits = {
+  maxBlobs: 20,
+  maxDoubles: 20,
+  maxIndexes: 1,
+  maxBlobBytes: 16 * 1024,
+  maxIndexBytes: 96,
+  maxDataPointsPerInvocation: 250,
+} as const;
 
 const queryColumnSchema = S.Struct({
   name: S.String,
@@ -30,7 +50,18 @@ const queryResponseSchema = S.Struct({
   rows: S.Number,
 });
 
+export const AnalyticsEngineFieldValueSchema = S.NullOr(
+  S.Union([S.String, S.instanceOf(ArrayBuffer)]),
+);
+
+export const AnalyticsEngineDataPointSchema = S.Struct({
+  indexes: S.optionalKey(S.Array(AnalyticsEngineFieldValueSchema)),
+  doubles: S.optionalKey(S.Array(S.Finite)),
+  blobs: S.optionalKey(S.Array(AnalyticsEngineFieldValueSchema)),
+});
+
 const decodeQueryResponse = S.decodeUnknownEffect(queryResponseSchema);
+const decodeDataPoint = S.decodeUnknownEffect(AnalyticsEngineDataPointSchema);
 
 /** Error raised when an Analytics Engine operation fails. */
 export class AnalyticsEngineOperationError extends Data.TaggedError(
@@ -39,6 +70,23 @@ export class AnalyticsEngineOperationError extends Data.TaggedError(
   readonly binding: string;
   readonly operation: string;
   readonly cause: unknown;
+}> {}
+
+export interface AnalyticsEngineWriteViolation {
+  readonly path: string;
+  readonly message: string;
+  readonly limit?: number;
+  readonly actual?: number;
+}
+
+/** Error raised when an Analytics Engine write input violates Cloudflare limits. */
+export class AnalyticsEngineWriteValidationError extends Data.TaggedError(
+  "AnalyticsEngineWriteValidationError",
+)<{
+  readonly binding: string;
+  readonly operation: string;
+  readonly violations: ReadonlyArray<AnalyticsEngineWriteViolation>;
+  readonly cause?: unknown;
 }> {}
 
 /** Error raised when an Analytics Engine SQL API query fails. */
@@ -60,8 +108,30 @@ export interface AnalyticsEngineDefinition {
 export type AnalyticsEngineBinding = CloudflareAnalyticsEngineDataset;
 export type AnalyticsEngineDataPoint = CloudflareAnalyticsEngineDataPoint;
 export type AnalyticsEngineFieldValue = ArrayBuffer | string | null;
+export type AnalyticsEngineWriteError =
+  | AnalyticsEngineOperationError
+  | AnalyticsEngineWriteValidationError;
+export type AnalyticsEngineInvalidWritePolicy = "error" | "drop";
 export type AnalyticsEngineQueryColumn = S.Schema.Type<typeof queryColumnSchema>;
 export type AnalyticsEngineQueryRow = S.Schema.Type<typeof queryRowSchema>;
+
+export interface AnalyticsEngineWriteOptions {
+  /**
+   * Controls invalid write behavior. The default is `"error"`, which fails with
+   * `AnalyticsEngineWriteValidationError`. `"drop"` skips invalid points.
+   */
+  readonly onInvalid?: AnalyticsEngineInvalidWritePolicy;
+}
+
+export interface AnalyticsEngineWriteBatchOptions extends AnalyticsEngineWriteOptions {
+  /**
+   * Maximum points per native batch call. Values are clamped to Cloudflare's
+   * per-invocation limit.
+   */
+  readonly batchSize?: number;
+}
+
+export type AnalyticsEngineWritePolicy = AnalyticsEngineWriteBatchOptions;
 
 export interface AnalyticsEngineQueryResult<Row = AnalyticsEngineQueryRow> {
   readonly meta: ReadonlyArray<AnalyticsEngineQueryColumn>;
@@ -86,10 +156,20 @@ export interface AnalyticsEngineQueryOptions {
 export interface AnalyticsEngineClient {
   readonly writeDataPoint: (
     dataPoint?: AnalyticsEngineDataPoint,
-  ) => Effect.Effect<void, AnalyticsEngineOperationError>;
+    options?: AnalyticsEngineWriteOptions,
+  ) => Effect.Effect<void, AnalyticsEngineWriteError>;
   readonly write: (
     dataPoint?: AnalyticsEngineDataPoint,
-  ) => Effect.Effect<void, AnalyticsEngineOperationError>;
+    options?: AnalyticsEngineWriteOptions,
+  ) => Effect.Effect<void, AnalyticsEngineWriteError>;
+  readonly writeDataPoints: (
+    dataPoints: ReadonlyArray<AnalyticsEngineDataPoint>,
+    options?: AnalyticsEngineWriteBatchOptions,
+  ) => Effect.Effect<void, AnalyticsEngineWriteError>;
+  readonly writeBatch: (
+    dataPoints: ReadonlyArray<AnalyticsEngineDataPoint>,
+    options?: AnalyticsEngineWriteBatchOptions,
+  ) => Effect.Effect<void, AnalyticsEngineWriteError>;
   readonly unsafeRaw: Effect.Effect<AnalyticsEngineBinding>;
   readonly definition: AnalyticsEngineDefinition;
 }
@@ -144,6 +224,7 @@ export interface AnalyticsEngineQueryService<Id extends string> {
 
 export type LayerOptions = {
   readonly binding: string;
+  readonly write?: AnalyticsEngineWritePolicy;
 };
 
 export type QueryConfigOptions = {
@@ -188,6 +269,19 @@ export interface QueryTagClass<Self, Id extends string> extends Context.ServiceC
 const analyticsEngineError = (binding: string, operation: string, cause: unknown) =>
   new AnalyticsEngineOperationError({ binding, operation, cause });
 
+const analyticsEngineWriteValidationError = (
+  binding: string,
+  operation: string,
+  violations: ReadonlyArray<AnalyticsEngineWriteViolation>,
+  cause?: unknown,
+) =>
+  new AnalyticsEngineWriteValidationError({
+    binding,
+    operation,
+    violations,
+    cause,
+  });
+
 const analyticsEngineQueryError = (
   definition: AnalyticsEngineQueryDefinition,
   operation: string,
@@ -215,6 +309,250 @@ const tryAnalyticsEngineSync = <A>(
   Effect.try({
     try: evaluate,
     catch: (cause) => analyticsEngineError(binding, operation, cause),
+  });
+
+const normalizeBatchSize = (batchSize: number | undefined) => {
+  if (batchSize === undefined || !Number.isFinite(batchSize) || batchSize <= 0) {
+    return writeLimits.maxDataPointsPerInvocation;
+  }
+
+  return Math.min(Math.floor(batchSize), writeLimits.maxDataPointsPerInvocation);
+};
+
+const resolveWritePolicy = (
+  defaults: AnalyticsEngineWritePolicy | undefined,
+  options: AnalyticsEngineWriteBatchOptions | undefined,
+) => ({
+  onInvalid: options?.onInvalid ?? defaults?.onInvalid ?? "error",
+  batchSize: normalizeBatchSize(options?.batchSize ?? defaults?.batchSize),
+});
+
+const fieldPath = (prefix: string, field: string) => (prefix === "" ? field : `${prefix}.${field}`);
+
+const indexedPath = (prefix: string, field: string, index: number) =>
+  `${fieldPath(prefix, field)}[${index}]`;
+
+const byteLength = (value: AnalyticsEngineFieldValue) => {
+  if (value === null) {
+    return 0;
+  }
+
+  return typeof value === "string" ? textEncoder.encode(value).byteLength : value.byteLength;
+};
+
+const lengthViolation = (
+  path: string,
+  label: string,
+  actual: number,
+  limit: number,
+): AnalyticsEngineWriteViolation => ({
+  path,
+  message: `${label} exceeds Cloudflare Analytics Engine limit`,
+  actual,
+  limit,
+});
+
+const validateDataPointLimits = (
+  dataPoint: AnalyticsEngineDataPoint,
+  pathPrefix = "",
+): ReadonlyArray<AnalyticsEngineWriteViolation> => {
+  const violations: Array<AnalyticsEngineWriteViolation> = [];
+
+  if (dataPoint.blobs !== undefined && dataPoint.blobs.length > writeLimits.maxBlobs) {
+    violations.push(
+      lengthViolation(
+        fieldPath(pathPrefix, "blobs"),
+        "blobs",
+        dataPoint.blobs.length,
+        writeLimits.maxBlobs,
+      ),
+    );
+  }
+
+  if (dataPoint.doubles !== undefined && dataPoint.doubles.length > writeLimits.maxDoubles) {
+    violations.push(
+      lengthViolation(
+        fieldPath(pathPrefix, "doubles"),
+        "doubles",
+        dataPoint.doubles.length,
+        writeLimits.maxDoubles,
+      ),
+    );
+  }
+
+  if (dataPoint.indexes !== undefined && dataPoint.indexes.length > writeLimits.maxIndexes) {
+    violations.push(
+      lengthViolation(
+        fieldPath(pathPrefix, "indexes"),
+        "indexes",
+        dataPoint.indexes.length,
+        writeLimits.maxIndexes,
+      ),
+    );
+  }
+
+  if (dataPoint.blobs !== undefined) {
+    const blobBytes = dataPoint.blobs.reduce((total, value) => total + byteLength(value), 0);
+
+    if (blobBytes > writeLimits.maxBlobBytes) {
+      violations.push(
+        lengthViolation(
+          fieldPath(pathPrefix, "blobs"),
+          "blob bytes",
+          blobBytes,
+          writeLimits.maxBlobBytes,
+        ),
+      );
+    }
+  }
+
+  if (dataPoint.indexes !== undefined) {
+    for (let index = 0; index < dataPoint.indexes.length; index++) {
+      const indexBytes = byteLength(dataPoint.indexes[index] ?? null);
+
+      if (indexBytes > writeLimits.maxIndexBytes) {
+        violations.push(
+          lengthViolation(
+            indexedPath(pathPrefix, "indexes", index),
+            "index bytes",
+            indexBytes,
+            writeLimits.maxIndexBytes,
+          ),
+        );
+      }
+    }
+  }
+
+  return violations;
+};
+
+const schemaViolation = (
+  pathPrefix: string,
+  cause: S.SchemaError,
+): AnalyticsEngineWriteViolation => ({
+  path: pathPrefix === "" ? "$" : pathPrefix,
+  message: cause.message,
+});
+
+const toAnalyticsEngineDataPoint = (
+  dataPoint: S.Schema.Type<typeof AnalyticsEngineDataPointSchema>,
+): AnalyticsEngineDataPoint => ({
+  ...(dataPoint.indexes === undefined ? {} : { indexes: [...dataPoint.indexes] }),
+  ...(dataPoint.doubles === undefined ? {} : { doubles: [...dataPoint.doubles] }),
+  ...(dataPoint.blobs === undefined ? {} : { blobs: [...dataPoint.blobs] }),
+});
+
+const validateDataPoint = (
+  binding: string,
+  operation: string,
+  dataPoint: AnalyticsEngineDataPoint,
+  pathPrefix = "",
+): Effect.Effect<AnalyticsEngineDataPoint, AnalyticsEngineWriteValidationError> =>
+  Effect.gen(function* () {
+    const decoded = yield* decodeDataPoint(dataPoint).pipe(
+      Effect.mapError((cause) =>
+        analyticsEngineWriteValidationError(
+          binding,
+          operation,
+          [schemaViolation(pathPrefix, cause)],
+          cause,
+        ),
+      ),
+    );
+    const validated = toAnalyticsEngineDataPoint(decoded);
+    const violations = validateDataPointLimits(validated, pathPrefix);
+
+    if (violations.length > 0) {
+      return yield* Effect.fail(
+        analyticsEngineWriteValidationError(binding, operation, violations),
+      );
+    }
+
+    return validated;
+  });
+
+const validateOptionalDataPoint = (
+  binding: string,
+  operation: string,
+  dataPoint: AnalyticsEngineDataPoint | undefined,
+): Effect.Effect<AnalyticsEngineDataPoint | undefined, AnalyticsEngineWriteValidationError> =>
+  dataPoint === undefined
+    ? Effect.succeed(undefined)
+    : validateDataPoint(binding, operation, dataPoint);
+
+const validateDataPoints = (
+  binding: string,
+  operation: string,
+  dataPoints: ReadonlyArray<AnalyticsEngineDataPoint>,
+  policy: ReturnType<typeof resolveWritePolicy>,
+): Effect.Effect<ReadonlyArray<AnalyticsEngineDataPoint>, AnalyticsEngineWriteValidationError> =>
+  Effect.gen(function* () {
+    const points =
+      dataPoints.length > writeLimits.maxDataPointsPerInvocation && policy.onInvalid === "drop"
+        ? dataPoints.slice(0, writeLimits.maxDataPointsPerInvocation)
+        : dataPoints;
+    const violations: Array<AnalyticsEngineWriteViolation> = [];
+
+    if (
+      dataPoints.length > writeLimits.maxDataPointsPerInvocation &&
+      policy.onInvalid === "error"
+    ) {
+      violations.push(
+        lengthViolation(
+          "dataPoints",
+          "data points per Worker invocation",
+          dataPoints.length,
+          writeLimits.maxDataPointsPerInvocation,
+        ),
+      );
+    }
+
+    const validPoints: Array<AnalyticsEngineDataPoint> = [];
+
+    for (let index = 0; index < points.length; index++) {
+      const result = yield* Effect.result(
+        validateDataPoint(binding, operation, points[index], `dataPoints[${index}]`),
+      );
+
+      if (Result.isSuccess(result)) {
+        validPoints.push(result.success);
+      } else if (policy.onInvalid === "error") {
+        violations.push(...result.failure.violations);
+      }
+    }
+
+    if (violations.length > 0) {
+      return yield* Effect.fail(
+        analyticsEngineWriteValidationError(binding, operation, violations),
+      );
+    }
+
+    return validPoints;
+  });
+
+const writeChunks = (
+  binding: string,
+  operation: string,
+  dataset: AnalyticsEngineBinding,
+  dataPoints: ReadonlyArray<AnalyticsEngineDataPoint>,
+  batchSize: number,
+): Effect.Effect<void, AnalyticsEngineOperationError> =>
+  Effect.gen(function* () {
+    const writeDataPoints = Reflect.get(dataset, "writeDataPoints");
+
+    for (let index = 0; index < dataPoints.length; index += batchSize) {
+      const chunk = dataPoints.slice(index, index + batchSize);
+
+      if (typeof writeDataPoints === "function") {
+        yield* tryAnalyticsEngineSync(binding, operation, () =>
+          writeDataPoints.call(dataset, chunk),
+        );
+      } else {
+        for (const point of chunk) {
+          yield* tryAnalyticsEngineSync(binding, operation, () => dataset.writeDataPoint(point));
+        }
+      }
+    }
   });
 
 const queryApiUrl = (definition: AnalyticsEngineQueryDefinition) => {
@@ -364,17 +702,56 @@ export const isAnalyticsEngineDataset = (value: unknown): value is AnalyticsEngi
 };
 
 export const makeClient =
-  (definition: AnalyticsEngineDefinition) =>
+  (definition: AnalyticsEngineDefinition, defaults?: AnalyticsEngineWritePolicy) =>
   (dataset: AnalyticsEngineBinding): AnalyticsEngineClient => {
-    const writeDataPoint = (dataPoint?: AnalyticsEngineDataPoint) =>
-      tryAnalyticsEngineSync(definition.binding, "writeDataPoint", () =>
-        dataset.writeDataPoint(dataPoint),
+    const writeDataPoint = (
+      dataPoint?: AnalyticsEngineDataPoint,
+      options?: AnalyticsEngineWriteOptions,
+    ) => {
+      const policy = resolveWritePolicy(defaults, options);
+
+      return validateOptionalDataPoint(definition.binding, "writeDataPoint", dataPoint).pipe(
+        Effect.matchEffect({
+          onFailure: (error) =>
+            policy.onInvalid === "drop" ? Effect.succeed(undefined) : Effect.fail(error),
+          onSuccess: (point) =>
+            tryAnalyticsEngineSync(definition.binding, "writeDataPoint", () =>
+              dataset.writeDataPoint(point),
+            ),
+        }),
       );
+    };
+
+    const writeDataPoints = (
+      dataPoints: ReadonlyArray<AnalyticsEngineDataPoint>,
+      options?: AnalyticsEngineWriteBatchOptions,
+    ) => {
+      const policy = resolveWritePolicy(defaults, options);
+
+      return Effect.gen(function* () {
+        const validPoints = yield* validateDataPoints(
+          definition.binding,
+          "writeDataPoints",
+          dataPoints,
+          policy,
+        );
+
+        yield* writeChunks(
+          definition.binding,
+          "writeDataPoints",
+          dataset,
+          validPoints,
+          policy.batchSize,
+        );
+      });
+    };
 
     return {
       definition,
       writeDataPoint,
       write: writeDataPoint,
+      writeDataPoints,
+      writeBatch: writeDataPoints,
       unsafeRaw: Effect.succeed(dataset),
     };
   };
@@ -417,11 +794,17 @@ export const queryFetchLayerConfig = <Self>(
 
 export const layer = <Self>(
   tag: Context.Service<Self, AnalyticsEngineClient>,
-  definition: AnalyticsEngineDefinition,
+  definition: LayerOptions,
 ) =>
-  Binding.layer(tag, definition.binding, isAnalyticsEngineDataset, makeClient(definition), {
-    expected: expectedAnalyticsEngineDataset,
-  });
+  Binding.layer(
+    tag,
+    definition.binding,
+    isAnalyticsEngineDataset,
+    makeClient(definition, definition.write),
+    {
+      expected: expectedAnalyticsEngineDataset,
+    },
+  );
 
 export const make = <Id extends string>(id: Id) => Tag<AnalyticsEngineService<Id>>()<Id>(id);
 

--- a/packages/effect-cf/src/AnalyticsEngine.ts
+++ b/packages/effect-cf/src/AnalyticsEngine.ts
@@ -1,0 +1,463 @@
+import type {
+  AnalyticsEngineDataPoint as CloudflareAnalyticsEngineDataPoint,
+  AnalyticsEngineDataset as CloudflareAnalyticsEngineDataset,
+} from "@cloudflare/workers-types";
+import { Config, Context, Data, Effect, Layer, Option, Redacted, Schema as S } from "effect";
+import {
+  FetchHttpClient,
+  type Headers,
+  HttpClient,
+  type HttpClientResponse,
+  HttpClientRequest,
+} from "effect/unstable/http";
+
+import * as Binding from "./Binding";
+import type { WorkerEnvironment } from "./Environment";
+
+const expectedAnalyticsEngineDataset = "Analytics Engine dataset binding with writeDataPoint()";
+const defaultQueryApiBaseUrl = "https://api.cloudflare.com/client/v4";
+
+const queryColumnSchema = S.Struct({
+  name: S.String,
+  type: S.String,
+});
+
+const queryRowSchema = S.Record(S.String, S.Unknown);
+
+const queryResponseSchema = S.Struct({
+  meta: S.Array(queryColumnSchema),
+  data: S.Array(queryRowSchema),
+  rows: S.Number,
+});
+
+const decodeQueryResponse = S.decodeUnknownEffect(queryResponseSchema);
+
+/** Error raised when an Analytics Engine operation fails. */
+export class AnalyticsEngineOperationError extends Data.TaggedError(
+  "AnalyticsEngineOperationError",
+)<{
+  readonly binding: string;
+  readonly operation: string;
+  readonly cause: unknown;
+}> {}
+
+/** Error raised when an Analytics Engine SQL API query fails. */
+export class AnalyticsEngineQueryError extends Data.TaggedError("AnalyticsEngineQueryError")<{
+  readonly operation: string;
+  readonly accountId: string;
+  readonly message: string;
+  readonly status?: number;
+  readonly body?: string;
+  readonly cause?: unknown;
+}> {}
+
+/** Typed Analytics Engine dataset binding definition. */
+export interface AnalyticsEngineDefinition {
+  /** Binding name as configured in `wrangler.jsonc`. */
+  readonly binding: string;
+}
+
+export type AnalyticsEngineBinding = CloudflareAnalyticsEngineDataset;
+export type AnalyticsEngineDataPoint = CloudflareAnalyticsEngineDataPoint;
+export type AnalyticsEngineFieldValue = ArrayBuffer | string | null;
+export type AnalyticsEngineQueryColumn = S.Schema.Type<typeof queryColumnSchema>;
+export type AnalyticsEngineQueryRow = S.Schema.Type<typeof queryRowSchema>;
+
+export interface AnalyticsEngineQueryResult<Row = AnalyticsEngineQueryRow> {
+  readonly meta: ReadonlyArray<AnalyticsEngineQueryColumn>;
+  readonly data: ReadonlyArray<Row>;
+  readonly rows: number;
+}
+
+export interface AnalyticsEngineQueryDefinition {
+  /** Cloudflare account id that owns the Analytics Engine datasets. */
+  readonly accountId: string;
+  /** API token with Account Analytics Read permission. */
+  readonly apiToken: Redacted.Redacted<string>;
+  /** Base Cloudflare API URL. Defaults to `https://api.cloudflare.com/client/v4`. */
+  readonly apiBaseUrl?: string | URL;
+}
+
+export interface AnalyticsEngineQueryOptions {
+  /** Additional request headers. Authorization is always derived from `apiToken`. */
+  readonly headers?: Headers.Input;
+}
+
+export interface AnalyticsEngineClient {
+  readonly writeDataPoint: (
+    dataPoint?: AnalyticsEngineDataPoint,
+  ) => Effect.Effect<void, AnalyticsEngineOperationError>;
+  readonly write: (
+    dataPoint?: AnalyticsEngineDataPoint,
+  ) => Effect.Effect<void, AnalyticsEngineOperationError>;
+  readonly unsafeRaw: Effect.Effect<AnalyticsEngineBinding>;
+  readonly definition: AnalyticsEngineDefinition;
+}
+
+export interface AnalyticsEngineQueryClient {
+  readonly query: (
+    sql: string,
+    options?: AnalyticsEngineQueryOptions,
+  ) => Effect.Effect<AnalyticsEngineQueryResult, AnalyticsEngineQueryError | S.SchemaError>;
+  readonly queryResult: <Row>(
+    row: S.Codec<Row, unknown>,
+    sql: string,
+    options?: AnalyticsEngineQueryOptions,
+  ) => Effect.Effect<AnalyticsEngineQueryResult<Row>, AnalyticsEngineQueryError | S.SchemaError>;
+  readonly queryRows: <Row>(
+    row: S.Codec<Row, unknown>,
+    sql: string,
+    options?: AnalyticsEngineQueryOptions,
+  ) => Effect.Effect<ReadonlyArray<Row>, AnalyticsEngineQueryError | S.SchemaError>;
+  readonly queryOne: <Row>(
+    row: S.Codec<Row, unknown>,
+    sql: string,
+    options?: AnalyticsEngineQueryOptions,
+  ) => Effect.Effect<Option.Option<Row>, AnalyticsEngineQueryError | S.SchemaError>;
+  readonly queryText: (
+    sql: string,
+    options?: AnalyticsEngineQueryOptions,
+  ) => Effect.Effect<string, AnalyticsEngineQueryError>;
+  readonly raw: (
+    sql: string,
+    options?: AnalyticsEngineQueryOptions,
+  ) => Effect.Effect<HttpClientResponse.HttpClientResponse, AnalyticsEngineQueryError>;
+  readonly definition: AnalyticsEngineQueryDefinition;
+}
+
+declare const AnalyticsEngineServiceTypeId: unique symbol;
+declare const AnalyticsEngineQueryServiceTypeId: unique symbol;
+
+/** Nominal service marker for Analytics Engine services created with {@link make}. */
+export interface AnalyticsEngineService<Id extends string> {
+  readonly [AnalyticsEngineServiceTypeId]: {
+    readonly id: Id;
+  };
+}
+
+/** Nominal service marker for Analytics Engine query services created with {@link makeQuery}. */
+export interface AnalyticsEngineQueryService<Id extends string> {
+  readonly [AnalyticsEngineQueryServiceTypeId]: {
+    readonly id: Id;
+  };
+}
+
+export type LayerOptions = {
+  readonly binding: string;
+};
+
+export type QueryConfigOptions = {
+  readonly accountId?: Config.Config<string>;
+  readonly apiToken?: Config.Config<Redacted.Redacted<string>>;
+  readonly apiBaseUrl?: Config.Config<string>;
+};
+
+export interface TagClass<Self, Id extends string> extends Context.ServiceClass<
+  Self,
+  Id,
+  AnalyticsEngineClient
+> {
+  readonly id: Id;
+  readonly layer: (
+    options: LayerOptions,
+  ) => Layer.Layer<
+    Self,
+    Binding.BindingNotFoundError | Binding.BindingValidationError,
+    WorkerEnvironment
+  >;
+}
+
+export interface QueryTagClass<Self, Id extends string> extends Context.ServiceClass<
+  Self,
+  Id,
+  AnalyticsEngineQueryClient
+> {
+  readonly id: Id;
+  readonly layer: (
+    definition: AnalyticsEngineQueryDefinition,
+  ) => Layer.Layer<Self, never, HttpClient.HttpClient>;
+  readonly fetchLayer: (definition: AnalyticsEngineQueryDefinition) => Layer.Layer<Self>;
+  readonly layerConfig: (
+    config?: Config.Config<AnalyticsEngineQueryDefinition>,
+  ) => Layer.Layer<Self, Config.ConfigError, HttpClient.HttpClient>;
+  readonly fetchLayerConfig: (
+    config?: Config.Config<AnalyticsEngineQueryDefinition>,
+  ) => Layer.Layer<Self, Config.ConfigError>;
+}
+
+const analyticsEngineError = (binding: string, operation: string, cause: unknown) =>
+  new AnalyticsEngineOperationError({ binding, operation, cause });
+
+const analyticsEngineQueryError = (
+  definition: AnalyticsEngineQueryDefinition,
+  operation: string,
+  message: string,
+  options?: {
+    readonly status?: number;
+    readonly body?: string;
+    readonly cause?: unknown;
+  },
+) =>
+  new AnalyticsEngineQueryError({
+    operation,
+    accountId: definition.accountId,
+    message,
+    status: options?.status,
+    body: options?.body,
+    cause: options?.cause,
+  });
+
+const tryAnalyticsEngineSync = <A>(
+  binding: string,
+  operation: string,
+  evaluate: () => A,
+): Effect.Effect<A, AnalyticsEngineOperationError> =>
+  Effect.try({
+    try: evaluate,
+    catch: (cause) => analyticsEngineError(binding, operation, cause),
+  });
+
+const queryApiUrl = (definition: AnalyticsEngineQueryDefinition) => {
+  const baseUrl = new URL(definition.apiBaseUrl ?? defaultQueryApiBaseUrl);
+  const pathname = baseUrl.pathname.replace(/\/+$/, "");
+  baseUrl.pathname = `${pathname}/accounts/${definition.accountId}/analytics_engine/sql`;
+  return baseUrl.href;
+};
+
+const queryRequest = (
+  definition: AnalyticsEngineQueryDefinition,
+  sql: string,
+  options?: AnalyticsEngineQueryOptions,
+) => {
+  let request = HttpClientRequest.post(queryApiUrl(definition)).pipe(
+    HttpClientRequest.bodyText(sql, "text/plain;charset=UTF-8"),
+  );
+
+  if (options?.headers !== undefined) {
+    request = HttpClientRequest.setHeaders(request, options.headers);
+  }
+
+  return HttpClientRequest.bearerToken(request, definition.apiToken);
+};
+
+const responseText = (
+  definition: AnalyticsEngineQueryDefinition,
+  response: HttpClientResponse.HttpClientResponse,
+  operation: string,
+) =>
+  response.text.pipe(
+    Effect.catch((cause) =>
+      Effect.fail(
+        analyticsEngineQueryError(
+          definition,
+          operation,
+          "Failed to read Analytics Engine SQL API response body",
+          { cause },
+        ),
+      ),
+    ),
+  );
+
+const executeQueryRequest = (
+  definition: AnalyticsEngineQueryDefinition,
+  httpClient: HttpClient.HttpClient,
+  sql: string,
+  options?: AnalyticsEngineQueryOptions,
+) =>
+  Effect.gen(function* () {
+    const response = yield* httpClient.execute(queryRequest(definition, sql, options)).pipe(
+      Effect.mapError((cause) =>
+        analyticsEngineQueryError(definition, "query", "Analytics Engine SQL API request failed", {
+          cause,
+        }),
+      ),
+    );
+
+    if (response.status < 200 || response.status >= 300) {
+      const body = yield* responseText(definition, response, "queryErrorBody");
+      return yield* Effect.fail(
+        analyticsEngineQueryError(
+          definition,
+          "query",
+          `Analytics Engine SQL API returned HTTP ${response.status}`,
+          { status: response.status, body },
+        ),
+      );
+    }
+
+    return response;
+  });
+
+const makeQueryClientWith = (
+  definition: AnalyticsEngineQueryDefinition,
+  httpClient: HttpClient.HttpClient,
+): AnalyticsEngineQueryClient => {
+  const raw = (sql: string, options?: AnalyticsEngineQueryOptions) =>
+    executeQueryRequest(definition, httpClient, sql, options);
+  const query = (sql: string, options?: AnalyticsEngineQueryOptions) =>
+    Effect.gen(function* () {
+      const response = yield* raw(sql, options);
+      const json = yield* response.json.pipe(
+        Effect.catch((cause) =>
+          Effect.fail(
+            analyticsEngineQueryError(
+              definition,
+              "json",
+              "Failed to read Analytics Engine SQL API JSON response body",
+              { cause },
+            ),
+          ),
+        ),
+      );
+      return yield* decodeQueryResponse(json);
+    });
+  const queryResult = <Row>(
+    row: S.Codec<Row, unknown>,
+    sql: string,
+    options?: AnalyticsEngineQueryOptions,
+  ) =>
+    Effect.gen(function* () {
+      const result = yield* query(sql, options);
+      const decodeRow = S.decodeUnknownEffect(row);
+      const data: Array<Row> = [];
+
+      for (const value of result.data) {
+        data.push(yield* decodeRow(value));
+      }
+
+      return {
+        ...result,
+        data,
+        rows: result.rows,
+      } satisfies AnalyticsEngineQueryResult<Row>;
+    });
+
+  return {
+    definition,
+    raw,
+    query,
+    queryResult,
+    queryRows: (row, sql, options) =>
+      queryResult(row, sql, options).pipe(Effect.map((result) => result.data)),
+    queryOne: (row, sql, options) =>
+      queryResult(row, sql, options).pipe(
+        Effect.map((result) =>
+          result.data[0] === undefined ? Option.none() : Option.some(result.data[0]),
+        ),
+      ),
+    queryText: (sql, options) =>
+      raw(sql, options).pipe(
+        Effect.flatMap((response) => responseText(definition, response, "text")),
+      ),
+  };
+};
+
+export const makeQueryClient = (definition: AnalyticsEngineQueryDefinition) =>
+  Effect.map(HttpClient.HttpClient, (httpClient) => makeQueryClientWith(definition, httpClient));
+
+export const isAnalyticsEngineDataset = (value: unknown): value is AnalyticsEngineBinding => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  return typeof Reflect.get(value, "writeDataPoint") === "function";
+};
+
+export const makeClient =
+  (definition: AnalyticsEngineDefinition) =>
+  (dataset: AnalyticsEngineBinding): AnalyticsEngineClient => {
+    const writeDataPoint = (dataPoint?: AnalyticsEngineDataPoint) =>
+      tryAnalyticsEngineSync(definition.binding, "writeDataPoint", () =>
+        dataset.writeDataPoint(dataPoint),
+      );
+
+    return {
+      definition,
+      writeDataPoint,
+      write: writeDataPoint,
+      unsafeRaw: Effect.succeed(dataset),
+    };
+  };
+
+export const queryConfig = (options?: QueryConfigOptions) =>
+  Config.all({
+    accountId: options?.accountId ?? Config.string("CLOUDFLARE_ACCOUNT_ID"),
+    apiToken: options?.apiToken ?? Config.redacted("CLOUDFLARE_API_TOKEN"),
+    apiBaseUrl:
+      options?.apiBaseUrl ??
+      Config.string("CLOUDFLARE_API_BASE_URL").pipe(Config.withDefault(defaultQueryApiBaseUrl)),
+  });
+
+export const queryLayer = <Self>(
+  tag: Context.Service<Self, AnalyticsEngineQueryClient>,
+  definition: AnalyticsEngineQueryDefinition,
+) => Layer.effect(tag, makeQueryClient(definition));
+
+export const queryFetchLayer = <Self>(
+  tag: Context.Service<Self, AnalyticsEngineQueryClient>,
+  definition: AnalyticsEngineQueryDefinition,
+) => queryLayer(tag, definition).pipe(Layer.provide(FetchHttpClient.layer));
+
+export const queryLayerConfig = <Self>(
+  tag: Context.Service<Self, AnalyticsEngineQueryClient>,
+  config: Config.Config<AnalyticsEngineQueryDefinition> = queryConfig(),
+) =>
+  Layer.effect(
+    tag,
+    Effect.gen(function* () {
+      const definition = yield* config;
+      return yield* makeQueryClient(definition);
+    }),
+  );
+
+export const queryFetchLayerConfig = <Self>(
+  tag: Context.Service<Self, AnalyticsEngineQueryClient>,
+  config: Config.Config<AnalyticsEngineQueryDefinition> = queryConfig(),
+) => queryLayerConfig(tag, config).pipe(Layer.provide(FetchHttpClient.layer));
+
+export const layer = <Self>(
+  tag: Context.Service<Self, AnalyticsEngineClient>,
+  definition: AnalyticsEngineDefinition,
+) =>
+  Binding.layer(tag, definition.binding, isAnalyticsEngineDataset, makeClient(definition), {
+    expected: expectedAnalyticsEngineDataset,
+  });
+
+export const make = <Id extends string>(id: Id) => Tag<AnalyticsEngineService<Id>>()<Id>(id);
+
+export const makeQuery = <Id extends string>(id: Id) =>
+  QueryTag<AnalyticsEngineQueryService<Id>>()<Id>(id);
+
+export const Tag =
+  <Self>() =>
+  <Id extends string>(id: Id) => {
+    const tag = Context.Service<Self, AnalyticsEngineClient>()(id);
+
+    const makeLayer = (definition: LayerOptions) => layer(tag, definition);
+
+    return Object.assign(tag, {
+      id,
+      layer: makeLayer,
+    }) as TagClass<Self, Id>;
+  };
+
+export const QueryTag =
+  <Self>() =>
+  <Id extends string>(id: Id) => {
+    const tag = Context.Service<Self, AnalyticsEngineQueryClient>()(id);
+    const makeLayer = (definition: AnalyticsEngineQueryDefinition) => queryLayer(tag, definition);
+    const makeFetchLayer = (definition: AnalyticsEngineQueryDefinition) =>
+      queryFetchLayer(tag, definition);
+    const makeLayerConfig = (config?: Config.Config<AnalyticsEngineQueryDefinition>) =>
+      queryLayerConfig(tag, config);
+    const makeFetchLayerConfig = (config?: Config.Config<AnalyticsEngineQueryDefinition>) =>
+      queryFetchLayerConfig(tag, config);
+
+    return Object.assign(tag, {
+      id,
+      layer: makeLayer,
+      fetchLayer: makeFetchLayer,
+      layerConfig: makeLayerConfig,
+      fetchLayerConfig: makeFetchLayerConfig,
+    }) as QueryTagClass<Self, Id>;
+  };

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -1,4 +1,5 @@
 export * as AiGateway from "./AiGateway";
+export * as AnalyticsEngine from "./AnalyticsEngine";
 export * as Binding from "./Binding";
 export * as BrowserRendering from "./BrowserRendering";
 export * as CloudflareOtlp from "./CloudflareOtlp";

--- a/packages/effect-cf/tests/AnalyticsEngine.test.ts
+++ b/packages/effect-cf/tests/AnalyticsEngine.test.ts
@@ -1,0 +1,292 @@
+import { assert, expect, layer, test } from "@effect/vitest";
+import { Config, ConfigProvider, Effect, Layer, Option, Redacted, Schema as S } from "effect";
+import { FetchHttpClient, HttpClient } from "effect/unstable/http";
+
+import { AnalyticsEngine, Binding, WorkerEnvironment } from "../src/index";
+
+class RequestAnalytics extends AnalyticsEngine.Tag<RequestAnalytics>()("test/RequestAnalytics") {}
+
+class RequestAnalyticsQuery extends AnalyticsEngine.QueryTag<RequestAnalyticsQuery>()(
+  "test/RequestAnalyticsQuery",
+) {}
+
+interface FakeAnalyticsEngineDataset extends AnalyticsEngine.AnalyticsEngineBinding {
+  readonly points: Array<AnalyticsEngine.AnalyticsEngineDataPoint | undefined>;
+}
+
+const makeFakeAnalyticsEngineDataset = (
+  writeDataPoint?: (dataPoint?: AnalyticsEngine.AnalyticsEngineDataPoint) => void,
+): FakeAnalyticsEngineDataset => {
+  const points: Array<AnalyticsEngine.AnalyticsEngineDataPoint | undefined> = [];
+
+  return {
+    points,
+    writeDataPoint:
+      writeDataPoint ??
+      ((dataPoint) => {
+        points.push(dataPoint);
+      }),
+  };
+};
+
+const analyticsLayer = (dataset: AnalyticsEngine.AnalyticsEngineBinding) =>
+  RequestAnalytics.layer({ binding: "REQUEST_ANALYTICS" }).pipe(
+    Layer.provide(Layer.succeed(WorkerEnvironment, { REQUEST_ANALYTICS: dataset })),
+  );
+
+const fetchLayer = (request: typeof fetch) =>
+  FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch, request)));
+
+const queryLayerWithFetch = (
+  queryLayer: Layer.Layer<RequestAnalyticsQuery, Config.ConfigError, HttpClient.HttpClient>,
+  request: typeof fetch,
+) => queryLayer.pipe(Layer.provide(fetchLayer(request)));
+
+layer(analyticsLayer(makeFakeAnalyticsEngineDataset()))("AnalyticsEngine", (it) => {
+  it.effect("writes data points to the native binding", () =>
+    Effect.gen(function* () {
+      const analytics = yield* RequestAnalytics;
+      const raw = yield* analytics.unsafeRaw;
+
+      yield* analytics.writeDataPoint({
+        indexes: ["example.com"],
+        blobs: ["/home", "US", null],
+        doubles: [1, 42],
+      });
+      yield* analytics.write({ indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] });
+
+      assert.deepStrictEqual((raw as FakeAnalyticsEngineDataset).points, [
+        {
+          indexes: ["example.com"],
+          blobs: ["/home", "US", null],
+          doubles: [1, 42],
+        },
+        {
+          indexes: ["example.com"],
+          blobs: ["/pricing"],
+          doubles: [1],
+        },
+      ]);
+    }),
+  );
+});
+
+test("AnalyticsEngine layer validates the binding shape", async () => {
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const analytics = yield* RequestAnalytics;
+        yield* analytics.writeDataPoint({ indexes: ["example.com"] });
+      }).pipe(
+        Effect.provide(
+          RequestAnalytics.layer({ binding: "REQUEST_ANALYTICS" }).pipe(
+            Layer.provide(
+              Layer.succeed(WorkerEnvironment, {
+                REQUEST_ANALYTICS: {} as AnalyticsEngine.AnalyticsEngineBinding,
+              }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toBeInstanceOf(Binding.BindingValidationError);
+});
+
+test("AnalyticsEngine wraps operation failures", async () => {
+  const cause = new Error("invalid analytics point");
+
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const analytics = yield* RequestAnalytics;
+        yield* analytics.writeDataPoint({ indexes: ["example.com"] });
+      }).pipe(
+        Effect.provide(
+          analyticsLayer(
+            makeFakeAnalyticsEngineDataset(() => {
+              throw cause;
+            }),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "AnalyticsEngineOperationError",
+    binding: "REQUEST_ANALYTICS",
+    operation: "writeDataPoint",
+    cause,
+  });
+});
+
+test("AnalyticsEngine query client posts SQL with redacted authorization and decodes rows", async () => {
+  const seen: Array<{
+    readonly url: string;
+    readonly headers: Record<string, string>;
+    readonly body: string | undefined;
+  }> = [];
+  const request: typeof fetch = async (input, init) => {
+    const url = typeof input === "string" || input instanceof URL ? input.toString() : input.url;
+    const body =
+      typeof init?.body === "string"
+        ? init.body
+        : init?.body instanceof Uint8Array
+          ? new TextDecoder().decode(init.body)
+          : undefined;
+
+    seen.push({
+      url,
+      headers: Object.fromEntries(new Headers(init?.headers).entries()),
+      body,
+    });
+
+    return Response.json({
+      meta: [
+        { name: "path", type: "String" },
+        { name: "views", type: "UInt64" },
+      ],
+      data: [{ path: "/home", views: 42 }],
+      rows: 1,
+    });
+  };
+
+  const client = await Effect.runPromise(
+    AnalyticsEngine.makeQueryClient({
+      accountId: "account-1",
+      apiToken: Redacted.make("secret-token"),
+    }).pipe(Effect.provide(fetchLayer(request))),
+  );
+  const rowSchema = S.Struct({
+    path: S.String,
+    views: S.Number,
+  });
+
+  const result = await Effect.runPromise(
+    client.queryResult(
+      rowSchema,
+      "SELECT blob1 AS path, SUM(_sample_interval) AS views FROM request_metrics GROUP BY path",
+    ),
+  );
+
+  expect(result).toEqual({
+    meta: [
+      { name: "path", type: "String" },
+      { name: "views", type: "UInt64" },
+    ],
+    data: [{ path: "/home", views: 42 }],
+    rows: 1,
+  });
+  assert.strictEqual(
+    seen[0]?.url,
+    "https://api.cloudflare.com/client/v4/accounts/account-1/analytics_engine/sql",
+  );
+  assert.strictEqual(seen[0]?.headers.authorization, "Bearer secret-token");
+  assert.strictEqual(seen[0]?.headers["content-type"], "text/plain;charset=UTF-8");
+});
+
+test("AnalyticsEngine query layer reads config through the active ConfigProvider", async () => {
+  const request: typeof fetch = async () =>
+    Response.json({
+      meta: [{ name: "dataset", type: "String" }],
+      data: [{ dataset: "request_metrics" }],
+      rows: 1,
+    });
+
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const query = yield* RequestAnalyticsQuery;
+      const row = yield* query.queryOne(S.Struct({ dataset: S.String }), "SHOW TABLES");
+      return row;
+    }).pipe(
+      Effect.provide(queryLayerWithFetch(RequestAnalyticsQuery.layerConfig(), request)),
+      Effect.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromUnknown({
+            CLOUDFLARE_ACCOUNT_ID: "account-1",
+            CLOUDFLARE_API_TOKEN: "secret-token",
+          }),
+        ),
+      ),
+    ),
+  );
+
+  assert.deepStrictEqual(Option.getOrUndefined(result), { dataset: "request_metrics" });
+});
+
+test("AnalyticsEngine query config accepts custom config keys", async () => {
+  const seen: Array<string | undefined> = [];
+  const request: typeof fetch = async (_input, init) => {
+    seen.push(new Headers(init?.headers).get("authorization") ?? undefined);
+    return Response.json({ meta: [], data: [], rows: 0 });
+  };
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const query = yield* RequestAnalyticsQuery;
+      yield* query.query("SHOW TABLES");
+    }).pipe(
+      Effect.provide(
+        queryLayerWithFetch(
+          RequestAnalyticsQuery.layerConfig(
+            AnalyticsEngine.queryConfig({
+              accountId: Config.string("ACCOUNT_ID"),
+              apiToken: Config.redacted("API_TOKEN"),
+            }),
+          ),
+          request,
+        ),
+      ),
+      Effect.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromUnknown({
+            ACCOUNT_ID: "account-1",
+            API_TOKEN: "custom-secret",
+          }),
+        ),
+      ),
+    ),
+  );
+
+  assert.deepStrictEqual(seen, ["Bearer custom-secret"]);
+});
+
+test("AnalyticsEngine query client maps non-2xx responses", async () => {
+  const client = await Effect.runPromise(
+    AnalyticsEngine.makeQueryClient({
+      accountId: "account-1",
+      apiToken: Redacted.make("secret-token"),
+    }).pipe(Effect.provide(fetchLayer(async () => new Response("bad query", { status: 400 })))),
+  );
+
+  await expect(Effect.runPromise(client.query("SELECT nope"))).rejects.toMatchObject({
+    _tag: "AnalyticsEngineQueryError",
+    operation: "query",
+    accountId: "account-1",
+    status: 400,
+    body: "bad query",
+  });
+});
+
+test("AnalyticsEngine query client surfaces schema failures", async () => {
+  const client = await Effect.runPromise(
+    AnalyticsEngine.makeQueryClient({
+      accountId: "account-1",
+      apiToken: Redacted.make("secret-token"),
+    }).pipe(
+      Effect.provide(
+        fetchLayer(async () =>
+          Response.json({
+            meta: [{ name: "views", type: "UInt64" }],
+            data: [{ views: "not-a-number" }],
+            rows: 1,
+          }),
+        ),
+      ),
+    ),
+  );
+
+  await expect(
+    Effect.runPromise(client.queryRows(S.Struct({ views: S.Number }), "SELECT views")),
+  ).rejects.toMatchObject({
+    _tag: "SchemaError",
+  });
+});

--- a/packages/effect-cf/tests/AnalyticsEngine.test.ts
+++ b/packages/effect-cf/tests/AnalyticsEngine.test.ts
@@ -122,6 +122,25 @@ test("AnalyticsEngine validates write limits before calling the native binding",
   assert.deepStrictEqual(dataset.points, []);
 });
 
+test("AnalyticsEngine accepts omitted, undefined, and null write inputs", async () => {
+  const dataset = makeFakeAnalyticsEngineDataset();
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const analytics = yield* RequestAnalytics;
+
+      yield* analytics.writeDataPoint();
+      yield* analytics.writeDataPoint({
+        indexes: undefined,
+        doubles: undefined,
+        blobs: [null],
+      });
+    }).pipe(Effect.provide(analyticsLayer(dataset))),
+  );
+
+  assert.deepStrictEqual(dataset.points, [undefined, { blobs: [null] }]);
+});
+
 test("AnalyticsEngine validates blob and index byte limits", async () => {
   const dataset = makeFakeAnalyticsEngineDataset();
 

--- a/packages/effect-cf/tests/AnalyticsEngine.test.ts
+++ b/packages/effect-cf/tests/AnalyticsEngine.test.ts
@@ -12,25 +12,46 @@ class RequestAnalyticsQuery extends AnalyticsEngine.QueryTag<RequestAnalyticsQue
 
 interface FakeAnalyticsEngineDataset extends AnalyticsEngine.AnalyticsEngineBinding {
   readonly points: Array<AnalyticsEngine.AnalyticsEngineDataPoint | undefined>;
+  readonly batches: Array<Array<AnalyticsEngine.AnalyticsEngineDataPoint>>;
+  readonly writeDataPoints?: (
+    dataPoints: ReadonlyArray<AnalyticsEngine.AnalyticsEngineDataPoint>,
+  ) => void;
 }
 
 const makeFakeAnalyticsEngineDataset = (
   writeDataPoint?: (dataPoint?: AnalyticsEngine.AnalyticsEngineDataPoint) => void,
+  options?: {
+    readonly nativeWriteDataPoints?: boolean;
+  },
 ): FakeAnalyticsEngineDataset => {
   const points: Array<AnalyticsEngine.AnalyticsEngineDataPoint | undefined> = [];
+  const batches: Array<Array<AnalyticsEngine.AnalyticsEngineDataPoint>> = [];
 
   return {
     points,
+    batches,
     writeDataPoint:
       writeDataPoint ??
       ((dataPoint) => {
         points.push(dataPoint);
       }),
-  };
+    ...(options?.nativeWriteDataPoints === true
+      ? {
+          writeDataPoints: (
+            dataPoints: ReadonlyArray<AnalyticsEngine.AnalyticsEngineDataPoint>,
+          ) => {
+            batches.push([...dataPoints]);
+          },
+        }
+      : {}),
+  } as FakeAnalyticsEngineDataset;
 };
 
-const analyticsLayer = (dataset: AnalyticsEngine.AnalyticsEngineBinding) =>
-  RequestAnalytics.layer({ binding: "REQUEST_ANALYTICS" }).pipe(
+const analyticsLayer = (
+  dataset: AnalyticsEngine.AnalyticsEngineBinding,
+  options?: Omit<AnalyticsEngine.LayerOptions, "binding">,
+) =>
+  RequestAnalytics.layer({ binding: "REQUEST_ANALYTICS", ...options }).pipe(
     Layer.provide(Layer.succeed(WorkerEnvironment, { REQUEST_ANALYTICS: dataset })),
   );
 
@@ -69,6 +90,222 @@ layer(analyticsLayer(makeFakeAnalyticsEngineDataset()))("AnalyticsEngine", (it) 
       ]);
     }),
   );
+});
+
+test("AnalyticsEngine validates write limits before calling the native binding", async () => {
+  const dataset = makeFakeAnalyticsEngineDataset();
+
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const analytics = yield* RequestAnalytics;
+        yield* analytics.writeDataPoint({
+          blobs: Array.from({ length: AnalyticsEngine.writeLimits.maxBlobs + 1 }, (_, index) =>
+            String(index),
+          ),
+        });
+      }).pipe(Effect.provide(analyticsLayer(dataset))),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "AnalyticsEngineWriteValidationError",
+    binding: "REQUEST_ANALYTICS",
+    operation: "writeDataPoint",
+    violations: [
+      {
+        path: "blobs",
+        actual: AnalyticsEngine.writeLimits.maxBlobs + 1,
+        limit: AnalyticsEngine.writeLimits.maxBlobs,
+      },
+    ],
+  });
+
+  assert.deepStrictEqual(dataset.points, []);
+});
+
+test("AnalyticsEngine validates blob and index byte limits", async () => {
+  const dataset = makeFakeAnalyticsEngineDataset();
+
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const analytics = yield* RequestAnalytics;
+        yield* analytics.writeDataPoint({
+          indexes: ["x".repeat(AnalyticsEngine.writeLimits.maxIndexBytes + 1)],
+          blobs: ["x".repeat(AnalyticsEngine.writeLimits.maxBlobBytes + 1)],
+        });
+      }).pipe(Effect.provide(analyticsLayer(dataset))),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "AnalyticsEngineWriteValidationError",
+    violations: [
+      {
+        path: "blobs",
+        actual: AnalyticsEngine.writeLimits.maxBlobBytes + 1,
+        limit: AnalyticsEngine.writeLimits.maxBlobBytes,
+      },
+      {
+        path: "indexes[0]",
+        actual: AnalyticsEngine.writeLimits.maxIndexBytes + 1,
+        limit: AnalyticsEngine.writeLimits.maxIndexBytes,
+      },
+    ],
+  });
+
+  assert.deepStrictEqual(dataset.points, []);
+});
+
+test("AnalyticsEngine surfaces schema validation errors for writes", async () => {
+  const dataset = makeFakeAnalyticsEngineDataset();
+
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const analytics = yield* RequestAnalytics;
+        yield* analytics.writeDataPoint({
+          doubles: [Number.NaN],
+        });
+      }).pipe(Effect.provide(analyticsLayer(dataset))),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "AnalyticsEngineWriteValidationError",
+    binding: "REQUEST_ANALYTICS",
+    operation: "writeDataPoint",
+    violations: [
+      {
+        path: "$",
+      },
+    ],
+  });
+
+  assert.deepStrictEqual(dataset.points, []);
+});
+
+test("AnalyticsEngine can drop invalid writes by layer policy", async () => {
+  const dataset = makeFakeAnalyticsEngineDataset();
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const analytics = yield* RequestAnalytics;
+
+      yield* analytics.writeDataPoint({
+        indexes: ["example.com", "overflow"],
+      });
+      yield* analytics.writeDataPoint({
+        indexes: ["example.com"],
+        blobs: ["/home"],
+      });
+    }).pipe(Effect.provide(analyticsLayer(dataset, { write: { onInvalid: "drop" } }))),
+  );
+
+  assert.deepStrictEqual(dataset.points, [
+    {
+      indexes: ["example.com"],
+      blobs: ["/home"],
+    },
+  ]);
+});
+
+test("AnalyticsEngine hard-error policy can override a drop layer policy", async () => {
+  const dataset = makeFakeAnalyticsEngineDataset();
+
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const analytics = yield* RequestAnalytics;
+        yield* analytics.writeDataPoint(
+          {
+            indexes: ["example.com", "overflow"],
+          },
+          { onInvalid: "error" },
+        );
+      }).pipe(Effect.provide(analyticsLayer(dataset, { write: { onInvalid: "drop" } }))),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "AnalyticsEngineWriteValidationError",
+    violations: [
+      {
+        path: "indexes",
+        actual: 2,
+        limit: AnalyticsEngine.writeLimits.maxIndexes,
+      },
+    ],
+  });
+
+  assert.deepStrictEqual(dataset.points, []);
+});
+
+test("AnalyticsEngine batches writeDataPoints through the native batch API when available", async () => {
+  const dataset = makeFakeAnalyticsEngineDataset(undefined, { nativeWriteDataPoints: true });
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const analytics = yield* RequestAnalytics;
+
+      yield* analytics.writeDataPoints(
+        [{ indexes: ["one"] }, { indexes: ["two"] }, { indexes: ["three"] }],
+        { batchSize: 2 },
+      );
+    }).pipe(Effect.provide(analyticsLayer(dataset))),
+  );
+
+  assert.deepStrictEqual(dataset.points, []);
+  assert.deepStrictEqual(dataset.batches, [
+    [{ indexes: ["one"] }, { indexes: ["two"] }],
+    [{ indexes: ["three"] }],
+  ]);
+});
+
+test("AnalyticsEngine enforces the per-invocation data point limit", async () => {
+  const dataset = makeFakeAnalyticsEngineDataset();
+  const dataPoints = Array.from(
+    { length: AnalyticsEngine.writeLimits.maxDataPointsPerInvocation + 1 },
+    (_, index) => ({ indexes: [String(index)] }),
+  );
+
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const analytics = yield* RequestAnalytics;
+        yield* analytics.writeBatch(dataPoints);
+      }).pipe(Effect.provide(analyticsLayer(dataset))),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "AnalyticsEngineWriteValidationError",
+    operation: "writeDataPoints",
+    violations: [
+      {
+        path: "dataPoints",
+        actual: AnalyticsEngine.writeLimits.maxDataPointsPerInvocation + 1,
+        limit: AnalyticsEngine.writeLimits.maxDataPointsPerInvocation,
+      },
+    ],
+  });
+
+  assert.deepStrictEqual(dataset.points, []);
+});
+
+test("AnalyticsEngine drops over-limit and invalid batch points when configured", async () => {
+  const dataset = makeFakeAnalyticsEngineDataset();
+  const dataPoints = Array.from(
+    { length: AnalyticsEngine.writeLimits.maxDataPointsPerInvocation + 1 },
+    (_, index) => ({
+      indexes: index === 1 ? ["example.com", "overflow"] : [String(index)],
+    }),
+  );
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const analytics = yield* RequestAnalytics;
+      yield* analytics.writeBatch(dataPoints, { onInvalid: "drop" });
+    }).pipe(Effect.provide(analyticsLayer(dataset))),
+  );
+
+  assert.strictEqual(
+    dataset.points.length,
+    AnalyticsEngine.writeLimits.maxDataPointsPerInvocation - 1,
+  );
+  assert.deepStrictEqual(dataset.points[0], { indexes: ["0"] });
+  assert.deepStrictEqual(dataset.points[1], { indexes: ["2"] });
 });
 
 test("AnalyticsEngine layer validates the binding shape", async () => {

--- a/packages/effect-cf/tests/binding-ergonomics.test-d.ts
+++ b/packages/effect-cf/tests/binding-ergonomics.test-d.ts
@@ -303,7 +303,10 @@ const vectorizeProgram = Effect.gen(function* () {
 
 export class RequestAnalytics extends AnalyticsEngine.Tag<RequestAnalytics>()("RequestAnalytics") {}
 
-export const RequestAnalyticsLayer = RequestAnalytics.layer({ binding: "REQUEST_ANALYTICS" });
+export const RequestAnalyticsLayer = RequestAnalytics.layer({
+  binding: "REQUEST_ANALYTICS",
+  write: { onInvalid: "drop", batchSize: 100 },
+});
 
 export class RequestAnalyticsQuery extends AnalyticsEngine.QueryTag<RequestAnalyticsQuery>()(
   "RequestAnalyticsQuery",
@@ -342,11 +345,25 @@ const analyticsEngineProgram = Effect.gen(function* () {
       blobs: ["/home", "US", null],
       doubles: [1, 42],
     }),
-  ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineOperationError>>();
+  ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineWriteError>>();
 
   expectTypeOf(
     analytics.write({ indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] }),
-  ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineOperationError>>();
+  ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineWriteError>>();
+
+  expectTypeOf(
+    analytics.writeDataPoints(
+      [
+        { indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] },
+        { indexes: ["example.com"], blobs: ["/home"], doubles: [1] },
+      ],
+      { onInvalid: "error", batchSize: 2 },
+    ),
+  ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineWriteError>>();
+
+  expectTypeOf(
+    analytics.writeBatch([{ indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] }]),
+  ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineWriteError>>();
 
   expectTypeOf(analytics.unsafeRaw).toEqualTypeOf<
     Effect.Effect<AnalyticsEngine.AnalyticsEngineBinding>
@@ -354,6 +371,9 @@ const analyticsEngineProgram = Effect.gen(function* () {
 
   // @ts-expect-error doubles only accept numbers.
   yield* analytics.writeDataPoint({ doubles: ["1"] });
+
+  // @ts-expect-error only known invalid-write policies are accepted.
+  yield* analytics.writeDataPoint({ doubles: [1] }, { onInvalid: "ignore" });
 });
 
 const analyticsEngineQueryProgram = Effect.gen(function* () {

--- a/packages/effect-cf/tests/binding-ergonomics.test-d.ts
+++ b/packages/effect-cf/tests/binding-ergonomics.test-d.ts
@@ -1,10 +1,12 @@
 import { expectTypeOf } from "vitest";
-import { Effect, Layer, Option, Schema } from "effect";
+import { Config, Effect, Layer, Option, Redacted, Schema } from "effect";
 import { PgClient } from "@effect/sql-pg";
+import { HttpClient } from "effect/unstable/http";
 import { SqlClient, SqlError } from "effect/unstable/sql";
 
 import {
   AiGateway,
+  AnalyticsEngine,
   Binding,
   BrowserRendering,
   DurableObject,
@@ -299,6 +301,121 @@ const vectorizeProgram = Effect.gen(function* () {
   ).toEqualTypeOf<Effect.Effect<Vectorize.VectorizeMatches, Vectorize.VectorizeOperationError>>();
 });
 
+export class RequestAnalytics extends AnalyticsEngine.Tag<RequestAnalytics>()("RequestAnalytics") {}
+
+export const RequestAnalyticsLayer = RequestAnalytics.layer({ binding: "REQUEST_ANALYTICS" });
+
+export class RequestAnalyticsQuery extends AnalyticsEngine.QueryTag<RequestAnalyticsQuery>()(
+  "RequestAnalyticsQuery",
+) {}
+
+export const RequestAnalyticsQueryLayer = RequestAnalyticsQuery.layer({
+  accountId: "account-1",
+  apiToken: Redacted.make("secret-token"),
+});
+
+export const RequestAnalyticsQueryFetchLayer = RequestAnalyticsQuery.fetchLayer({
+  accountId: "account-1",
+  apiToken: Redacted.make("secret-token"),
+});
+
+export const RequestAnalyticsQueryConfigLayer = RequestAnalyticsQuery.layerConfig(
+  AnalyticsEngine.queryConfig({
+    accountId: Config.string("ACCOUNT_ID"),
+    apiToken: Config.redacted("API_TOKEN"),
+  }),
+);
+
+export const RequestAnalyticsQueryFetchConfigLayer = RequestAnalyticsQuery.fetchLayerConfig(
+  AnalyticsEngine.queryConfig({
+    accountId: Config.string("ACCOUNT_ID"),
+    apiToken: Config.redacted("API_TOKEN"),
+  }),
+);
+
+const analyticsEngineProgram = Effect.gen(function* () {
+  const analytics = yield* RequestAnalytics;
+
+  expectTypeOf(
+    analytics.writeDataPoint({
+      indexes: ["example.com"],
+      blobs: ["/home", "US", null],
+      doubles: [1, 42],
+    }),
+  ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineOperationError>>();
+
+  expectTypeOf(
+    analytics.write({ indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] }),
+  ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineOperationError>>();
+
+  expectTypeOf(analytics.unsafeRaw).toEqualTypeOf<
+    Effect.Effect<AnalyticsEngine.AnalyticsEngineBinding>
+  >();
+
+  // @ts-expect-error doubles only accept numbers.
+  yield* analytics.writeDataPoint({ doubles: ["1"] });
+});
+
+const analyticsEngineQueryProgram = Effect.gen(function* () {
+  const query = yield* RequestAnalyticsQuery;
+  const row = Schema.Struct({
+    path: Schema.String,
+    views: Schema.Number,
+  });
+
+  expectTypeOf(query.query("SHOW TABLES")).toEqualTypeOf<
+    Effect.Effect<
+      AnalyticsEngine.AnalyticsEngineQueryResult,
+      AnalyticsEngine.AnalyticsEngineQueryError | Schema.SchemaError
+    >
+  >();
+
+  expectTypeOf(
+    query.queryRows(row, "SELECT blob1 AS path, double1 AS views FROM requests"),
+  ).toEqualTypeOf<
+    Effect.Effect<
+      ReadonlyArray<{ readonly path: string; readonly views: number }>,
+      AnalyticsEngine.AnalyticsEngineQueryError | Schema.SchemaError
+    >
+  >();
+
+  expectTypeOf(
+    query.queryOne(row, "SELECT blob1 AS path, double1 AS views FROM requests LIMIT 1"),
+  ).toEqualTypeOf<
+    Effect.Effect<
+      Option.Option<{ readonly path: string; readonly views: number }>,
+      AnalyticsEngine.AnalyticsEngineQueryError | Schema.SchemaError
+    >
+  >();
+
+  expectTypeOf(query.queryText("SHOW TABLES FORMAT TabSeparated")).toEqualTypeOf<
+    Effect.Effect<string, AnalyticsEngine.AnalyticsEngineQueryError>
+  >();
+});
+
+expectTypeOf(
+  AnalyticsEngine.makeQueryClient({
+    accountId: "account-1",
+    apiToken: Redacted.make("secret-token"),
+  }),
+).toEqualTypeOf<
+  Effect.Effect<AnalyticsEngine.AnalyticsEngineQueryClient, never, HttpClient.HttpClient>
+>();
+
+expectTypeOf(RequestAnalyticsQueryLayer).toEqualTypeOf<
+  Layer.Layer<RequestAnalyticsQuery, never, HttpClient.HttpClient>
+>();
+
+expectTypeOf(RequestAnalyticsQueryFetchLayer).toEqualTypeOf<Layer.Layer<RequestAnalyticsQuery>>();
+
+expectTypeOf(RequestAnalyticsQueryConfigLayer).toEqualTypeOf<
+  Layer.Layer<RequestAnalyticsQuery, Config.ConfigError, HttpClient.HttpClient>
+>();
+
+expectTypeOf(RequestAnalyticsQueryFetchConfigLayer).toEqualTypeOf<
+  Layer.Layer<RequestAnalyticsQuery, Config.ConfigError>
+>();
+
 export class Gateway extends AiGateway.Tag<Gateway>()("Gateway") {}
 
 export const GatewayLayer = Gateway.layer({ binding: "AI", gatewayId: "default" });
@@ -462,6 +579,8 @@ void imagesProgram;
 void emailProgram;
 void workersAiProgram;
 void vectorizeProgram;
+void analyticsEngineProgram;
+void analyticsEngineQueryProgram;
 void aiGatewayProgram;
 void browserRenderingProgram;
 void workerProgram;

--- a/packages/effect-cf/tests/env.d.ts
+++ b/packages/effect-cf/tests/env.d.ts
@@ -13,9 +13,14 @@ declare global {
       HYPERDRIVE?: Hyperdrive;
       IMAGES?: ImagesBinding;
       AI?: Ai;
+      REQUEST_ANALYTICS?: AnalyticsEngineDataset;
       RECIPE_VECTORS?: Vectorize;
       MYBROWSER?: unknown;
       DATABASE_URL?: string;
+      CLOUDFLARE_ACCOUNT_ID?: string;
+      CLOUDFLARE_API_TOKEN?: string;
+      ACCOUNT_ID?: string;
+      API_TOKEN?: string;
       SECRET_VALUE?: string;
       APP_NAME?: string;
       APP_PORT?: string;


### PR DESCRIPTION
## Summary

- add an Effect-native Analytics Engine dataset wrapper for validated `writeDataPoint(...)`, `write(...)`, `writeDataPoints(...)` / `writeBatch(...)`, raw binding access, and operation error mapping
- validate write inputs against Cloudflare Analytics Engine count, byte, and per-invocation limits with `AnalyticsEngineWriteValidationError` plus configurable hard-error/drop policy
- add an Analytics Engine SQL API query client backed by Effect `HttpClient`, with config/redacted token support and schema-decoded rows
- document the write/query usage and add a minor changeset for the new public API

## Validation

- `vp install`
- `vp check --fix`
- `vp check`
- `vp test`