### PR TITLE
fix: normalize null Workflow status errors

### DIFF
--- a/.changeset/calm-workflows-rest.md
+++ b/.changeset/calm-workflows-rest.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": patch
+---
+
+Treat Cloudflare Workflow status responses with a null error as having no error.

--- a/packages/effect-cf/src/WorkflowBinding.ts
+++ b/packages/effect-cf/src/WorkflowBinding.ts
@@ -187,7 +187,7 @@ export const makeClient = <
             return {
               status: status.status,
               output,
-              error: status.error === undefined ? Option.none() : Option.some(status.error),
+              error: status.error == null ? Option.none() : Option.some(status.error),
             };
           }),
         ),

--- a/packages/effect-cf/tests/WorkflowBinding.test.ts
+++ b/packages/effect-cf/tests/WorkflowBinding.test.ts
@@ -1,0 +1,38 @@
+import type {
+  Workflow as CloudflareWorkflow,
+  WorkflowInstance as CloudflareWorkflowInstance,
+} from "@cloudflare/workers-types";
+import { assert, it } from "@effect/vitest";
+import { Effect, Option, Schema as S } from "effect";
+
+import { WorkflowBinding } from "../src/index";
+
+it.effect("normalizes a null Workflow status error to Option.none", () => {
+  const rawInstance = {
+    id: "workflow-1",
+    pause: async () => undefined,
+    resume: async () => undefined,
+    terminate: async () => undefined,
+    restart: async () => undefined,
+    status: async () => ({ status: "complete", error: null }),
+    sendEvent: async () => undefined,
+  } as unknown as CloudflareWorkflowInstance;
+  const workflow = {
+    create: async () => rawInstance,
+    createBatch: async () => [rawInstance],
+    get: async () => rawInstance,
+  } as unknown as CloudflareWorkflow<unknown>;
+  const client = WorkflowBinding.makeClient({
+    binding: "TEST_WORKFLOW",
+    payload: S.Unknown,
+    result: S.Unknown,
+  })(workflow);
+
+  return Effect.gen(function* () {
+    const instance = yield* client.get(rawInstance.id);
+    const status = yield* instance.status;
+
+    assert.strictEqual(status.status, "complete");
+    assert.isTrue(Option.isNone(status.error));
+  });
+});


### PR DESCRIPTION
## Summary

- Treat Cloudflare Workflow status responses with `error: null` as `Option.none()`
- Add a regression test through the public Workflow binding client
- Add a patch changeset for `effect-cf`

Cloudflare can return `null` at runtime even though `@cloudflare/workers-types` currently declares the field as optional. Representing that value as `Option.some(null)` breaks the public `WorkflowInstanceStatus` contract and caused a production consumer to defect while reading `error.message`.

## Validation

- `vp test packages/effect-cf/tests/WorkflowBinding.test.ts`
- `vp check`
- `vp test`