### PR TITLE
feat: add Cloudflare Cache API support

### DIFF
--- a/.changeset/calm-caches-flow.md
+++ b/.changeset/calm-caches-flow.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add Effect-native support for Cloudflare's default and named Cache API instances, including typed operation errors and `Option`-based cache misses.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # effect-cf
 
-Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, KV, Email, Analytics Engine, and Durable Object storage.
+Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, Cache, KV, Email, Analytics Engine, and Durable Object storage.
 
 ## Install
 

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -1,6 +1,6 @@
 # effect-cf
 
-Effect-native Cloudflare primitives for Workers, Durable Objects, Containers, bindings, KV, D1, Queues, Email, Analytics Engine, Workflows, and Durable Object storage.
+Effect-native Cloudflare primitives for Workers, Durable Objects, Containers, bindings, Cache, KV, D1, Queues, Email, Analytics Engine, Workflows, and Durable Object storage.
 
 ## Install
 
@@ -31,6 +31,7 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `DurableObjectState` / `DurableObjectStorage` - Effect wrappers for state, alarms, SQL, and embedded KV
 - `DurableObjectWebSocket` - WebSocket upgrade helpers for Durable Objects
 - `ContainerNamespace` - named Cloudflare Container instances with Effect-wrapped request and lifecycle operations
+- `Cache` - Effect wrapper for Cloudflare's default and named Cache API instances
 - `Kv` - typed KV namespace helper
 - `D1` - typed D1 database binding helper with an `@effect/sql-d1` backed SQL layer
 - `R2` - typed R2 bucket binding helper with Effect-wrapped object and multipart operations
@@ -160,6 +161,38 @@ export const enqueueAvatar = (userId: string, imageKey: string) =>
 Producers should usually use `const queue = yield* AvatarQueue` and then call `queue.send(...)`, `queue.sendBatch(...)`, or `queue.metrics()`. The static `AvatarQueue.send(...)` helpers remain available for concise one-off calls.
 
 Queue handlers run inline failures through Cloudflare's normal retry path. If background work scheduled with `WorkerContext.waitUntil(...)` should also make the batch retry, use `WorkerContext.waitUntilPropagating(...)` or `waitUntil(..., { mode: "propagate" })`; the default `waitUntil` mode observes and logs failures without rejecting the native `waitUntil` promise.
+
+## Cache Example
+
+`Cache.layer` exposes Cloudflare's global Cache API as an Effect service. Cache misses are represented by `Option.none()`, and named caches are available through `open(...)`.
+
+```ts
+import { Effect, Option } from "effect";
+import { Cache, Worker } from "effect-cf";
+
+export default Worker.make(Cache.layer, {
+  fetch: Effect.gen(function* () {
+    const request = yield* Worker.NativeRequest;
+    const storage = yield* Cache.CacheStorage;
+    const cached = yield* storage.default.match(request);
+
+    if (Option.isSome(cached)) {
+      return cached.value;
+    }
+
+    const response = new Response("fresh", {
+      headers: { "Cache-Control": "public, max-age=300" },
+    });
+
+    const context = yield* Worker.WorkerContext;
+    yield* context.waitUntil(storage.default.put(request, response.clone()));
+
+    return response;
+  }),
+});
+```
+
+Use `const cache = yield* storage.open("api-cache")` for a named cache. `match`, `put`, `delete`, and `open` failures are reported as `CacheOperationError` values.
 
 ## R2 Example
 

