### PR TITLE
feat: add Container namespace bindings

### DIFF
--- a/.changeset/green-containers-flow.md
+++ b/.changeset/green-containers-flow.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add `ContainerNamespace` services for named Cloudflare Container request forwarding and lifecycle operations.

--- a/bun.lock
+++ b/bun.lock
@@ -308,8 +308,9 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.13.1",
+      "version": "0.16.0",
       "devDependencies": {
+        "@cloudflare/containers": "catalog:",
         "@cloudflare/vitest-pool-workers": "catalog:",
         "@cloudflare/workers-types": "catalog:",
         "@effect/platform-node": "4.0.0-beta.77",
@@ -340,6 +341,7 @@
     "vitest": "catalog:",
   },
   "catalog": {
+    "@cloudflare/containers": "0.3.7",
     "@cloudflare/vitest-pool-workers": "0.16.15",
     "@cloudflare/workers-types": "4.20260611.1",
     "@effect/platform-bun": "4.0.0-beta.77",
@@ -393,6 +395,8 @@
     "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
+
+    "@cloudflare/containers": ["@cloudflare/containers@0.3.7", "", {}, "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 

--- a/examples/containers/README.md
+++ b/examples/containers/README.md
@@ -1,0 +1,76 @@
+# Cloudflare Containers
+
+`effect-cf` wraps the namespace binding that a Worker uses to locate and
+control named Containers. The Container Durable Object entrypoint itself
+continues to extend `Container` from `@cloudflare/containers`.
+
+```ts
+import { Container, ContainerProxy } from "@cloudflare/containers";
+import { Effect, Layer } from "effect";
+import { ContainerNamespace, Worker } from "effect-cf";
+
+export class RendererContainer extends Container {
+  defaultPort = 8080;
+  requiredPorts = [8080];
+  sleepAfter = "10m";
+}
+
+// Required only when RendererContainer configures outbound interception.
+export { ContainerProxy };
+
+class Renderers extends ContainerNamespace.Tag<Renderers>()("Renderers") {}
+
+const AppLive = Layer.mergeAll(Renderers.layer({ binding: "RENDERERS" }));
+
+export default Worker.make(AppLive, {
+  fetch: Effect.gen(function* () {
+    const request = yield* Worker.NativeRequest;
+    const name = new URL(request.url).searchParams.get("renderer") ?? "default";
+    const renderer = Renderers.byName(name);
+
+    yield* renderer.startAndWaitForPorts({
+      ports: 8080,
+      cancellationOptions: { portReadyTimeoutMS: 30_000 },
+    });
+
+    return yield* renderer.fetch(request);
+  }),
+});
+```
+
+A minimal Wrangler configuration declares both the Container image and its
+Durable Object namespace:
+
+```jsonc
+{
+  "name": "container-example",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-06-11",
+  "containers": [
+    {
+      "class_name": "RendererContainer",
+      "image": "./Dockerfile",
+      "max_instances": 5,
+    },
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "RENDERERS",
+        "class_name": "RendererContainer",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["RendererContainer"],
+    },
+  ],
+}
+```
+
+Use the namespace or named instance `unsafeRaw` Effect only for a native SDK
+operation that effect-cf does not expose. Container responses are not
+status-checked or transformed, so HTTP errors and WebSocket upgrade responses
+retain native Cloudflare behavior.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "packageManager": "bun@1.3.13",
   "catalog": {
+    "@cloudflare/containers": "0.3.7",
     "@cloudflare/workers-types": "4.20260611.1",
     "@cloudflare/vitest-pool-workers": "0.16.15",
     "@effect/platform-bun": "4.0.0-beta.77",

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -1,6 +1,6 @@
 # effect-cf
 
-Effect-native Cloudflare primitives for Workers, Durable Objects, bindings, KV, D1, Queues, Email, Analytics Engine, Workflows, and Durable Object storage.
+Effect-native Cloudflare primitives for Workers, Durable Objects, Containers, bindings, KV, D1, Queues, Email, Analytics Engine, Workflows, and Durable Object storage.
 
 ## Install
 
@@ -30,6 +30,7 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `DurableObject` - Durable Object entrypoint factory and typed namespace helpers
 - `DurableObjectState` / `DurableObjectStorage` - Effect wrappers for state, alarms, SQL, and embedded KV
 - `DurableObjectWebSocket` - WebSocket upgrade helpers for Durable Objects
+- `ContainerNamespace` - named Cloudflare Container instances with Effect-wrapped request and lifecycle operations
 - `Kv` - typed KV namespace helper
 - `D1` - typed D1 database binding helper with an `@effect/sql-d1` backed SQL layer
 - `R2` - typed R2 bucket binding helper with Effect-wrapped object and multipart operations
@@ -84,6 +85,46 @@ export const readCounter = Effect.gen(function* () {
 ```
 
 Define Wrangler bindings and migrations in the consuming application. Durable Object namespace bindings are provided with `YourObject.layer({ binding })`, and consumers use `const namespace = yield* YourObject`.
+
+## Container Example
+
+Container entrypoints remain owned by `@cloudflare/containers`; `effect-cf`
+wraps the Container namespace used by a calling Worker.
+
+```ts
+import { Container, switchPort } from "@cloudflare/containers";
+import { Effect, Layer } from "effect";
+import { ContainerNamespace, Worker } from "effect-cf";
+
+export class RendererContainer extends Container {
+  defaultPort = 8080;
+  sleepAfter = "10m";
+}
+
+class Renderers extends ContainerNamespace.Tag<Renderers>()("Renderers") {}
+
+const RenderersLive = Renderers.layer({ binding: "RENDERERS" });
+
+export default Worker.make(RenderersLive, {
+  fetch: Effect.gen(function* () {
+    const request = yield* Worker.NativeRequest;
+    const renderer = Renderers.byName(new URL(request.url).pathname);
+
+    yield* renderer.startAndWaitForPorts({ ports: 8080 });
+    return yield* renderer.fetch(switchPort(request, 8080));
+  }),
+});
+```
+
+The instance client exposes `state`, `fetch`, `start`,
+`startAndWaitForPorts`, `stop`, `destroy`, and the Effect-valued native
+`unsafeRaw` stub.
+Responses are returned unchanged, including non-2xx and WebSocket upgrade
+responses. If the Container uses outbound interception, also export
+`ContainerProxy` from `@cloudflare/containers`.
+
+See [`examples/containers/README.md`](../../examples/containers/README.md) for
+the corresponding Wrangler configuration and entrypoint responsibilities.
 
 ## Queue Example
 

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -39,6 +39,7 @@
     "prepublishOnly": "vp run build"
   },
   "devDependencies": {
+    "@cloudflare/containers": "catalog:",
     "@cloudflare/vitest-pool-workers": "catalog:",
     "@cloudflare/workers-types": "catalog:",
     "@effect/platform-node": "4.0.0-beta.77",

--- a/packages/effect-cf/src/ContainerNamespace.ts
+++ b/packages/effect-cf/src/ContainerNamespace.ts
@@ -1,0 +1,337 @@
+import { Context, Data, Effect, Schema, type Layer } from "effect";
+
+import * as Binding from "./Binding";
+import type { WorkerEnvironment } from "./Environment";
+
+const expectedContainerNamespace = "Container namespace binding with getByName()";
+
+/** Signal accepted by Cloudflare Container instances. */
+export type ContainerSignal = "SIGKILL" | "SIGINT" | "SIGTERM";
+
+/** Per-instance Container startup configuration. */
+export interface ContainerStartOptions {
+  readonly envVars?: Record<string, string>;
+  readonly entrypoint?: Array<string>;
+  readonly enableInternet?: boolean;
+  readonly labels?: Record<string, string>;
+}
+
+/** Serializable retry settings used while starting a Container. */
+export interface ContainerWaitOptions {
+  readonly portToCheck: number;
+  readonly retries?: number;
+  readonly waitInterval?: number;
+}
+
+/** Serializable timeout settings used while waiting for Container ports. */
+export interface ContainerReadinessOptions {
+  readonly instanceGetTimeoutMS?: number;
+  readonly portReadyTimeoutMS?: number;
+  readonly waitInterval?: number;
+}
+
+/** Options for starting a Container and waiting for its ports. */
+export interface ContainerStartAndWaitForPortsOptions {
+  readonly startOptions?: ContainerStartOptions;
+  readonly ports?: number | Array<number>;
+  readonly cancellationOptions?: ContainerReadinessOptions;
+}
+
+/** Serializable state reported by a Cloudflare Container instance. */
+export const ContainerState = Schema.Union([
+  Schema.Struct({
+    lastChange: Schema.Finite,
+    status: Schema.Literals(["running", "stopping", "stopped", "healthy"]),
+  }),
+  Schema.Struct({
+    lastChange: Schema.Finite,
+    status: Schema.Literal("stopped_with_code"),
+    exitCode: Schema.optionalKey(Schema.Int),
+  }),
+]);
+export type ContainerState = typeof ContainerState.Type;
+
+/**
+ * Native Container stub shape exposed by a Container namespace binding.
+ *
+ * This is structural so using Container bindings does not make
+ * `@cloudflare/containers` a runtime dependency of effect-cf.
+ */
+export interface ContainerStub {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+  getState(): Promise<ContainerState>;
+  start(options?: ContainerStartOptions, waitOptions?: ContainerWaitOptions): Promise<void>;
+  startAndWaitForPorts(options?: ContainerStartAndWaitForPortsOptions): Promise<void>;
+  stop(signal?: ContainerSignal): Promise<void>;
+  destroy(): Promise<void>;
+}
+
+/** Native Container namespace binding shape. */
+export interface ContainerNamespaceResource {
+  getByName(
+    name: string,
+    options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+  ): ContainerStub;
+}
+
+/** Container namespace binding metadata. */
+export interface ContainerNamespaceDefinition {
+  /** Binding name as configured in `wrangler.jsonc`. */
+  readonly binding: string;
+}
+
+/** Failure raised when invoking a named Container operation. */
+export class ContainerOperationError extends Data.TaggedError("ContainerOperationError")<{
+  readonly binding: string;
+  readonly instance: string;
+  readonly operation: string;
+  readonly cause: unknown;
+}> {}
+
+/** Effect-wrapped client for one named Container instance. */
+export interface ContainerInstanceClient {
+  readonly unsafeRaw: Effect.Effect<ContainerStub, ContainerOperationError>;
+  readonly state: Effect.Effect<ContainerState, ContainerOperationError>;
+  readonly fetch: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Effect.Effect<Response, ContainerOperationError>;
+  readonly start: (
+    options?: ContainerStartOptions,
+    waitOptions?: ContainerWaitOptions,
+  ) => Effect.Effect<void, ContainerOperationError>;
+  readonly startAndWaitForPorts: (
+    options?: ContainerStartAndWaitForPortsOptions,
+  ) => Effect.Effect<void, ContainerOperationError>;
+  readonly stop: (signal?: ContainerSignal) => Effect.Effect<void, ContainerOperationError>;
+  readonly destroy: Effect.Effect<void, ContainerOperationError>;
+}
+
+/** Effect client for a Container namespace binding. */
+export interface ContainerNamespaceClient {
+  readonly definition: ContainerNamespaceDefinition;
+  readonly getByName: (
+    name: string,
+    options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+  ) => Effect.Effect<ContainerInstanceClient, ContainerOperationError>;
+  readonly byName: (
+    name: string,
+    options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+  ) => ContainerInstanceClient;
+  readonly unsafeRaw: Effect.Effect<ContainerNamespaceResource>;
+}
+
+export type ContainerNamespaceStaticClient<R> = {
+  readonly getByName: (
+    name: string,
+    options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+  ) => Effect.Effect<ContainerInstanceClient, ContainerOperationError, R>;
+  readonly byName: (
+    name: string,
+    options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+  ) => {
+    readonly state: Effect.Effect<ContainerState, ContainerOperationError, R>;
+    readonly fetch: (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => Effect.Effect<Response, ContainerOperationError, R>;
+    readonly start: (
+      options?: ContainerStartOptions,
+      waitOptions?: ContainerWaitOptions,
+    ) => Effect.Effect<void, ContainerOperationError, R>;
+    readonly startAndWaitForPorts: (
+      options?: ContainerStartAndWaitForPortsOptions,
+    ) => Effect.Effect<void, ContainerOperationError, R>;
+    readonly stop: (signal?: ContainerSignal) => Effect.Effect<void, ContainerOperationError, R>;
+    readonly destroy: Effect.Effect<void, ContainerOperationError, R>;
+    readonly unsafeRaw: Effect.Effect<ContainerStub, ContainerOperationError, R>;
+  };
+  readonly unsafeRaw: () => Effect.Effect<ContainerNamespaceResource, never, R>;
+};
+
+export type LayerOptions = {
+  readonly binding: string;
+};
+
+export interface TagClass<Self, Id extends string>
+  extends
+    Context.ServiceClass<Self, Id, ContainerNamespaceClient>,
+    ContainerNamespaceStaticClient<Self> {
+  readonly id: Id;
+  readonly layer: (
+    options: LayerOptions,
+  ) => Layer.Layer<
+    Self,
+    Binding.BindingNotFoundError | Binding.BindingValidationError,
+    WorkerEnvironment
+  >;
+}
+
+const tryContainerPromise = <A>(
+  definition: ContainerNamespaceDefinition,
+  instance: string,
+  operation: string,
+  evaluate: () => Promise<A>,
+): Effect.Effect<A, ContainerOperationError> =>
+  Effect.tryPromise({
+    try: evaluate,
+    catch: (cause) =>
+      new ContainerOperationError({
+        binding: definition.binding,
+        instance,
+        operation,
+        cause,
+      }),
+  });
+
+const makeInstanceClient = (
+  definition: ContainerNamespaceDefinition,
+  instance: string,
+  stub: ContainerStub,
+): ContainerInstanceClient => ({
+  unsafeRaw: Effect.succeed(stub),
+  state: tryContainerPromise(definition, instance, "state", () => stub.getState()).pipe(
+    Effect.flatMap(Schema.decodeUnknownEffect(ContainerState)),
+    Effect.mapError((cause) =>
+      cause instanceof ContainerOperationError
+        ? cause
+        : new ContainerOperationError({
+            binding: definition.binding,
+            instance,
+            operation: "state",
+            cause,
+          }),
+    ),
+  ),
+  fetch: (input, init) =>
+    tryContainerPromise(definition, instance, "fetch", () => stub.fetch(input, init)),
+  start: (options, waitOptions) =>
+    tryContainerPromise(definition, instance, "start", () => stub.start(options, waitOptions)),
+  startAndWaitForPorts: (options) =>
+    tryContainerPromise(definition, instance, "startAndWaitForPorts", () =>
+      stub.startAndWaitForPorts(options),
+    ),
+  stop: (signal) => tryContainerPromise(definition, instance, "stop", () => stub.stop(signal)),
+  destroy: tryContainerPromise(definition, instance, "destroy", () => stub.destroy()),
+});
+
+export const isContainerNamespaceResource = (value: unknown): value is ContainerNamespaceResource =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof Reflect.get(value, "getByName") === "function";
+
+export const makeClient =
+  (definition: ContainerNamespaceDefinition) =>
+  (namespace: ContainerNamespaceResource): ContainerNamespaceClient => {
+    const getByName = (
+      name: string,
+      options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+    ) =>
+      Effect.try({
+        try: () => makeInstanceClient(definition, name, namespace.getByName(name, options)),
+        catch: (cause) =>
+          new ContainerOperationError({
+            binding: definition.binding,
+            instance: name,
+            operation: "getByName",
+            cause,
+          }),
+      });
+
+    const byName = (
+      name: string,
+      options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+    ): ContainerInstanceClient => {
+      const instance = getByName(name, options);
+      return {
+        unsafeRaw: Effect.flatMap(instance, (client) => client.unsafeRaw),
+        state: Effect.flatMap(instance, (client) => client.state),
+        fetch: (input, init) => Effect.flatMap(instance, (client) => client.fetch(input, init)),
+        start: (startOptions, waitOptions) =>
+          Effect.flatMap(instance, (client) => client.start(startOptions, waitOptions)),
+        startAndWaitForPorts: (startOptions) =>
+          Effect.flatMap(instance, (client) => client.startAndWaitForPorts(startOptions)),
+        stop: (signal) => Effect.flatMap(instance, (client) => client.stop(signal)),
+        destroy: Effect.flatMap(instance, (client) => client.destroy),
+      };
+    };
+
+    return {
+      definition,
+      getByName,
+      byName,
+      unsafeRaw: Effect.succeed(namespace),
+    };
+  };
+
+export const layer = <Self>(
+  tag: Context.Service<Self, ContainerNamespaceClient>,
+  definition: ContainerNamespaceDefinition,
+) =>
+  Binding.layer(tag, definition.binding, isContainerNamespaceResource, makeClient(definition), {
+    expected: expectedContainerNamespace,
+  });
+
+export const make = <Id extends string>(id: Id) => Tag<ContainerNamespaceService<Id>>()<Id>(id);
+
+declare const ContainerNamespaceServiceTypeId: unique symbol;
+
+/** Nominal service marker for Container namespaces created with {@link make}. */
+export interface ContainerNamespaceService<Id extends string> {
+  readonly [ContainerNamespaceServiceTypeId]: {
+    readonly id: Id;
+  };
+}
+
+/** Creates a typed Effect service for a Cloudflare Container namespace. */
+export const Tag =
+  <Self>() =>
+  <Id extends string>(id: Id) => {
+    const tag = Context.Service<Self, ContainerNamespaceClient>()(id);
+    const makeLayer = (definition: LayerOptions) => layer(tag, definition);
+
+    const getByName = (
+      name: string,
+      options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+    ) =>
+      Effect.gen(function* () {
+        const namespace = yield* tag;
+        return yield* namespace.getByName(name, options);
+      });
+
+    const byName = (
+      name: string,
+      options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+    ) => ({
+      state: Effect.flatMap(getByName(name, options), (instance) => instance.state),
+      fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+        Effect.flatMap(getByName(name, options), (instance) => instance.fetch(input, init)),
+      start: (startOptions?: ContainerStartOptions, waitOptions?: ContainerWaitOptions) =>
+        Effect.flatMap(getByName(name, options), (instance) =>
+          instance.start(startOptions, waitOptions),
+        ),
+      startAndWaitForPorts: (startOptions?: ContainerStartAndWaitForPortsOptions) =>
+        Effect.flatMap(getByName(name, options), (instance) =>
+          instance.startAndWaitForPorts(startOptions),
+        ),
+      stop: (signal?: ContainerSignal) =>
+        Effect.flatMap(getByName(name, options), (instance) => instance.stop(signal)),
+      destroy: Effect.flatMap(getByName(name, options), (instance) => instance.destroy),
+      unsafeRaw: Effect.flatMap(getByName(name, options), (instance) => instance.unsafeRaw),
+    });
+
+    const unsafeRaw = Effect.fn(function* () {
+      const namespace = yield* tag;
+      return yield* namespace.unsafeRaw;
+    });
+
+    return Object.assign(tag, {
+      id,
+      layer: makeLayer,
+      getByName,
+      byName,
+      unsafeRaw,
+    }) as TagClass<Self, Id>;
+  };
+
+export const ContainerNamespace = Tag;

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -3,6 +3,7 @@ export * as AnalyticsEngine from "./AnalyticsEngine";
 export * as Binding from "./Binding";
 export * as BrowserRendering from "./BrowserRendering";
 export * as CloudflareOtlp from "./CloudflareOtlp";
+export * as ContainerNamespace from "./ContainerNamespace";
 export * as D1 from "./D1";
 export * as DurableObject from "./DurableObject";
 export * as DurableObjectAlarm from "./DurableObjectAlarm";

--- a/packages/effect-cf/tests/ContainerNamespace.test.ts
+++ b/packages/effect-cf/tests/ContainerNamespace.test.ts
@@ -1,0 +1,254 @@
+import { assert, it } from "@effect/vitest";
+import type { Container as CloudflareContainer } from "@cloudflare/containers";
+import { Effect, Layer } from "effect";
+import { expectTypeOf } from "vitest";
+
+import { Binding, ContainerNamespace, WorkerEnvironment, type WorkerEnv } from "../src/index";
+
+class TestContainers extends ContainerNamespace.Tag<TestContainers>()("TestContainers") {}
+
+type Call =
+  | { readonly operation: "destroy" }
+  | { readonly operation: "fetch"; readonly input: RequestInfo | URL; readonly init?: RequestInit }
+  | { readonly operation: "getByName"; readonly name: string }
+  | { readonly operation: "getState" }
+  | {
+      readonly operation: "start";
+      readonly options?: ContainerNamespace.ContainerStartOptions;
+      readonly waitOptions?: ContainerNamespace.ContainerWaitOptions;
+    }
+  | {
+      readonly operation: "startAndWaitForPorts";
+      readonly options?: ContainerNamespace.ContainerStartAndWaitForPortsOptions;
+    }
+  | { readonly operation: "stop"; readonly signal?: ContainerNamespace.ContainerSignal };
+
+const makeFake = (options?: {
+  readonly fetchFailure?: unknown;
+  readonly stopFailure?: unknown;
+}) => {
+  const calls: Array<Call> = [];
+  const response = new Response("container", {
+    status: 503,
+    headers: { "x-container": "preserved" },
+  });
+  const stub: ContainerNamespace.ContainerStub = {
+    destroy: async () => {
+      calls.push({ operation: "destroy" });
+    },
+    fetch: async (input, init) => {
+      calls.push({ operation: "fetch", input, init });
+      if (options?.fetchFailure !== undefined) {
+        throw options.fetchFailure;
+      }
+      return response;
+    },
+    getState: async () => {
+      calls.push({ operation: "getState" });
+      return { lastChange: 42, status: "healthy" };
+    },
+    start: async (startOptions, waitOptions) => {
+      calls.push({ operation: "start", options: startOptions, waitOptions });
+    },
+    startAndWaitForPorts: async (startOptions) => {
+      calls.push({ operation: "startAndWaitForPorts", options: startOptions });
+    },
+    stop: async (signal) => {
+      calls.push({ operation: "stop", signal });
+      if (options?.stopFailure !== undefined) {
+        throw options.stopFailure;
+      }
+    },
+  };
+  const namespace: ContainerNamespace.ContainerNamespaceResource = {
+    getByName: (name) => {
+      calls.push({ operation: "getByName", name });
+      return stub;
+    },
+  };
+  const env = { CONTAINERS: namespace } as unknown as WorkerEnv;
+  const live = TestContainers.layer({ binding: "CONTAINERS" }).pipe(
+    Layer.provide(Layer.succeed(WorkerEnvironment, env)),
+  );
+
+  return { calls, live, namespace, response, stub };
+};
+
+it.effect("wraps a named Container and its lifecycle operations", () => {
+  const fake = makeFake();
+
+  return Effect.gen(function* () {
+    const containers = yield* TestContainers;
+    const instance = yield* containers.getByName("render-1");
+    const state = yield* instance.state;
+    const response = yield* instance.fetch(new Request("https://container.test/render"));
+
+    yield* instance.start(
+      { enableInternet: false, envVars: { MODE: "render" } },
+      { portToCheck: 8080 },
+    );
+    yield* instance.startAndWaitForPorts({
+      ports: [8080, 9090],
+      cancellationOptions: { portReadyTimeoutMS: 10_000 },
+    });
+    yield* instance.stop("SIGTERM");
+    yield* instance.destroy;
+    const raw = yield* instance.unsafeRaw;
+
+    assert.deepStrictEqual(state, { lastChange: 42, status: "healthy" });
+    assert.strictEqual(raw, fake.stub);
+    assert.strictEqual(response, fake.response);
+    assert.strictEqual(response.status, 503);
+    assert.strictEqual(response.headers.get("x-container"), "preserved");
+    assert.deepStrictEqual(
+      fake.calls.map((call) => call.operation),
+      ["getByName", "getState", "fetch", "start", "startAndWaitForPorts", "stop", "destroy"],
+    );
+  }).pipe(Effect.provide(fake.live));
+});
+
+it.effect("supports static byName helpers", () => {
+  const fake = makeFake();
+
+  return Effect.gen(function* () {
+    const instance = TestContainers.byName("render-2");
+
+    assert.deepStrictEqual(yield* instance.state, {
+      lastChange: 42,
+      status: "healthy",
+    });
+    yield* instance.start();
+    yield* instance.stop();
+    yield* instance.destroy;
+    assert.strictEqual(yield* instance.unsafeRaw, fake.stub);
+
+    const namespace = yield* TestContainers.unsafeRaw();
+    assert.strictEqual(namespace, fake.namespace);
+  }).pipe(Effect.provide(fake.live));
+});
+
+it.effect("defers lookup and reports synchronous namespace lookup failures", () => {
+  const cause = new Error("lookup failed");
+  const namespace: ContainerNamespace.ContainerNamespaceResource = {
+    getByName: () => {
+      throw cause;
+    },
+  };
+  const env = { CONTAINERS: namespace } as unknown as WorkerEnv;
+  const live = TestContainers.layer({ binding: "CONTAINERS" }).pipe(
+    Layer.provide(Layer.succeed(WorkerEnvironment, env)),
+  );
+  const raw = TestContainers.byName("deferred").unsafeRaw;
+
+  return Effect.gen(function* () {
+    const error = yield* Effect.flip(raw);
+    assert.instanceOf(error, ContainerNamespace.ContainerOperationError);
+    assert.strictEqual(error.operation, "getByName");
+    assert.strictEqual(error.cause, cause);
+  }).pipe(Effect.provide(live));
+});
+
+it.effect("decodes state and reports malformed native state", () => {
+  const fake = makeFake();
+  fake.stub.getState = async () =>
+    ({ lastChange: Number.NaN, status: "unknown" }) as unknown as ContainerNamespace.ContainerState;
+
+  return Effect.gen(function* () {
+    const error = yield* Effect.flip(TestContainers.byName("render-invalid").state);
+    assert.instanceOf(error, ContainerNamespace.ContainerOperationError);
+    assert.strictEqual(error.operation, "state");
+  }).pipe(Effect.provide(fake.live));
+});
+
+it.effect("maps rejected fetches to ContainerOperationError without changing the cause", () => {
+  const cause = new Error("container unavailable");
+  const fake = makeFake({ fetchFailure: cause });
+
+  return Effect.gen(function* () {
+    const error = yield* Effect.flip(
+      TestContainers.byName("render-3").fetch("https://container.test/"),
+    );
+
+    assert.instanceOf(error, ContainerNamespace.ContainerOperationError);
+    assert.strictEqual(error.binding, "CONTAINERS");
+    assert.strictEqual(error.instance, "render-3");
+    assert.strictEqual(error.operation, "fetch");
+    assert.strictEqual(error.cause, cause);
+  }).pipe(Effect.provide(fake.live));
+});
+
+it.effect("maps rejected lifecycle calls to ContainerOperationError", () => {
+  const cause = new Error("stop failed");
+  const fake = makeFake({ stopFailure: cause });
+
+  return Effect.gen(function* () {
+    const error = yield* Effect.flip(TestContainers.byName("render-3").stop("SIGKILL"));
+
+    assert.instanceOf(error, ContainerNamespace.ContainerOperationError);
+    assert.strictEqual(error.binding, "CONTAINERS");
+    assert.strictEqual(error.instance, "render-3");
+    assert.strictEqual(error.operation, "stop");
+    assert.strictEqual(error.cause, cause);
+  }).pipe(Effect.provide(fake.live));
+});
+
+it.effect("reports missing and invalid bindings through Binding errors", () =>
+  Effect.gen(function* () {
+    const missing = yield* Effect.flip(
+      TestContainers.getByName("missing").pipe(
+        Effect.provide(
+          TestContainers.layer({ binding: "CONTAINERS" }).pipe(
+            Layer.provide(Layer.succeed(WorkerEnvironment, {})),
+          ),
+        ),
+      ),
+    );
+
+    assert.instanceOf(missing, Binding.BindingNotFoundError);
+
+    const invalid = yield* Effect.flip(
+      TestContainers.getByName("invalid").pipe(
+        Effect.provide(
+          TestContainers.layer({ binding: "CONTAINERS" }).pipe(
+            Layer.provide(
+              Layer.succeed(WorkerEnvironment, {
+                CONTAINERS: { fetch: () => Promise.resolve(new Response()) },
+              } as unknown as WorkerEnv),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    if (invalid._tag === "BindingValidationError") {
+      assert.strictEqual(invalid.binding, "CONTAINERS");
+      assert.include(invalid.expected, "getByName()");
+    } else {
+      assert.fail("expected BindingValidationError");
+    }
+  }),
+);
+
+it("is structurally compatible with native @cloudflare/containers namespaces", () => {
+  type NativeNamespace = globalThis.DurableObjectNamespace<CloudflareContainer>;
+  type NativeStub = ReturnType<NativeNamespace["getByName"]>;
+  const acceptNamespace = (_namespace: ContainerNamespace.ContainerNamespaceResource) => {};
+  const acceptStub = (_stub: ContainerNamespace.ContainerStub) => {};
+
+  acceptNamespace({} as NativeNamespace);
+  acceptStub({} as NativeStub);
+});
+
+it("tracks the service requirement in the static API", () => {
+  expectTypeOf(TestContainers.byName("render-4").state).toEqualTypeOf<
+    Effect.Effect<
+      ContainerNamespace.ContainerState,
+      ContainerNamespace.ContainerOperationError,
+      TestContainers
+    >
+  >();
+
+  expectTypeOf(TestContainers.byName("render-4").fetch("https://container.test/")).toEqualTypeOf<
+    Effect.Effect<Response, ContainerNamespace.ContainerOperationError, TestContainers>
+  >();
+});


### PR DESCRIPTION
## Summary
- add a root-exported Effect wrapper for named Cloudflare Container namespace bindings
- preserve native Response behavior while typing lifecycle failures as ContainerOperationError
- add native SDK compatibility coverage, fake-namespace tests, docs, and a minor changeset

## Verification
- bun run ready
- 178 tests passed, 1 skipped
- native @cloudflare/containers structural compatibility test
- all example Worker dry-run builds passed