--- a/packages/effect-cf/src/Cache.ts
+++ b/packages/effect-cf/src/Cache.ts
@@ -1,0 +1,104 @@
+import type {
+  Cache as CloudflareCache,
+  CacheQueryOptions as CloudflareCacheQueryOptions,
+  CacheStorage as CloudflareCacheStorage,
+  RequestInfo as CloudflareRequestInfo,
+} from "@cloudflare/workers-types";
+import { Context, Data, Effect, Layer, Option } from "effect";
+
+/** Request key accepted by Cloudflare's Cache API. */
+export type CacheRequest = CloudflareRequestInfo | URL;
+
+/** Query options supported by Cloudflare's Cache API. */
+export type CacheQueryOptions = CloudflareCacheQueryOptions;
+
+/** Cache operation represented by {@link CacheOperationError}. */
+export type CacheOperation = "open" | "match" | "put" | "delete";
+
+/** Error raised when a Cloudflare Cache API operation fails. */
+export class CacheOperationError extends Data.TaggedError("CacheOperationError")<{
+  readonly cache: string;
+  readonly operation: CacheOperation;
+  readonly cause: unknown;
+}> {}
+
+/** Effect wrapper around one Cloudflare `Cache` instance. */
+export interface CacheClient {
+  /** Cache name (`default` for `caches.default`). */
+  readonly name: string;
+  /** Finds a cached response, mapping cache misses to `Option.none()`. */
+  readonly match: (
+    request: CacheRequest,
+    options?: CacheQueryOptions,
+  ) => Effect.Effect<Option.Option<Response>, CacheOperationError>;
+  /** Stores a response under the request key. */
+  readonly put: (
+    request: CacheRequest,
+    response: Response,
+  ) => Effect.Effect<void, CacheOperationError>;
+  /** Deletes a cached response and reports whether it existed. */
+  readonly delete: (
+    request: CacheRequest,
+    options?: CacheQueryOptions,
+  ) => Effect.Effect<boolean, CacheOperationError>;
+  /** Access to the native Cloudflare `Cache` instance. */
+  readonly unsafeRaw: Effect.Effect<CloudflareCache>;
+}
+
+/** Effect wrapper around Cloudflare's global `caches` object. */
+export interface CacheStorageClient {
+  /** Cloudflare's shared default cache. */
+  readonly default: CacheClient;
+  /** Opens a named cache. */
+  readonly open: (name: string) => Effect.Effect<CacheClient, CacheOperationError>;
+  /** Access to the native Cloudflare `CacheStorage` instance. */
+  readonly unsafeRaw: Effect.Effect<CloudflareCacheStorage>;
+}
+
+/** Service for Cloudflare's global Cache API. */
+export class CacheStorage extends Context.Service<CacheStorage, CacheStorageClient>()(
+  "effect-cf/CacheStorage",
+) {}
+
+const cacheError = (cache: string, operation: CacheOperation, cause: unknown) =>
+  new CacheOperationError({ cache, operation, cause });
+
+const tryCachePromise = <A>(
+  cache: string,
+  operation: CacheOperation,
+  evaluate: () => Promise<A>,
+): Effect.Effect<A, CacheOperationError> =>
+  Effect.tryPromise({
+    try: evaluate,
+    catch: (cause) => cacheError(cache, operation, cause),
+  });
+
+/** Wraps a native Cloudflare `Cache` instance. */
+export const makeCacheClient = (cache: CloudflareCache, name = "default"): CacheClient => ({
+  name,
+  match: (request, options) =>
+    tryCachePromise(name, "match", () => cache.match(request, options)).pipe(
+      Effect.map(Option.fromUndefinedOr),
+    ),
+  put: (request, response) => tryCachePromise(name, "put", () => cache.put(request, response)),
+  delete: (request, options) =>
+    tryCachePromise(name, "delete", () => cache.delete(request, options)),
+  unsafeRaw: Effect.succeed(cache),
+});
+
+/** Wraps a native Cloudflare `CacheStorage` instance. */
+export const makeClient = (storage: CloudflareCacheStorage): CacheStorageClient => ({
+  default: makeCacheClient(storage.default),
+  open: (name) =>
+    tryCachePromise(name, "open", () => storage.open(name)).pipe(
+      Effect.map((cache) => makeCacheClient(cache, name)),
+    ),
+  unsafeRaw: Effect.succeed(storage),
+});
+
+/** Provides Cache API services from an explicit native `CacheStorage` instance. */
+export const layerFrom = (storage: CloudflareCacheStorage): Layer.Layer<CacheStorage> =>
+  Layer.succeed(CacheStorage, makeClient(storage));
+
+/** Provides Cache API services from Cloudflare's global `caches` object. */
+export const layer: Layer.Layer<CacheStorage> = Layer.sync(CacheStorage, () => makeClient(caches));

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -2,6 +2,7 @@ export * as AiGateway from "./AiGateway";
 export * as AnalyticsEngine from "./AnalyticsEngine";
 export * as Binding from "./Binding";
 export * as BrowserRendering from "./BrowserRendering";
+export * as Cache from "./Cache";
 export * as CloudflareOtlp from "./CloudflareOtlp";
 export * as ContainerNamespace from "./ContainerNamespace";
 export * as D1 from "./D1";

--- a/packages/effect-cf/tests/Cache.test.ts
+++ b/packages/effect-cf/tests/Cache.test.ts
@@ -1,0 +1,190 @@
+import { assert, expect, layer, test } from "@effect/vitest";
+import { Effect, Option } from "effect";
+
+import { Cache } from "../src/index";
+
+interface MatchCall {
+  readonly request: Cache.CacheRequest;
+  readonly options: Cache.CacheQueryOptions | undefined;
+}
+
+interface FakeCacheOptions {
+  readonly match?: (
+    request: Cache.CacheRequest,
+    options: Cache.CacheQueryOptions | undefined,
+  ) => Promise<Response | undefined>;
+  readonly put?: (request: Cache.CacheRequest, response: Response) => Promise<void>;
+  readonly delete?: (
+    request: Cache.CacheRequest,
+    options: Cache.CacheQueryOptions | undefined,
+  ) => Promise<boolean>;
+}
+
+const makeFakeCache = (options: FakeCacheOptions = {}) =>
+  ({
+    match: options.match ?? (async () => undefined),
+    put: options.put ?? (async () => undefined),
+    delete: options.delete ?? (async () => false),
+  }) as globalThis.Cache;
+
+const makeFakeStorage = (
+  defaultCache: globalThis.Cache,
+  open: (name: string) => Promise<globalThis.Cache> = async () => makeFakeCache(),
+) =>
+  ({
+    default: defaultCache,
+    open,
+  }) as globalThis.CacheStorage;
+
+{
+  const calls: Array<MatchCall> = [];
+  const response = new Response("cached");
+  const cache = makeFakeCache({
+    match: async (request, options) => {
+      calls.push({ request, options });
+      const url =
+        typeof request === "string" ? request : request instanceof URL ? request.href : request.url;
+      return url.endsWith("/hit") ? response : undefined;
+    },
+  });
+
+  layer(Cache.layerFrom(makeFakeStorage(cache)))("Cache match", (it) => {
+    it.effect("maps hits and misses to Option while forwarding query options", () =>
+      Effect.gen(function* () {
+        const storage = yield* Cache.CacheStorage;
+        const hit = yield* storage.default.match("https://example.com/hit", {
+          ignoreMethod: true,
+        });
+        const miss = yield* storage.default.match("https://example.com/miss");
+
+        assert.strictEqual(Option.getOrUndefined(hit), response);
+        assert.strictEqual(Option.isNone(miss), true);
+        assert.deepStrictEqual(calls, [
+          {
+            request: "https://example.com/hit",
+            options: { ignoreMethod: true },
+          },
+          {
+            request: "https://example.com/miss",
+            options: undefined,
+          },
+        ]);
+      }),
+    );
+  });
+}
+
+{
+  const putCalls: Array<{ readonly request: Cache.CacheRequest; readonly response: Response }> = [];
+  const deleteCalls: Array<MatchCall> = [];
+  const cache = makeFakeCache({
+    put: async (request, response) => {
+      putCalls.push({ request, response });
+    },
+    delete: async (request, options) => {
+      deleteCalls.push({ request, options });
+      return true;
+    },
+  });
+  const storage = makeFakeStorage(cache);
+
+  layer(Cache.layerFrom(storage))("Cache writes", (it) => {
+    it.effect("wraps put, delete, and native escape hatches", () =>
+      Effect.gen(function* () {
+        const service = yield* Cache.CacheStorage;
+        const response = new Response("fresh");
+
+        yield* service.default.put("https://example.com/item", response);
+        const deleted = yield* service.default.delete("https://example.com/item", {
+          ignoreMethod: true,
+        });
+        const rawCache = yield* service.default.unsafeRaw;
+        const rawStorage = yield* service.unsafeRaw;
+
+        assert.strictEqual(deleted, true);
+        assert.deepStrictEqual(putCalls, [{ request: "https://example.com/item", response }]);
+        assert.deepStrictEqual(deleteCalls, [
+          {
+            request: "https://example.com/item",
+            options: { ignoreMethod: true },
+          },
+        ]);
+        assert.strictEqual(rawCache, cache);
+        assert.strictEqual(rawStorage, storage);
+      }),
+    );
+  });
+}
+
+test("CacheStorage opens named caches", async () => {
+  const namedCache = makeFakeCache();
+  const storage = makeFakeStorage(makeFakeCache(), async (name) => {
+    assert.strictEqual(name, "api-cache");
+    return namedCache;
+  });
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const service = yield* Cache.CacheStorage;
+      const cache = yield* service.open("api-cache");
+      const raw = yield* cache.unsafeRaw;
+
+      assert.strictEqual(cache.name, "api-cache");
+      assert.strictEqual(raw, namedCache);
+    }).pipe(Effect.provide(Cache.layerFrom(storage))),
+  );
+});
+
+test("CacheStorage open maps rejected promises", async () => {
+  const cause = new Error("cache unavailable");
+  const storage = makeFakeStorage(makeFakeCache(), async () => {
+    throw cause;
+  });
+
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* Cache.CacheStorage;
+        yield* service.open("api-cache");
+      }).pipe(Effect.provide(Cache.layerFrom(storage))),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "CacheOperationError",
+    cache: "api-cache",
+    operation: "open",
+    cause,
+  });
+});
+
+test("Cache methods map rejected promises", async () => {
+  const cause = new Error("cache unavailable");
+  const cache = Cache.makeCacheClient(
+    makeFakeCache({
+      match: async () => {
+        throw cause;
+      },
+      put: async () => {
+        throw cause;
+      },
+      delete: async () => {
+        throw cause;
+      },
+    }),
+    "api-cache",
+  );
+  const request = "https://example.com/item";
+  const operations = [
+    ["match", cache.match(request)],
+    ["put", cache.put(request, new Response("fresh"))],
+    ["delete", cache.delete(request)],
+  ] as const;
+
+  for (const [operation, effect] of operations) {
+    await expect(Effect.runPromise(effect)).rejects.toMatchObject({
+      _tag: "CacheOperationError",
+      cache: "api-cache",
+      operation,
+      cause,
+    });
+  }
+});

--- a/packages/effect-cf/tests/Cache.worker.test.ts
+++ b/packages/effect-cf/tests/Cache.worker.test.ts
@@ -1,0 +1,18 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+import { Effect } from "effect";
+import { expect, test } from "vite-plus/test";
+
+import { Cache } from "../src/index";
+
+test("Cache.layer reads the Workers runtime CacheStorage global", async () => {
+  const [storage, defaultCache] = await Effect.runPromise(
+    Effect.gen(function* () {
+      const service = yield* Cache.CacheStorage;
+      return yield* Effect.all([service.unsafeRaw, service.default.unsafeRaw]);
+    }).pipe(Effect.provide(Cache.layer)),
+  );
+
+  expect(storage).toBe(caches);
+  expect(defaultCache).toBe(caches.default);
+});


### PR DESCRIPTION
## Summary

- Add Effect-native wrappers for the default and named Cloudflare Cache API instances.
- Represent cache misses with Option and operation failures with typed CacheOperationError values.
- Document the service, export it publicly, and cover it with unit and Workers-runtime tests.

## Validation

- `vp check`
- `vp test`
- `vp run -r build`