### PR TITLE
feat: validate Email Service messages and surface Cloudflare error codes

### DIFF
--- a/.changeset/wild-moons-smile.md
+++ b/.changeset/wild-moons-smile.md
@@ -1,0 +1,9 @@
+---
+"effect-cf": minor
+---
+
+Add Cloudflare Email Service sending support to `Email`.
+
+Structured messages sent through a `send_email` binding are now validated against documented Email Sending limits — combined `to`/`cc`/`bcc` recipients, attachment count, custom header sizes, and required fields — and fail with `EmailValidationError` before the binding is called. Opt out with `layer({ binding, send: { validate: false } })`. Raw RFC 5322 `EmailMessage` values are still passed through untouched, and Cloudflare's `E_*` error codes are now reported on `EmailOperationError.code`.
+
+`Email.SendingTag` adds an Email Sending REST API client for sending from outside a Worker or without a binding, with `layer`, `fetchLayer`, `layerConfig`, and `fetchLayerConfig` constructors and `Email.sendingConfig` for account id and redacted API token configuration. Sends return the per-recipient delivery status as `{ delivered, permanentBounces, queued }` and fail with `EmailSendingError` carrying the HTTP status and Cloudflare's error array.

--- a/.changeset/wild-moons-smile.md
+++ b/.changeset/wild-moons-smile.md
@@ -4,6 +4,6 @@
 
 Add Cloudflare Email Service sending support to `Email`.
 
-Structured messages sent through a `send_email` binding are now validated against documented Email Sending limits — combined `to`/`cc`/`bcc` recipients, attachment count, custom header sizes, and required fields — and fail with `EmailValidationError` before the binding is called. Opt out with `layer({ binding, send: { validate: false } })`. Raw RFC 5322 `EmailMessage` values are still passed through untouched, and Cloudflare's `E_*` error codes are now reported on `EmailOperationError.code`.
+Structured messages sent through a `send_email` binding are now validated against documented Email Sending limits — combined `to`/`cc`/`bcc` recipients, attachment count, custom header sizes, and required fields — and fail with `EmailValidationError` before the binding is called. Opt out with `layer({ binding, send: { validate: false } })`. Raw RFC 5322 `EmailMessage` values are still passed through untouched, so the legacy `cloudflare:email` API keeps working.
 
-`Email.SendingTag` adds an Email Sending REST API client for sending from outside a Worker or without a binding, with `layer`, `fetchLayer`, `layerConfig`, and `fetchLayerConfig` constructors and `Email.sendingConfig` for account id and redacted API token configuration. Sends return the per-recipient delivery status as `{ delivered, permanentBounces, queued }` and fail with `EmailSendingError` carrying the HTTP status and Cloudflare's error array.
+Cloudflare's `E_*` error codes are now reported on `EmailOperationError.code`, with the documented set exported as `Email.emailErrorCodes` and `Email.EmailErrorCode`. Documented limits are exported as `Email.sendLimits`.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,29 @@ const layer = AnalyticsQuery.layerConfig(
 ).pipe(Layer.provide(FetchHttpClient.layer));
 ```
 
+Email Service transactional sends:
+
+```ts
+import { Effect } from "effect";
+import { Email } from "effect-cf";
+
+class TransactionalEmail extends Email.Tag<TransactionalEmail>()("TransactionalEmail") {}
+
+const program = Effect.gen(function* () {
+  const email = yield* TransactionalEmail;
+
+  return yield* email.send({
+    from: { name: "Example", email: "welcome@example.com" },
+    to: "user@example.com",
+    subject: "Welcome to Example",
+    text: "Welcome! Thanks for signing up.",
+    html: "<h1>Welcome!</h1><p>Thanks for signing up.</p>",
+  });
+});
+```
+
+Messages are validated against the documented Cloudflare Email Sending limits before the binding is called, so a bad recipient list or oversized header fails with `EmailValidationError` and no round trip. Cloudflare's `E_*` codes are reported on `EmailOperationError.code`. See [`examples/email/README.md`](examples/email/README.md) for the Wrangler configuration and domain onboarding steps.
+
 ## Changelog
 
 See [packages/effect-cf/CHANGELOG.md](./packages/effect-cf/CHANGELOG.md).

--- a/examples/email/README.md
+++ b/examples/email/README.md
@@ -1,0 +1,93 @@
+# Cloudflare Email Service
+
+`effect-cf` wraps the `send_email` binding that Cloudflare Email Service exposes
+to a Worker. Structured messages are validated against documented Email Sending
+limits before the binding is called, and Cloudflare's `E_*` codes are surfaced
+on `EmailOperationError.code`, so both failure modes are typed and recoverable.
+
+Before sending, onboard the sending domain under **Compute > Email Service >
+Email Sending** in the Cloudflare dashboard. Cloudflare adds the MX, SPF, DKIM,
+and DMARC records that authenticate mail from that domain.
+
+```ts
+import { Effect, Layer } from "effect";
+import { Email, Worker } from "effect-cf";
+
+class TransactionalEmail extends Email.Tag<TransactionalEmail>()("TransactionalEmail") {}
+
+const AppLive = Layer.mergeAll(TransactionalEmail.layer({ binding: "EMAIL" }));
+
+export default Worker.make(AppLive, {
+  fetch: Effect.gen(function* () {
+    const request = yield* Worker.NativeRequest;
+    const to = new URL(request.url).searchParams.get("to");
+
+    if (to === null) {
+      return new Response("Missing ?to", { status: 400 });
+    }
+
+    const email = yield* TransactionalEmail;
+    const result = yield* email.send({
+      from: { name: "Example", email: "welcome@example.com" },
+      to,
+      subject: "Welcome to Example",
+      text: "Welcome! Thanks for signing up.",
+      html: "<h1>Welcome!</h1><p>Thanks for signing up.</p>",
+    });
+
+    return new Response(`Email sent: ${result.messageId}`);
+  }).pipe(
+    // The message never reached Cloudflare; every broken field is listed.
+    Effect.catchTag("EmailValidationError", (error) =>
+      Effect.succeed(Response.json({ violations: error.violations }, { status: 400 })),
+    ),
+    // Cloudflare rejected the send; `code` says whether retrying can help.
+    Effect.catchTag("EmailOperationError", (error) =>
+      Effect.succeed(
+        Response.json(
+          { code: error.code ?? "E_INTERNAL_SERVER_ERROR" },
+          { status: error.code === "E_RATE_LIMIT_EXCEEDED" ? 429 : 500 },
+        ),
+      ),
+    ),
+  ),
+});
+```
+
+A minimal Wrangler configuration declares the binding. `remote: true` lets
+`wrangler dev` send through the real Email Service while the Worker runs
+locally:
+
+```jsonc
+{
+  "name": "email-example",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-06-11",
+  "send_email": [
+    {
+      "name": "EMAIL",
+      "remote": true,
+    },
+  ],
+}
+```
+
+Restrict which senders and recipients a binding may use with Cloudflare's
+`allowed_destination_addresses` and `destination_address` attributes on the
+binding. `EmailOperationError.code` reports `E_RECIPIENT_NOT_ALLOWED` when a
+send falls outside those restrictions.
+
+Validation covers the limits Cloudflare documents: at most 50 combined `to`,
+`cc`, and `bcc` addresses, at most 32 attachments, custom header name, value,
+and total size caps, a required `from` and `subject`, at least one of `text` or
+`html`, and a `contentId` on every inline attachment. Pass
+`layer({ binding: "EMAIL", send: { validate: false } })` to skip these checks
+and let Cloudflare reject the message instead.
+
+Total message size is exposed as `Email.sendLimits.maxMessageBytes` but is not
+checked locally, because the encoded MIME size is only known once Cloudflare
+composes the message. Oversized messages fail with `E_CONTENT_TOO_LARGE`.
+
+Raw RFC 5322 messages built with `EmailMessage` from `cloudflare:email` are
+passed to the binding untouched, so existing Email Routing code keeps working
+alongside structured sends.

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -320,6 +320,8 @@ Messages that violate a documented limit fail with `EmailValidationError` carryi
 
 Cloudflare's total message size limit is exposed as `Email.sendLimits.maxMessageBytes` but is not enforced, because the encoded MIME size is only known once Cloudflare composes the message. Oversized messages fail at the binding with `E_CONTENT_TOO_LARGE`.
 
+See [`examples/email/README.md`](../../examples/email/README.md) for domain onboarding, binding restrictions, and typed recovery from `EmailValidationError` and `EmailOperationError`.
+
 ## Analytics Engine Example
 
 Analytics Engine tags expose Cloudflare dataset bindings as Effect-wrapped `writeDataPoint(...)` operations. Writes use Cloudflare's native non-blocking runtime API and are validated against Workers Analytics Engine limits before reaching the binding.

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -37,7 +37,7 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `R2` - typed R2 bucket binding helper with Effect-wrapped object and multipart operations
 - `Hyperdrive` - typed Hyperdrive binding helper for connection strings and optional Postgres SQL integration
 - `Images` - typed Cloudflare Images binding helper with transformation APIs and optional hosted image operations
-- `Email` - typed Cloudflare Email Service helpers for `send_email` bindings and the Email Sending REST API
+- `Email` - typed Cloudflare Email Service binding helper for `send_email` bindings, with limit validation and typed error codes
 - `AnalyticsEngine` - typed Cloudflare Analytics Engine write bindings and SQL API query helpers
 - `Queue` - typed Queue producer/consumer tags plus client and error types
 - `Workflow` - typed Workflow entrypoints, steps, starter clients, and instance types
@@ -318,36 +318,7 @@ Onboard the sending domain under **Compute > Email Service > Email Sending**, th
 
 Messages that violate a documented limit fail with `EmailValidationError` carrying every violation, without calling the binding. Use `layer({ binding, send: { validate: false } })` to skip validation and let Cloudflare reject the message instead. Raw RFC 5322 `EmailMessage` values are always passed through untouched, so the legacy `cloudflare:email` API keeps working.
 
-Outside Workers — or when no binding is available — `Email.SendingTag` wraps the Email Sending REST API. Configuration can stay in Effect `Config`, including a redacted API token, and the outbound transport is an Effect `HttpClient` dependency. Use `fetchLayerConfig(...)` as shorthand when the platform fetch-backed client is enough.
-
-```ts
-import { Effect } from "effect";
-import { Email, WorkerConfig } from "effect-cf";
-
-class EmailSending extends Email.SendingTag<EmailSending>()("EmailSending") {}
-
-export const EmailSendingLayer = EmailSending.fetchLayerConfig(
-  Email.sendingConfig({
-    accountId: WorkerConfig.string("CLOUDFLARE_ACCOUNT_ID"),
-    apiToken: WorkerConfig.redacted("CLOUDFLARE_API_TOKEN"),
-  }),
-);
-
-export const sendInvoice = (to: string) =>
-  Effect.gen(function* () {
-    const sending = yield* EmailSending;
-    const result = yield* sending.send({
-      from: "invoices@example.com",
-      to,
-      subject: "Your Invoice",
-      html: "<h1>Invoice attached</h1>",
-    });
-
-    return result.delivered;
-  });
-```
-
-`send(...)` returns the per-recipient delivery status as `{ delivered, permanentBounces, queued }`. Failed requests fail with `EmailSendingError`, which carries the HTTP status and Cloudflare's numeric `errors` array. Attachment content given as `ArrayBuffer` or a typed array is base64 encoded for the REST payload; `Email.toSendingPayload(...)` exposes that conversion directly. SMTP submission is not covered, because Workers cannot open the outbound SMTP connection it requires.
+Cloudflare's total message size limit is exposed as `Email.sendLimits.maxMessageBytes` but is not enforced, because the encoded MIME size is only known once Cloudflare composes the message. Oversized messages fail at the binding with `E_CONTENT_TOO_LARGE`.
 
 ## Analytics Engine Example
 

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -37,7 +37,7 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `R2` - typed R2 bucket binding helper with Effect-wrapped object and multipart operations
 - `Hyperdrive` - typed Hyperdrive binding helper for connection strings and optional Postgres SQL integration
 - `Images` - typed Cloudflare Images binding helper with transformation APIs and optional hosted image operations
-- `Email` - typed Cloudflare Send Email binding helper for `send_email` bindings
+- `Email` - typed Cloudflare Email Service helpers for `send_email` bindings and the Email Sending REST API
 - `AnalyticsEngine` - typed Cloudflare Analytics Engine write bindings and SQL API query helpers
 - `Queue` - typed Queue producer/consumer tags plus client and error types
 - `Workflow` - typed Workflow entrypoints, steps, starter clients, and instance types
@@ -284,7 +284,7 @@ export const resizeAvatar = (image: Images.ImageInputValue) =>
 
 ## Email Example
 
-Email tags expose Cloudflare Send Email bindings as Effect-wrapped `send(...)` operations.
+Email tags expose Cloudflare Email Service `send_email` bindings as Effect-wrapped `send(...)` operations. Structured messages are validated against documented Email Sending limits before reaching the binding, and Cloudflare's `E_*` error codes are surfaced on `EmailOperationError.code`.
 
 ```ts
 import { Effect } from "effect";
@@ -307,6 +307,47 @@ export const sendWelcomeEmail = (to: string) =>
     });
   });
 ```
+
+Onboard the sending domain under **Compute > Email Service > Email Sending**, then declare the binding in the consuming Worker's `wrangler.jsonc`:
+
+```jsonc
+{
+  "send_email": [{ "name": "EMAIL" }],
+}
+```
+
+Messages that violate a documented limit fail with `EmailValidationError` carrying every violation, without calling the binding. Use `layer({ binding, send: { validate: false } })` to skip validation and let Cloudflare reject the message instead. Raw RFC 5322 `EmailMessage` values are always passed through untouched, so the legacy `cloudflare:email` API keeps working.
+
+Outside Workers — or when no binding is available — `Email.SendingTag` wraps the Email Sending REST API. Configuration can stay in Effect `Config`, including a redacted API token, and the outbound transport is an Effect `HttpClient` dependency. Use `fetchLayerConfig(...)` as shorthand when the platform fetch-backed client is enough.
+
+```ts
+import { Effect } from "effect";
+import { Email, WorkerConfig } from "effect-cf";
+
+class EmailSending extends Email.SendingTag<EmailSending>()("EmailSending") {}
+
+export const EmailSendingLayer = EmailSending.fetchLayerConfig(
+  Email.sendingConfig({
+    accountId: WorkerConfig.string("CLOUDFLARE_ACCOUNT_ID"),
+    apiToken: WorkerConfig.redacted("CLOUDFLARE_API_TOKEN"),
+  }),
+);
+
+export const sendInvoice = (to: string) =>
+  Effect.gen(function* () {
+    const sending = yield* EmailSending;
+    const result = yield* sending.send({
+      from: "invoices@example.com",
+      to,
+      subject: "Your Invoice",
+      html: "<h1>Invoice attached</h1>",
+    });
+
+    return result.delivered;
+  });
+```
+
+`send(...)` returns the per-recipient delivery status as `{ delivered, permanentBounces, queued }`. Failed requests fail with `EmailSendingError`, which carries the HTTP status and Cloudflare's numeric `errors` array. Attachment content given as `ArrayBuffer` or a typed array is base64 encoded for the REST payload; `Email.toSendingPayload(...)` exposes that conversion directly. SMTP submission is not covered, because Workers cannot open the outbound SMTP connection it requires.
 
 ## Analytics Engine Example
 

--- a/packages/effect-cf/src/Email.ts
+++ b/packages/effect-cf/src/Email.ts
@@ -5,18 +5,116 @@ import type {
   EmailSendResult as CloudflareEmailSendResult,
   SendEmail as CloudflareSendEmail,
 } from "@cloudflare/workers-types";
-import { Context, Data, Effect, type Layer } from "effect";
+import { type Redacted, Config, Context, Data, Effect, Layer, Schema as S } from "effect";
+import {
+  FetchHttpClient,
+  type Headers,
+  HttpClient,
+  type HttpClientResponse,
+  HttpClientRequest,
+} from "effect/unstable/http";
 
 import * as Binding from "./Binding";
 import type { WorkerEnvironment } from "./Environment";
 
 const expectedSendEmailBinding = "Send Email binding with send()";
+const defaultSendingApiBaseUrl = "https://api.cloudflare.com/client/v4";
+const textEncoder = new TextEncoder();
+
+/** Documented Cloudflare Email Sending limits. */
+export const sendLimits = {
+  /** Combined `to`, `cc`, and `bcc` addresses per message. */
+  maxRecipients: 50,
+  maxAttachments: 32,
+  /** Total message size, including attachments. Not enforced client side. */
+  maxMessageBytes: 5 * 1024 * 1024,
+  maxHeaderNameBytes: 100,
+  maxHeaderValueBytes: 2048,
+  maxHeadersBytes: 16 * 1024,
+  /** Allowlisted custom headers, excluding `X-` prefixed headers. */
+  maxAllowlistHeaders: 20,
+} as const;
+
+/** Error codes reported by Cloudflare Email Sending. */
+export const emailErrorCodes = [
+  "E_VALIDATION_ERROR",
+  "E_FIELD_MISSING",
+  "E_TOO_MANY_RECIPIENTS",
+  "E_TOO_MANY_ATTACHMENTS",
+  "E_SENDER_NOT_VERIFIED",
+  "E_RECIPIENT_NOT_ALLOWED",
+  "E_RECIPIENT_SUPPRESSED",
+  "E_SENDER_DOMAIN_NOT_AVAILABLE",
+  "E_CONTENT_TOO_LARGE",
+  "E_DELIVERY_FAILED",
+  "E_RATE_LIMIT_EXCEEDED",
+  "E_DAILY_LIMIT_EXCEEDED",
+  "E_INTERNAL_SERVER_ERROR",
+  "E_HEADER_NOT_ALLOWED",
+  "E_HEADER_USE_API_FIELD",
+  "E_HEADER_VALUE_INVALID",
+  "E_HEADER_VALUE_TOO_LONG",
+  "E_HEADER_NAME_INVALID",
+  "E_HEADERS_TOO_LARGE",
+  "E_HEADERS_TOO_MANY",
+] as const;
+
+/** A documented Cloudflare Email Sending error code. */
+export type EmailErrorCode = (typeof emailErrorCodes)[number];
+
+const sendingApiErrorSchema = S.Struct({
+  code: S.Number,
+  message: S.String,
+});
+
+const sendingResultSchema = S.Struct({
+  delivered: S.Array(S.String),
+  permanent_bounces: S.Array(S.String),
+  queued: S.Array(S.String),
+});
+
+const sendingResponseSchema = S.Struct({
+  success: S.Boolean,
+  errors: S.Array(sendingApiErrorSchema),
+  result: S.NullOr(sendingResultSchema),
+});
+
+const decodeSendingResponse = S.decodeUnknownEffect(sendingResponseSchema);
 
 /** Error raised when a Cloudflare Send Email operation fails. */
 export class EmailOperationError extends Data.TaggedError("EmailOperationError")<{
   readonly binding: string;
   readonly operation: string;
   readonly cause: unknown;
+  /** Cloudflare error code taken from the thrown error, when present. */
+  readonly code?: EmailErrorCode | (string & {});
+}> {}
+
+/** A single message field that violates a documented Email Sending limit. */
+export interface EmailViolation {
+  readonly path: string;
+  readonly message: string;
+  readonly limit?: number;
+  readonly actual?: number;
+}
+
+/** Error raised when a message violates documented Cloudflare Email Sending limits. */
+export class EmailValidationError extends Data.TaggedError("EmailValidationError")<{
+  /** Binding name for binding sends, or Cloudflare account id for REST sends. */
+  readonly source: string;
+  readonly operation: string;
+  readonly violations: ReadonlyArray<EmailViolation>;
+}> {}
+
+/** Error raised when a Cloudflare Email Sending REST API request fails. */
+export class EmailSendingError extends Data.TaggedError("EmailSendingError")<{
+  readonly operation: string;
+  readonly accountId: string;
+  readonly message: string;
+  readonly status?: number;
+  readonly errors?: ReadonlyArray<EmailSendingApiError>;
+  readonly body?: string;
+  readonly cause?: unknown;
 }> {}
 
 /** Typed Cloudflare Send Email binding definition. */
@@ -32,6 +130,24 @@ export type EmailMessageBuilder = Parameters<CloudflareSendEmail["send"]>[0];
 export type EmailSendInput = EmailMessage | EmailMessageBuilder;
 export type EmailSendResult = CloudflareEmailSendResult;
 export type EmailBinding = CloudflareSendEmail;
+export type EmailRecipients = string | EmailAddress | ReadonlyArray<string | EmailAddress>;
+export type EmailSendError = EmailOperationError | EmailValidationError;
+export type EmailSendingApiError = S.Schema.Type<typeof sendingApiErrorSchema>;
+
+/** Per-recipient delivery status returned by the Email Sending REST API. */
+export interface EmailSendingResult {
+  /** Addresses the message was delivered to immediately. */
+  readonly delivered: ReadonlyArray<string>;
+  /** Addresses that permanently bounced. */
+  readonly permanentBounces: ReadonlyArray<string>;
+  /** Addresses whose delivery was queued for later. */
+  readonly queued: ReadonlyArray<string>;
+}
+
+export interface EmailSendOptions {
+  /** Validates builder messages against documented limits. Defaults to `true`. */
+  readonly validate?: boolean;
+}
 
 interface EmailRuntimeBinding {
   readonly send: (message: EmailSendInput) => Promise<EmailSendResult>;
@@ -39,14 +155,47 @@ interface EmailRuntimeBinding {
 
 export interface EmailClient {
   readonly send: {
-    (message: EmailMessage): Effect.Effect<EmailSendResult, EmailOperationError>;
-    (builder: EmailMessageBuilder): Effect.Effect<EmailSendResult, EmailOperationError>;
+    (message: EmailMessage): Effect.Effect<EmailSendResult, EmailSendError>;
+    (builder: EmailMessageBuilder): Effect.Effect<EmailSendResult, EmailSendError>;
   };
   readonly unsafeRaw: Effect.Effect<EmailBinding>;
   readonly definition: EmailDefinition;
 }
 
+/** Cloudflare Email Sending REST API definition. */
+export interface EmailSendingDefinition {
+  /** Cloudflare account id that owns the onboarded sending domain. */
+  readonly accountId: string;
+  /** API token with the Email Sending permission. */
+  readonly apiToken: Redacted.Redacted<string>;
+  /** Base Cloudflare API URL. Defaults to `https://api.cloudflare.com/client/v4`. */
+  readonly apiBaseUrl?: string | URL;
+  /** Validates messages against documented limits. Defaults to `true`. */
+  readonly validate?: boolean;
+}
+
+export interface EmailSendingOptions {
+  /** Additional request headers. Authorization is always derived from `apiToken`. */
+  readonly headers?: Headers.Input;
+}
+
+export interface EmailSendingClient {
+  readonly send: (
+    message: EmailMessageBuilder,
+    options?: EmailSendingOptions,
+  ) => Effect.Effect<EmailSendingResult, EmailSendingError | EmailValidationError | S.SchemaError>;
+  readonly raw: (
+    message: EmailMessageBuilder,
+    options?: EmailSendingOptions,
+  ) => Effect.Effect<
+    HttpClientResponse.HttpClientResponse,
+    EmailSendingError | EmailValidationError
+  >;
+  readonly definition: EmailSendingDefinition;
+}
+
 declare const EmailServiceTypeId: unique symbol;
+declare const EmailSendingServiceTypeId: unique symbol;
 
 /** Nominal service marker for Send Email services created with {@link make}. */
 export interface EmailService<Id extends string> {
@@ -55,8 +204,22 @@ export interface EmailService<Id extends string> {
   };
 }
 
+/** Nominal service marker for Email Sending REST services created with {@link makeSending}. */
+export interface EmailSendingService<Id extends string> {
+  readonly [EmailSendingServiceTypeId]: {
+    readonly id: Id;
+  };
+}
+
 export type LayerOptions = {
   readonly binding: string;
+  readonly send?: EmailSendOptions;
+};
+
+export type SendingConfigOptions = {
+  readonly accountId?: Config.Config<string>;
+  readonly apiToken?: Config.Config<Redacted.Redacted<string>>;
+  readonly apiBaseUrl?: Config.Config<string>;
 };
 
 export interface TagClass<Self, Id extends string> extends Context.ServiceClass<
@@ -74,8 +237,63 @@ export interface TagClass<Self, Id extends string> extends Context.ServiceClass<
   >;
 }
 
+export interface SendingTagClass<Self, Id extends string> extends Context.ServiceClass<
+  Self,
+  Id,
+  EmailSendingClient
+> {
+  readonly id: Id;
+  readonly layer: (
+    definition: EmailSendingDefinition,
+  ) => Layer.Layer<Self, never, HttpClient.HttpClient>;
+  readonly fetchLayer: (definition: EmailSendingDefinition) => Layer.Layer<Self>;
+  readonly layerConfig: (
+    config?: Config.Config<EmailSendingDefinition>,
+  ) => Layer.Layer<Self, Config.ConfigError, HttpClient.HttpClient>;
+  readonly fetchLayerConfig: (
+    config?: Config.Config<EmailSendingDefinition>,
+  ) => Layer.Layer<Self, Config.ConfigError>;
+}
+
+const emailErrorCode = (cause: unknown): EmailOperationError["code"] => {
+  if (typeof cause !== "object" || cause === null) {
+    return undefined;
+  }
+
+  const code = Reflect.get(cause, "code");
+
+  return typeof code === "string" ? code : undefined;
+};
+
 const emailError = (binding: string, operation: string, cause: unknown) =>
-  new EmailOperationError({ binding, operation, cause });
+  new EmailOperationError({ binding, operation, cause, code: emailErrorCode(cause) });
+
+const emailValidationError = (
+  source: string,
+  operation: string,
+  violations: ReadonlyArray<EmailViolation>,
+) => new EmailValidationError({ source, operation, violations });
+
+const emailSendingError = (
+  definition: EmailSendingDefinition,
+  operation: string,
+  message: string,
+  options?: {
+    readonly status?: number;
+    readonly errors?: ReadonlyArray<EmailSendingApiError>;
+    readonly body?: string;
+    readonly cause?: unknown;
+  },
+) =>
+  new EmailSendingError({
+    operation,
+    accountId: definition.accountId,
+    message,
+    status: options?.status,
+    errors: options?.errors,
+    body: options?.body,
+    cause: options?.cause,
+  });
 
 const tryEmailPromise = <A>(
   binding: string,
@@ -86,6 +304,260 @@ const tryEmailPromise = <A>(
     try: evaluate,
     catch: (cause) => emailError(binding, operation, cause),
   });
+
+const builderFields = [
+  "subject",
+  "html",
+  "text",
+  "cc",
+  "bcc",
+  "replyTo",
+  "attachments",
+  "headers",
+] as const;
+
+/**
+ * Distinguishes structured Email Sending messages from raw MIME `EmailMessage`
+ * values, which only carry envelope `from` and `to` addresses.
+ */
+export const isEmailMessageBuilder = (message: EmailSendInput): message is EmailMessageBuilder => {
+  if (typeof message !== "object" || message === null) {
+    return false;
+  }
+
+  return builderFields.some((field) => Reflect.get(message, field) !== undefined);
+};
+
+const byteLength = (value: string) => textEncoder.encode(value).byteLength;
+
+const limitViolation = (
+  path: string,
+  label: string,
+  actual: number,
+  limit: number,
+): EmailViolation => ({
+  path,
+  message: `${label} exceeds Cloudflare Email Sending limit`,
+  actual,
+  limit,
+});
+
+const addressList = (value: EmailRecipients | undefined): ReadonlyArray<string | EmailAddress> => {
+  if (value === undefined) {
+    return [];
+  }
+
+  return Array.isArray(value) ? value : [value as string | EmailAddress];
+};
+
+const addressViolations = (path: string, value: unknown): ReadonlyArray<EmailViolation> => {
+  if (typeof value === "string") {
+    return value.includes("@") ? [] : [{ path, message: "Email address must contain an @ symbol" }];
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return [{ path, message: "Email address must be a string or { name, email } object" }];
+  }
+
+  const email = Reflect.get(value, "email");
+
+  if (typeof email !== "string" || !email.includes("@")) {
+    return [{ path: `${path}.email`, message: "Email address must contain an @ symbol" }];
+  }
+
+  return [];
+};
+
+const recipientViolations = (
+  field: "to" | "cc" | "bcc",
+  value: EmailRecipients | undefined,
+): ReadonlyArray<EmailViolation> =>
+  addressList(value).flatMap((address, index) => addressViolations(`${field}[${index}]`, address));
+
+const attachmentViolations = (
+  attachments: ReadonlyArray<EmailAttachment>,
+): ReadonlyArray<EmailViolation> => {
+  const violations: Array<EmailViolation> = [];
+
+  if (attachments.length > sendLimits.maxAttachments) {
+    violations.push(
+      limitViolation("attachments", "attachments", attachments.length, sendLimits.maxAttachments),
+    );
+  }
+
+  for (let index = 0; index < attachments.length; index++) {
+    const attachment = attachments[index];
+    const path = `attachments[${index}]`;
+
+    if (typeof attachment !== "object" || attachment === null) {
+      violations.push({ path, message: "Attachment must be an object" });
+      continue;
+    }
+
+    if (typeof attachment.filename !== "string" || attachment.filename === "") {
+      violations.push({ path: `${path}.filename`, message: "Attachment filename is required" });
+    }
+
+    if (typeof attachment.type !== "string" || attachment.type === "") {
+      violations.push({ path: `${path}.type`, message: "Attachment MIME type is required" });
+    }
+
+    if (attachment.content === undefined || attachment.content === null) {
+      violations.push({ path: `${path}.content`, message: "Attachment content is required" });
+    }
+
+    if (attachment.disposition === "inline" && typeof attachment.contentId !== "string") {
+      violations.push({
+        path: `${path}.contentId`,
+        message: "Inline attachments require a contentId",
+      });
+    }
+  }
+
+  return violations;
+};
+
+const headerViolations = (headers: Record<string, string>): ReadonlyArray<EmailViolation> => {
+  const violations: Array<EmailViolation> = [];
+  const entries = Object.entries(headers);
+  let totalBytes = 0;
+  let allowlistHeaders = 0;
+
+  for (const [name, value] of entries) {
+    const path = `headers["${name}"]`;
+    const nameBytes = byteLength(name);
+
+    if (nameBytes > sendLimits.maxHeaderNameBytes) {
+      violations.push(
+        limitViolation(path, "header name bytes", nameBytes, sendLimits.maxHeaderNameBytes),
+      );
+    }
+
+    if (typeof value !== "string") {
+      violations.push({ path, message: "Header value must be a string" });
+      continue;
+    }
+
+    const valueBytes = byteLength(value);
+
+    if (valueBytes > sendLimits.maxHeaderValueBytes) {
+      violations.push(
+        limitViolation(path, "header value bytes", valueBytes, sendLimits.maxHeaderValueBytes),
+      );
+    }
+
+    totalBytes += nameBytes + valueBytes;
+
+    if (!name.toLowerCase().startsWith("x-")) {
+      allowlistHeaders += 1;
+    }
+  }
+
+  if (totalBytes > sendLimits.maxHeadersBytes) {
+    violations.push(
+      limitViolation("headers", "header bytes", totalBytes, sendLimits.maxHeadersBytes),
+    );
+  }
+
+  if (allowlistHeaders > sendLimits.maxAllowlistHeaders) {
+    violations.push(
+      limitViolation(
+        "headers",
+        "allowlisted custom headers",
+        allowlistHeaders,
+        sendLimits.maxAllowlistHeaders,
+      ),
+    );
+  }
+
+  return violations;
+};
+
+/**
+ * Validates a structured message against documented Cloudflare Email Sending
+ * limits and returns every violation found. Total message size is not checked
+ * because the encoded MIME size is only known once Cloudflare composes it.
+ */
+export const validateMessage = (message: EmailMessageBuilder): ReadonlyArray<EmailViolation> => {
+  const violations: Array<EmailViolation> = [];
+  const fields = message as {
+    readonly to?: EmailRecipients;
+    readonly cc?: EmailRecipients;
+    readonly bcc?: EmailRecipients;
+    readonly from?: unknown;
+    readonly replyTo?: unknown;
+    readonly subject?: unknown;
+    readonly text?: unknown;
+    readonly html?: unknown;
+    readonly attachments?: ReadonlyArray<EmailAttachment>;
+    readonly headers?: Record<string, string>;
+  };
+
+  if (fields.from === undefined) {
+    violations.push({ path: "from", message: "A from address is required" });
+  } else {
+    violations.push(...addressViolations("from", fields.from));
+  }
+
+  if (fields.replyTo !== undefined) {
+    violations.push(...addressViolations("replyTo", fields.replyTo));
+  }
+
+  if (typeof fields.subject !== "string" || fields.subject === "") {
+    violations.push({ path: "subject", message: "A subject is required" });
+  }
+
+  if (typeof fields.text !== "string" && typeof fields.html !== "string") {
+    violations.push({ path: "$", message: "A message requires either text or html content" });
+  }
+
+  const recipients =
+    addressList(fields.to).length + addressList(fields.cc).length + addressList(fields.bcc).length;
+
+  if (recipients === 0) {
+    violations.push({
+      path: "$",
+      message: "A message requires at least one to, cc, or bcc address",
+    });
+  }
+
+  if (recipients > sendLimits.maxRecipients) {
+    violations.push(
+      limitViolation(
+        "$",
+        "combined to, cc, and bcc addresses",
+        recipients,
+        sendLimits.maxRecipients,
+      ),
+    );
+  }
+
+  violations.push(...recipientViolations("to", fields.to));
+  violations.push(...recipientViolations("cc", fields.cc));
+  violations.push(...recipientViolations("bcc", fields.bcc));
+
+  if (fields.attachments !== undefined) {
+    violations.push(...attachmentViolations(fields.attachments));
+  }
+
+  if (fields.headers !== undefined) {
+    violations.push(...headerViolations(fields.headers));
+  }
+
+  return violations;
+};
+
+const validateSendInput = (
+  source: string,
+  operation: string,
+  message: EmailMessageBuilder,
+): Effect.Effect<EmailMessageBuilder, EmailValidationError> => {
+  const violations = validateMessage(message);
+
+  return violations.length > 0
+    ? Effect.fail(emailValidationError(source, operation, violations))
+    : Effect.succeed(message);
+};
 
 export const isEmailBinding = (value: unknown): value is EmailBinding => {
   if (typeof value !== "object" || value === null) {
@@ -98,13 +570,20 @@ export const isEmailBinding = (value: unknown): value is EmailBinding => {
 };
 
 export const makeClient =
-  (definition: EmailDefinition) =>
+  (definition: EmailDefinition, options?: EmailSendOptions) =>
   (email: EmailBinding): EmailClient => {
     const runtime = email as EmailRuntimeBinding;
-    const send = ((message: EmailSendInput) =>
-      tryEmailPromise(definition.binding, "send", () =>
-        runtime.send(message),
-      )) as EmailClient["send"];
+    const validate = options?.validate ?? true;
+    const send = ((message: EmailSendInput) => {
+      const dispatch = () =>
+        tryEmailPromise(definition.binding, "send", () => runtime.send(message));
+
+      if (!validate || !isEmailMessageBuilder(message)) {
+        return dispatch();
+      }
+
+      return validateSendInput(definition.binding, "send", message).pipe(Effect.flatMap(dispatch));
+    }) as EmailClient["send"];
 
     return {
       definition,
@@ -113,12 +592,274 @@ export const makeClient =
     };
   };
 
-export const layer = <Self>(tag: Context.Service<Self, EmailClient>, definition: EmailDefinition) =>
-  Binding.layer(tag, definition.binding, isEmailBinding, makeClient(definition), {
+const base64 = (content: ArrayBuffer | ArrayBufferView) => {
+  const bytes =
+    content instanceof ArrayBuffer
+      ? new Uint8Array(content)
+      : new Uint8Array(content.buffer, content.byteOffset, content.byteLength);
+  const chunkSize = 0x8000;
+  let binary = "";
+
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+
+  return btoa(binary);
+};
+
+const sendingAddress = (value: string | EmailAddress) => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return value.name === undefined || value.name === ""
+    ? { address: value.email }
+    : { address: value.email, name: value.name };
+};
+
+const sendingRecipients = (value: EmailRecipients) =>
+  Array.isArray(value) ? value.map(sendingAddress) : sendingAddress(value as string | EmailAddress);
+
+const sendingAttachment = (attachment: EmailAttachment) => ({
+  content: typeof attachment.content === "string" ? attachment.content : base64(attachment.content),
+  filename: attachment.filename,
+  type: attachment.type,
+  disposition: attachment.disposition,
+  ...(attachment.contentId === undefined ? {} : { content_id: attachment.contentId }),
+});
+
+/**
+ * Converts a structured Workers message into the Cloudflare Email Sending REST
+ * API payload, which uses `address` keys and snake_case fields.
+ */
+export const toSendingPayload = (message: EmailMessageBuilder): Record<string, unknown> => {
+  const fields = message as {
+    readonly to?: EmailRecipients;
+    readonly cc?: EmailRecipients;
+    readonly bcc?: EmailRecipients;
+    readonly from: string | EmailAddress;
+    readonly replyTo?: string | EmailAddress;
+    readonly subject: string;
+    readonly text?: string;
+    readonly html?: string;
+    readonly attachments?: ReadonlyArray<EmailAttachment>;
+    readonly headers?: Record<string, string>;
+  };
+
+  return {
+    from: sendingAddress(fields.from),
+    subject: fields.subject,
+    ...(fields.to === undefined ? {} : { to: sendingRecipients(fields.to) }),
+    ...(fields.cc === undefined ? {} : { cc: sendingRecipients(fields.cc) }),
+    ...(fields.bcc === undefined ? {} : { bcc: sendingRecipients(fields.bcc) }),
+    ...(fields.replyTo === undefined ? {} : { reply_to: sendingAddress(fields.replyTo) }),
+    ...(fields.text === undefined ? {} : { text: fields.text }),
+    ...(fields.html === undefined ? {} : { html: fields.html }),
+    ...(fields.attachments === undefined
+      ? {}
+      : { attachments: fields.attachments.map(sendingAttachment) }),
+    ...(fields.headers === undefined ? {} : { headers: fields.headers }),
+  };
+};
+
+const sendingApiUrl = (definition: EmailSendingDefinition) => {
+  const baseUrl = new URL(definition.apiBaseUrl ?? defaultSendingApiBaseUrl);
+  const pathname = baseUrl.pathname.replace(/\/+$/, "");
+
+  baseUrl.pathname = `${pathname}/accounts/${definition.accountId}/email/sending/send`;
+
+  return baseUrl.href;
+};
+
+const sendingRequest = (
+  definition: EmailSendingDefinition,
+  message: EmailMessageBuilder,
+  options?: EmailSendingOptions,
+) => {
+  let request = HttpClientRequest.post(sendingApiUrl(definition)).pipe(
+    HttpClientRequest.acceptJson,
+    HttpClientRequest.bodyJsonUnsafe(toSendingPayload(message)),
+  );
+
+  if (options?.headers !== undefined) {
+    request = HttpClientRequest.setHeaders(request, options.headers);
+  }
+
+  return HttpClientRequest.bearerToken(request, definition.apiToken);
+};
+
+const apiErrors = (body: string): ReadonlyArray<EmailSendingApiError> | undefined => {
+  const parsed = (() => {
+    try {
+      return JSON.parse(body) as unknown;
+    } catch {
+      return undefined;
+    }
+  })();
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return undefined;
+  }
+
+  const errors = Reflect.get(parsed, "errors");
+
+  if (!Array.isArray(errors)) {
+    return undefined;
+  }
+
+  const decoded = errors.filter(
+    (error): error is EmailSendingApiError =>
+      typeof error === "object" &&
+      error !== null &&
+      typeof Reflect.get(error, "code") === "number" &&
+      typeof Reflect.get(error, "message") === "string",
+  );
+
+  return decoded.length === 0 ? undefined : decoded;
+};
+
+const sendingResponseText = (
+  definition: EmailSendingDefinition,
+  response: HttpClientResponse.HttpClientResponse,
+  operation: string,
+) =>
+  response.text.pipe(
+    Effect.catch((cause) =>
+      Effect.fail(
+        emailSendingError(definition, operation, "Failed to read Email Sending API response body", {
+          cause,
+        }),
+      ),
+    ),
+  );
+
+const executeSendRequest = (
+  definition: EmailSendingDefinition,
+  httpClient: HttpClient.HttpClient,
+  message: EmailMessageBuilder,
+  options?: EmailSendingOptions,
+) =>
+  Effect.gen(function* () {
+    if (definition.validate ?? true) {
+      yield* validateSendInput(definition.accountId, "send", message);
+    }
+
+    const response = yield* httpClient
+      .execute(sendingRequest(definition, message, options))
+      .pipe(
+        Effect.mapError((cause) =>
+          emailSendingError(definition, "send", "Email Sending API request failed", { cause }),
+        ),
+      );
+
+    if (response.status < 200 || response.status >= 300) {
+      const body = yield* sendingResponseText(definition, response, "sendErrorBody");
+
+      return yield* Effect.fail(
+        emailSendingError(
+          definition,
+          "send",
+          `Email Sending API returned HTTP ${response.status}`,
+          { status: response.status, body, errors: apiErrors(body) },
+        ),
+      );
+    }
+
+    return response;
+  });
+
+const makeSendingClientWith = (
+  definition: EmailSendingDefinition,
+  httpClient: HttpClient.HttpClient,
+): EmailSendingClient => {
+  const raw = (message: EmailMessageBuilder, options?: EmailSendingOptions) =>
+    executeSendRequest(definition, httpClient, message, options);
+
+  const send = (message: EmailMessageBuilder, options?: EmailSendingOptions) =>
+    Effect.gen(function* () {
+      const response = yield* raw(message, options);
+      const json = yield* response.json.pipe(
+        Effect.catch((cause) =>
+          Effect.fail(
+            emailSendingError(
+              definition,
+              "json",
+              "Failed to read Email Sending API JSON response body",
+              { cause },
+            ),
+          ),
+        ),
+      );
+      const decoded = yield* decodeSendingResponse(json);
+
+      if (!decoded.success || decoded.result === null) {
+        return yield* Effect.fail(
+          emailSendingError(definition, "send", "Email Sending API reported a failed send", {
+            status: response.status,
+            errors: decoded.errors,
+          }),
+        );
+      }
+
+      return {
+        delivered: decoded.result.delivered,
+        permanentBounces: decoded.result.permanent_bounces,
+        queued: decoded.result.queued,
+      } satisfies EmailSendingResult;
+    });
+
+  return { definition, raw, send };
+};
+
+export const makeSendingClient = (definition: EmailSendingDefinition) =>
+  Effect.map(HttpClient.HttpClient, (httpClient) => makeSendingClientWith(definition, httpClient));
+
+export const sendingConfig = (options?: SendingConfigOptions) =>
+  Config.all({
+    accountId: options?.accountId ?? Config.string("CLOUDFLARE_ACCOUNT_ID"),
+    apiToken: options?.apiToken ?? Config.redacted("CLOUDFLARE_API_TOKEN"),
+    apiBaseUrl:
+      options?.apiBaseUrl ??
+      Config.string("CLOUDFLARE_API_BASE_URL").pipe(Config.withDefault(defaultSendingApiBaseUrl)),
+  });
+
+export const layer = <Self>(tag: Context.Service<Self, EmailClient>, definition: LayerOptions) =>
+  Binding.layer(tag, definition.binding, isEmailBinding, makeClient(definition, definition.send), {
     expected: expectedSendEmailBinding,
   });
 
+export const sendingLayer = <Self>(
+  tag: Context.Service<Self, EmailSendingClient>,
+  definition: EmailSendingDefinition,
+) => Layer.effect(tag, makeSendingClient(definition));
+
+export const sendingFetchLayer = <Self>(
+  tag: Context.Service<Self, EmailSendingClient>,
+  definition: EmailSendingDefinition,
+) => sendingLayer(tag, definition).pipe(Layer.provide(FetchHttpClient.layer));
+
+export const sendingLayerConfig = <Self>(
+  tag: Context.Service<Self, EmailSendingClient>,
+  config: Config.Config<EmailSendingDefinition> = sendingConfig(),
+) =>
+  Layer.effect(
+    tag,
+    Effect.gen(function* () {
+      const definition = yield* config;
+
+      return yield* makeSendingClient(definition);
+    }),
+  );
+
+export const sendingFetchLayerConfig = <Self>(
+  tag: Context.Service<Self, EmailSendingClient>,
+  config: Config.Config<EmailSendingDefinition> = sendingConfig(),
+) => sendingLayerConfig(tag, config).pipe(Layer.provide(FetchHttpClient.layer));
+
 export const make = <Id extends string>(id: Id) => Tag<EmailService<Id>>()<Id>(id);
+
+export const makeSending = <Id extends string>(id: Id) =>
+  SendingTag<EmailSendingService<Id>>()<Id>(id);
 
 export const Tag =
   <Self>() =>
@@ -131,4 +872,25 @@ export const Tag =
       id,
       layer: makeLayer,
     }) as TagClass<Self, Id>;
+  };
+
+export const SendingTag =
+  <Self>() =>
+  <Id extends string>(id: Id) => {
+    const tag = Context.Service<Self, EmailSendingClient>()(id);
+    const makeLayer = (definition: EmailSendingDefinition) => sendingLayer(tag, definition);
+    const makeFetchLayer = (definition: EmailSendingDefinition) =>
+      sendingFetchLayer(tag, definition);
+    const makeLayerConfig = (config?: Config.Config<EmailSendingDefinition>) =>
+      sendingLayerConfig(tag, config);
+    const makeFetchLayerConfig = (config?: Config.Config<EmailSendingDefinition>) =>
+      sendingFetchLayerConfig(tag, config);
+
+    return Object.assign(tag, {
+      id,
+      layer: makeLayer,
+      fetchLayer: makeFetchLayer,
+      layerConfig: makeLayerConfig,
+      fetchLayerConfig: makeFetchLayerConfig,
+    }) as SendingTagClass<Self, Id>;
   };

--- a/packages/effect-cf/src/Email.ts
+++ b/packages/effect-cf/src/Email.ts
@@ -5,20 +5,12 @@ import type {
   EmailSendResult as CloudflareEmailSendResult,
   SendEmail as CloudflareSendEmail,
 } from "@cloudflare/workers-types";
-import { type Redacted, Config, Context, Data, Effect, Layer, Schema as S } from "effect";
-import {
-  FetchHttpClient,
-  type Headers,
-  HttpClient,
-  type HttpClientResponse,
-  HttpClientRequest,
-} from "effect/unstable/http";
+import { Context, Data, Effect, type Layer } from "effect";
 
 import * as Binding from "./Binding";
 import type { WorkerEnvironment } from "./Environment";
 
 const expectedSendEmailBinding = "Send Email binding with send()";
-const defaultSendingApiBaseUrl = "https://api.cloudflare.com/client/v4";
 const textEncoder = new TextEncoder();
 
 /** Documented Cloudflare Email Sending limits. */
@@ -62,25 +54,6 @@ export const emailErrorCodes = [
 /** A documented Cloudflare Email Sending error code. */
 export type EmailErrorCode = (typeof emailErrorCodes)[number];
 
-const sendingApiErrorSchema = S.Struct({
-  code: S.Number,
-  message: S.String,
-});
-
-const sendingResultSchema = S.Struct({
-  delivered: S.Array(S.String),
-  permanent_bounces: S.Array(S.String),
-  queued: S.Array(S.String),
-});
-
-const sendingResponseSchema = S.Struct({
-  success: S.Boolean,
-  errors: S.Array(sendingApiErrorSchema),
-  result: S.NullOr(sendingResultSchema),
-});
-
-const decodeSendingResponse = S.decodeUnknownEffect(sendingResponseSchema);
-
 /** Error raised when a Cloudflare Send Email operation fails. */
 export class EmailOperationError extends Data.TaggedError("EmailOperationError")<{
   readonly binding: string;
@@ -100,21 +73,9 @@ export interface EmailViolation {
 
 /** Error raised when a message violates documented Cloudflare Email Sending limits. */
 export class EmailValidationError extends Data.TaggedError("EmailValidationError")<{
-  /** Binding name for binding sends, or Cloudflare account id for REST sends. */
-  readonly source: string;
+  readonly binding: string;
   readonly operation: string;
   readonly violations: ReadonlyArray<EmailViolation>;
-}> {}
-
-/** Error raised when a Cloudflare Email Sending REST API request fails. */
-export class EmailSendingError extends Data.TaggedError("EmailSendingError")<{
-  readonly operation: string;
-  readonly accountId: string;
-  readonly message: string;
-  readonly status?: number;
-  readonly errors?: ReadonlyArray<EmailSendingApiError>;
-  readonly body?: string;
-  readonly cause?: unknown;
 }> {}
 
 /** Typed Cloudflare Send Email binding definition. */
@@ -132,17 +93,6 @@ export type EmailSendResult = CloudflareEmailSendResult;
 export type EmailBinding = CloudflareSendEmail;
 export type EmailRecipients = string | EmailAddress | ReadonlyArray<string | EmailAddress>;
 export type EmailSendError = EmailOperationError | EmailValidationError;
-export type EmailSendingApiError = S.Schema.Type<typeof sendingApiErrorSchema>;
-
-/** Per-recipient delivery status returned by the Email Sending REST API. */
-export interface EmailSendingResult {
-  /** Addresses the message was delivered to immediately. */
-  readonly delivered: ReadonlyArray<string>;
-  /** Addresses that permanently bounced. */
-  readonly permanentBounces: ReadonlyArray<string>;
-  /** Addresses whose delivery was queued for later. */
-  readonly queued: ReadonlyArray<string>;
-}
 
 export interface EmailSendOptions {
   /** Validates builder messages against documented limits. Defaults to `true`. */
@@ -162,40 +112,7 @@ export interface EmailClient {
   readonly definition: EmailDefinition;
 }
 
-/** Cloudflare Email Sending REST API definition. */
-export interface EmailSendingDefinition {
-  /** Cloudflare account id that owns the onboarded sending domain. */
-  readonly accountId: string;
-  /** API token with the Email Sending permission. */
-  readonly apiToken: Redacted.Redacted<string>;
-  /** Base Cloudflare API URL. Defaults to `https://api.cloudflare.com/client/v4`. */
-  readonly apiBaseUrl?: string | URL;
-  /** Validates messages against documented limits. Defaults to `true`. */
-  readonly validate?: boolean;
-}
-
-export interface EmailSendingOptions {
-  /** Additional request headers. Authorization is always derived from `apiToken`. */
-  readonly headers?: Headers.Input;
-}
-
-export interface EmailSendingClient {
-  readonly send: (
-    message: EmailMessageBuilder,
-    options?: EmailSendingOptions,
-  ) => Effect.Effect<EmailSendingResult, EmailSendingError | EmailValidationError | S.SchemaError>;
-  readonly raw: (
-    message: EmailMessageBuilder,
-    options?: EmailSendingOptions,
-  ) => Effect.Effect<
-    HttpClientResponse.HttpClientResponse,
-    EmailSendingError | EmailValidationError
-  >;
-  readonly definition: EmailSendingDefinition;
-}
-
 declare const EmailServiceTypeId: unique symbol;
-declare const EmailSendingServiceTypeId: unique symbol;
 
 /** Nominal service marker for Send Email services created with {@link make}. */
 export interface EmailService<Id extends string> {
@@ -204,22 +121,9 @@ export interface EmailService<Id extends string> {
   };
 }
 
-/** Nominal service marker for Email Sending REST services created with {@link makeSending}. */
-export interface EmailSendingService<Id extends string> {
-  readonly [EmailSendingServiceTypeId]: {
-    readonly id: Id;
-  };
-}
-
 export type LayerOptions = {
   readonly binding: string;
   readonly send?: EmailSendOptions;
-};
-
-export type SendingConfigOptions = {
-  readonly accountId?: Config.Config<string>;
-  readonly apiToken?: Config.Config<Redacted.Redacted<string>>;
-  readonly apiBaseUrl?: Config.Config<string>;
 };
 
 export interface TagClass<Self, Id extends string> extends Context.ServiceClass<
@@ -237,24 +141,6 @@ export interface TagClass<Self, Id extends string> extends Context.ServiceClass<
   >;
 }
 
-export interface SendingTagClass<Self, Id extends string> extends Context.ServiceClass<
-  Self,
-  Id,
-  EmailSendingClient
-> {
-  readonly id: Id;
-  readonly layer: (
-    definition: EmailSendingDefinition,
-  ) => Layer.Layer<Self, never, HttpClient.HttpClient>;
-  readonly fetchLayer: (definition: EmailSendingDefinition) => Layer.Layer<Self>;
-  readonly layerConfig: (
-    config?: Config.Config<EmailSendingDefinition>,
-  ) => Layer.Layer<Self, Config.ConfigError, HttpClient.HttpClient>;
-  readonly fetchLayerConfig: (
-    config?: Config.Config<EmailSendingDefinition>,
-  ) => Layer.Layer<Self, Config.ConfigError>;
-}
-
 const emailErrorCode = (cause: unknown): EmailOperationError["code"] => {
   if (typeof cause !== "object" || cause === null) {
     return undefined;
@@ -269,31 +155,10 @@ const emailError = (binding: string, operation: string, cause: unknown) =>
   new EmailOperationError({ binding, operation, cause, code: emailErrorCode(cause) });
 
 const emailValidationError = (
-  source: string,
+  binding: string,
   operation: string,
   violations: ReadonlyArray<EmailViolation>,
-) => new EmailValidationError({ source, operation, violations });
-
-const emailSendingError = (
-  definition: EmailSendingDefinition,
-  operation: string,
-  message: string,
-  options?: {
-    readonly status?: number;
-    readonly errors?: ReadonlyArray<EmailSendingApiError>;
-    readonly body?: string;
-    readonly cause?: unknown;
-  },
-) =>
-  new EmailSendingError({
-    operation,
-    accountId: definition.accountId,
-    message,
-    status: options?.status,
-    errors: options?.errors,
-    body: options?.body,
-    cause: options?.cause,
-  });
+) => new EmailValidationError({ binding, operation, violations });
 
 const tryEmailPromise = <A>(
   binding: string,
@@ -548,14 +413,14 @@ export const validateMessage = (message: EmailMessageBuilder): ReadonlyArray<Ema
 };
 
 const validateSendInput = (
-  source: string,
+  binding: string,
   operation: string,
   message: EmailMessageBuilder,
 ): Effect.Effect<EmailMessageBuilder, EmailValidationError> => {
   const violations = validateMessage(message);
 
   return violations.length > 0
-    ? Effect.fail(emailValidationError(source, operation, violations))
+    ? Effect.fail(emailValidationError(binding, operation, violations))
     : Effect.succeed(message);
 };
 
@@ -592,274 +457,12 @@ export const makeClient =
     };
   };
 
-const base64 = (content: ArrayBuffer | ArrayBufferView) => {
-  const bytes =
-    content instanceof ArrayBuffer
-      ? new Uint8Array(content)
-      : new Uint8Array(content.buffer, content.byteOffset, content.byteLength);
-  const chunkSize = 0x8000;
-  let binary = "";
-
-  for (let index = 0; index < bytes.length; index += chunkSize) {
-    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
-  }
-
-  return btoa(binary);
-};
-
-const sendingAddress = (value: string | EmailAddress) => {
-  if (typeof value === "string") {
-    return value;
-  }
-
-  return value.name === undefined || value.name === ""
-    ? { address: value.email }
-    : { address: value.email, name: value.name };
-};
-
-const sendingRecipients = (value: EmailRecipients) =>
-  Array.isArray(value) ? value.map(sendingAddress) : sendingAddress(value as string | EmailAddress);
-
-const sendingAttachment = (attachment: EmailAttachment) => ({
-  content: typeof attachment.content === "string" ? attachment.content : base64(attachment.content),
-  filename: attachment.filename,
-  type: attachment.type,
-  disposition: attachment.disposition,
-  ...(attachment.contentId === undefined ? {} : { content_id: attachment.contentId }),
-});
-
-/**
- * Converts a structured Workers message into the Cloudflare Email Sending REST
- * API payload, which uses `address` keys and snake_case fields.
- */
-export const toSendingPayload = (message: EmailMessageBuilder): Record<string, unknown> => {
-  const fields = message as {
-    readonly to?: EmailRecipients;
-    readonly cc?: EmailRecipients;
-    readonly bcc?: EmailRecipients;
-    readonly from: string | EmailAddress;
-    readonly replyTo?: string | EmailAddress;
-    readonly subject: string;
-    readonly text?: string;
-    readonly html?: string;
-    readonly attachments?: ReadonlyArray<EmailAttachment>;
-    readonly headers?: Record<string, string>;
-  };
-
-  return {
-    from: sendingAddress(fields.from),
-    subject: fields.subject,
-    ...(fields.to === undefined ? {} : { to: sendingRecipients(fields.to) }),
-    ...(fields.cc === undefined ? {} : { cc: sendingRecipients(fields.cc) }),
-    ...(fields.bcc === undefined ? {} : { bcc: sendingRecipients(fields.bcc) }),
-    ...(fields.replyTo === undefined ? {} : { reply_to: sendingAddress(fields.replyTo) }),
-    ...(fields.text === undefined ? {} : { text: fields.text }),
-    ...(fields.html === undefined ? {} : { html: fields.html }),
-    ...(fields.attachments === undefined
-      ? {}
-      : { attachments: fields.attachments.map(sendingAttachment) }),
-    ...(fields.headers === undefined ? {} : { headers: fields.headers }),
-  };
-};
-
-const sendingApiUrl = (definition: EmailSendingDefinition) => {
-  const baseUrl = new URL(definition.apiBaseUrl ?? defaultSendingApiBaseUrl);
-  const pathname = baseUrl.pathname.replace(/\/+$/, "");
-
-  baseUrl.pathname = `${pathname}/accounts/${definition.accountId}/email/sending/send`;
-
-  return baseUrl.href;
-};
-
-const sendingRequest = (
-  definition: EmailSendingDefinition,
-  message: EmailMessageBuilder,
-  options?: EmailSendingOptions,
-) => {
-  let request = HttpClientRequest.post(sendingApiUrl(definition)).pipe(
-    HttpClientRequest.acceptJson,
-    HttpClientRequest.bodyJsonUnsafe(toSendingPayload(message)),
-  );
-
-  if (options?.headers !== undefined) {
-    request = HttpClientRequest.setHeaders(request, options.headers);
-  }
-
-  return HttpClientRequest.bearerToken(request, definition.apiToken);
-};
-
-const apiErrors = (body: string): ReadonlyArray<EmailSendingApiError> | undefined => {
-  const parsed = (() => {
-    try {
-      return JSON.parse(body) as unknown;
-    } catch {
-      return undefined;
-    }
-  })();
-
-  if (typeof parsed !== "object" || parsed === null) {
-    return undefined;
-  }
-
-  const errors = Reflect.get(parsed, "errors");
-
-  if (!Array.isArray(errors)) {
-    return undefined;
-  }
-
-  const decoded = errors.filter(
-    (error): error is EmailSendingApiError =>
-      typeof error === "object" &&
-      error !== null &&
-      typeof Reflect.get(error, "code") === "number" &&
-      typeof Reflect.get(error, "message") === "string",
-  );
-
-  return decoded.length === 0 ? undefined : decoded;
-};
-
-const sendingResponseText = (
-  definition: EmailSendingDefinition,
-  response: HttpClientResponse.HttpClientResponse,
-  operation: string,
-) =>
-  response.text.pipe(
-    Effect.catch((cause) =>
-      Effect.fail(
-        emailSendingError(definition, operation, "Failed to read Email Sending API response body", {
-          cause,
-        }),
-      ),
-    ),
-  );
-
-const executeSendRequest = (
-  definition: EmailSendingDefinition,
-  httpClient: HttpClient.HttpClient,
-  message: EmailMessageBuilder,
-  options?: EmailSendingOptions,
-) =>
-  Effect.gen(function* () {
-    if (definition.validate ?? true) {
-      yield* validateSendInput(definition.accountId, "send", message);
-    }
-
-    const response = yield* httpClient
-      .execute(sendingRequest(definition, message, options))
-      .pipe(
-        Effect.mapError((cause) =>
-          emailSendingError(definition, "send", "Email Sending API request failed", { cause }),
-        ),
-      );
-
-    if (response.status < 200 || response.status >= 300) {
-      const body = yield* sendingResponseText(definition, response, "sendErrorBody");
-
-      return yield* Effect.fail(
-        emailSendingError(
-          definition,
-          "send",
-          `Email Sending API returned HTTP ${response.status}`,
-          { status: response.status, body, errors: apiErrors(body) },
-        ),
-      );
-    }
-
-    return response;
-  });
-
-const makeSendingClientWith = (
-  definition: EmailSendingDefinition,
-  httpClient: HttpClient.HttpClient,
-): EmailSendingClient => {
-  const raw = (message: EmailMessageBuilder, options?: EmailSendingOptions) =>
-    executeSendRequest(definition, httpClient, message, options);
-
-  const send = (message: EmailMessageBuilder, options?: EmailSendingOptions) =>
-    Effect.gen(function* () {
-      const response = yield* raw(message, options);
-      const json = yield* response.json.pipe(
-        Effect.catch((cause) =>
-          Effect.fail(
-            emailSendingError(
-              definition,
-              "json",
-              "Failed to read Email Sending API JSON response body",
-              { cause },
-            ),
-          ),
-        ),
-      );
-      const decoded = yield* decodeSendingResponse(json);
-
-      if (!decoded.success || decoded.result === null) {
-        return yield* Effect.fail(
-          emailSendingError(definition, "send", "Email Sending API reported a failed send", {
-            status: response.status,
-            errors: decoded.errors,
-          }),
-        );
-      }
-
-      return {
-        delivered: decoded.result.delivered,
-        permanentBounces: decoded.result.permanent_bounces,
-        queued: decoded.result.queued,
-      } satisfies EmailSendingResult;
-    });
-
-  return { definition, raw, send };
-};
-
-export const makeSendingClient = (definition: EmailSendingDefinition) =>
-  Effect.map(HttpClient.HttpClient, (httpClient) => makeSendingClientWith(definition, httpClient));
-
-export const sendingConfig = (options?: SendingConfigOptions) =>
-  Config.all({
-    accountId: options?.accountId ?? Config.string("CLOUDFLARE_ACCOUNT_ID"),
-    apiToken: options?.apiToken ?? Config.redacted("CLOUDFLARE_API_TOKEN"),
-    apiBaseUrl:
-      options?.apiBaseUrl ??
-      Config.string("CLOUDFLARE_API_BASE_URL").pipe(Config.withDefault(defaultSendingApiBaseUrl)),
-  });
-
 export const layer = <Self>(tag: Context.Service<Self, EmailClient>, definition: LayerOptions) =>
   Binding.layer(tag, definition.binding, isEmailBinding, makeClient(definition, definition.send), {
     expected: expectedSendEmailBinding,
   });
 
-export const sendingLayer = <Self>(
-  tag: Context.Service<Self, EmailSendingClient>,
-  definition: EmailSendingDefinition,
-) => Layer.effect(tag, makeSendingClient(definition));
-
-export const sendingFetchLayer = <Self>(
-  tag: Context.Service<Self, EmailSendingClient>,
-  definition: EmailSendingDefinition,
-) => sendingLayer(tag, definition).pipe(Layer.provide(FetchHttpClient.layer));
-
-export const sendingLayerConfig = <Self>(
-  tag: Context.Service<Self, EmailSendingClient>,
-  config: Config.Config<EmailSendingDefinition> = sendingConfig(),
-) =>
-  Layer.effect(
-    tag,
-    Effect.gen(function* () {
-      const definition = yield* config;
-
-      return yield* makeSendingClient(definition);
-    }),
-  );
-
-export const sendingFetchLayerConfig = <Self>(
-  tag: Context.Service<Self, EmailSendingClient>,
-  config: Config.Config<EmailSendingDefinition> = sendingConfig(),
-) => sendingLayerConfig(tag, config).pipe(Layer.provide(FetchHttpClient.layer));
-
 export const make = <Id extends string>(id: Id) => Tag<EmailService<Id>>()<Id>(id);
-
-export const makeSending = <Id extends string>(id: Id) =>
-  SendingTag<EmailSendingService<Id>>()<Id>(id);
 
 export const Tag =
   <Self>() =>
@@ -872,25 +475,4 @@ export const Tag =
       id,
       layer: makeLayer,
     }) as TagClass<Self, Id>;
-  };
-
-export const SendingTag =
-  <Self>() =>
-  <Id extends string>(id: Id) => {
-    const tag = Context.Service<Self, EmailSendingClient>()(id);
-    const makeLayer = (definition: EmailSendingDefinition) => sendingLayer(tag, definition);
-    const makeFetchLayer = (definition: EmailSendingDefinition) =>
-      sendingFetchLayer(tag, definition);
-    const makeLayerConfig = (config?: Config.Config<EmailSendingDefinition>) =>
-      sendingLayerConfig(tag, config);
-    const makeFetchLayerConfig = (config?: Config.Config<EmailSendingDefinition>) =>
-      sendingFetchLayerConfig(tag, config);
-
-    return Object.assign(tag, {
-      id,
-      layer: makeLayer,
-      fetchLayer: makeFetchLayer,
-      layerConfig: makeLayerConfig,
-      fetchLayerConfig: makeFetchLayerConfig,
-    }) as SendingTagClass<Self, Id>;
   };

--- a/packages/effect-cf/tests/Email.test.ts
+++ b/packages/effect-cf/tests/Email.test.ts
@@ -1,9 +1,12 @@
 import { assert, expect, layer, test } from "@effect/vitest";
-import { Effect, Layer } from "effect";
+import { ConfigProvider, Effect, Layer, Redacted } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
 
 import { Binding, Email, WorkerEnvironment } from "../src/index";
 
 class TestEmail extends Email.Tag<TestEmail>()("test/TestEmail") {}
+
+class TestEmailSending extends Email.SendingTag<TestEmailSending>()("test/TestEmailSending") {}
 
 interface SendCall {
   readonly message: Email.EmailSendInput;
@@ -145,4 +148,355 @@ test("Send Email operations map rejected sends", async () => {
     operation: "send",
     cause,
   });
+});
+
+const recipients = (count: number) =>
+  Array.from({ length: count }, (_, index) => `user-${index}@example.com`);
+
+const fetchLayer = (request: typeof fetch) =>
+  FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch, request)));
+
+test("Send Email validates builder messages before calling the binding", async () => {
+  const calls: Array<SendCall> = [];
+
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const email = yield* TestEmail;
+
+        yield* email.send({
+          from: "team@example.com",
+          to: recipients(Email.sendLimits.maxRecipients + 1),
+          subject: "Welcome",
+          text: "Welcome to Example",
+        });
+      }).pipe(
+        Effect.provide(
+          emailLayer(
+            makeFakeEmail({
+              send: async (message) => {
+                calls.push({ message });
+
+                return { messageId: "email-1" };
+              },
+            }),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "EmailValidationError",
+    source: "EMAIL",
+    operation: "send",
+  });
+
+  assert.strictEqual(calls.length, 0);
+});
+
+test("Send Email validation reports every violated limit", async () => {
+  const violations = Email.validateMessage({
+    from: "not-an-address",
+    to: [],
+    subject: "",
+    attachments: Array.from({ length: Email.sendLimits.maxAttachments + 1 }, () => ({
+      disposition: "attachment" as const,
+      filename: "note.txt",
+      type: "text/plain",
+      content: "note",
+    })),
+  });
+
+  assert.deepStrictEqual(violations.map((violation) => violation.path).sort(), [
+    "$",
+    "$",
+    "attachments",
+    "from",
+    "subject",
+  ]);
+});
+
+test("Send Email validation can be disabled per layer", async () => {
+  const calls: Array<SendCall> = [];
+  const email = makeFakeEmail({
+    send: async (message) => {
+      calls.push({ message });
+
+      return { messageId: "email-unvalidated" };
+    },
+  });
+
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const client = yield* TestEmail;
+
+      return yield* client.send({
+        from: "team@example.com",
+        to: recipients(Email.sendLimits.maxRecipients + 1),
+        subject: "Welcome",
+        text: "Welcome to Example",
+      });
+    }).pipe(
+      Effect.provide(
+        TestEmail.layer({ binding: "EMAIL", send: { validate: false } }).pipe(
+          Layer.provide(Layer.succeed(WorkerEnvironment, { EMAIL: email })),
+        ),
+      ),
+    ),
+  );
+
+  assert.strictEqual(result.messageId, "email-unvalidated");
+  assert.strictEqual(calls.length, 1);
+});
+
+test("Send Email surfaces Cloudflare error codes", async () => {
+  const cause = Object.assign(new Error("sender domain is not verified"), {
+    code: "E_SENDER_NOT_VERIFIED",
+  });
+
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const email = yield* TestEmail;
+
+        yield* email.send({
+          from: "team@example.com",
+          to: "user@example.com",
+          subject: "Welcome",
+          text: "Welcome to Example",
+        });
+      }).pipe(
+        Effect.provide(
+          emailLayer(
+            makeFakeEmail({
+              send: async () => {
+                throw cause;
+              },
+            }),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "EmailOperationError",
+    binding: "EMAIL",
+    operation: "send",
+    code: "E_SENDER_NOT_VERIFIED",
+  });
+});
+
+test("Email Sending payload converts Workers fields to the REST shape", () => {
+  const payload = Email.toSendingPayload({
+    from: { name: "Support Team", email: "support@example.com" },
+    to: ["plain@example.com", { name: "Jane Doe", email: "jane@example.com" }],
+    cc: "manager@example.com",
+    replyTo: { name: "Support", email: "help@example.com" },
+    subject: "Team update",
+    html: "<h1>Monthly update</h1>",
+    headers: { "X-Campaign-ID": "monthly" },
+    attachments: [
+      {
+        disposition: "inline",
+        contentId: "logo",
+        filename: "logo.png",
+        type: "image/png",
+        content: new Uint8Array([1, 2, 3]),
+      },
+    ],
+  });
+
+  assert.deepStrictEqual(payload, {
+    from: { address: "support@example.com", name: "Support Team" },
+    subject: "Team update",
+    to: ["plain@example.com", { address: "jane@example.com", name: "Jane Doe" }],
+    cc: "manager@example.com",
+    reply_to: { address: "help@example.com", name: "Support" },
+    html: "<h1>Monthly update</h1>",
+    attachments: [
+      {
+        content: "AQID",
+        filename: "logo.png",
+        type: "image/png",
+        disposition: "inline",
+        content_id: "logo",
+      },
+    ],
+    headers: { "X-Campaign-ID": "monthly" },
+  });
+});
+
+test("Email Sending client posts messages and decodes delivery status", async () => {
+  const seen: Array<{
+    readonly url: string;
+    readonly headers: Record<string, string>;
+    readonly body: unknown;
+  }> = [];
+  const request: typeof fetch = async (input, init) => {
+    const url = typeof input === "string" || input instanceof URL ? input.toString() : input.url;
+    const raw =
+      typeof init?.body === "string"
+        ? init.body
+        : init?.body instanceof Uint8Array
+          ? new TextDecoder().decode(init.body)
+          : "null";
+
+    seen.push({
+      url,
+      headers: Object.fromEntries(new Headers(init?.headers).entries()),
+      body: JSON.parse(raw) as unknown,
+    });
+
+    return Response.json({
+      success: true,
+      errors: [],
+      messages: [],
+      result: {
+        delivered: ["recipient@example.com"],
+        permanent_bounces: [],
+        queued: ["queued@example.com"],
+      },
+    });
+  };
+
+  const client = await Effect.runPromise(
+    Email.makeSendingClient({
+      accountId: "account-1",
+      apiToken: Redacted.make("secret-token"),
+    }).pipe(Effect.provide(fetchLayer(request))),
+  );
+
+  const result = await Effect.runPromise(
+    client.send({
+      from: "welcome@example.com",
+      to: "recipient@example.com",
+      subject: "Welcome to our service!",
+      text: "Welcome! Thanks for signing up.",
+    }),
+  );
+
+  assert.deepStrictEqual(result, {
+    delivered: ["recipient@example.com"],
+    permanentBounces: [],
+    queued: ["queued@example.com"],
+  });
+  assert.strictEqual(
+    seen[0]?.url,
+    "https://api.cloudflare.com/client/v4/accounts/account-1/email/sending/send",
+  );
+  assert.strictEqual(seen[0]?.headers.authorization, "Bearer secret-token");
+  assert.deepStrictEqual(seen[0]?.body, {
+    from: "welcome@example.com",
+    to: "recipient@example.com",
+    subject: "Welcome to our service!",
+    text: "Welcome! Thanks for signing up.",
+  });
+});
+
+test("Email Sending client validates messages before requesting the API", async () => {
+  let requested = false;
+  const request: typeof fetch = async () => {
+    requested = true;
+
+    return Response.json({ success: true, errors: [], result: null });
+  };
+
+  const client = await Effect.runPromise(
+    Email.makeSendingClient({
+      accountId: "account-1",
+      apiToken: Redacted.make("secret-token"),
+    }).pipe(Effect.provide(fetchLayer(request))),
+  );
+
+  await expect(
+    Effect.runPromise(
+      client.send({
+        from: "welcome@example.com",
+        to: "recipient@example.com",
+        subject: "Welcome to our service!",
+      }),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "EmailValidationError",
+    source: "account-1",
+    operation: "send",
+  });
+
+  assert.strictEqual(requested, false);
+});
+
+test("Email Sending client reports Cloudflare API errors", async () => {
+  const request: typeof fetch = async () =>
+    Response.json(
+      {
+        success: false,
+        errors: [{ code: 10001, message: "email.sending.error.invalid_request_schema" }],
+        messages: [],
+        result: null,
+      },
+      { status: 400 },
+    );
+
+  const client = await Effect.runPromise(
+    Email.makeSendingClient({
+      accountId: "account-1",
+      apiToken: Redacted.make("secret-token"),
+    }).pipe(Effect.provide(fetchLayer(request))),
+  );
+
+  await expect(
+    Effect.runPromise(
+      client.send({
+        from: "welcome@example.com",
+        to: "recipient@example.com",
+        subject: "Welcome to our service!",
+        text: "Welcome! Thanks for signing up.",
+      }),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "EmailSendingError",
+    accountId: "account-1",
+    status: 400,
+    errors: [{ code: 10001, message: "email.sending.error.invalid_request_schema" }],
+  });
+});
+
+test("Email Sending layer reads config through the active ConfigProvider", async () => {
+  const seen: Array<string> = [];
+  const request: typeof fetch = async (input) => {
+    seen.push(typeof input === "string" || input instanceof URL ? input.toString() : input.url);
+
+    return Response.json({
+      success: true,
+      errors: [],
+      result: { delivered: ["recipient@example.com"], permanent_bounces: [], queued: [] },
+    });
+  };
+
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const sending = yield* TestEmailSending;
+
+      return yield* sending.send({
+        from: "welcome@example.com",
+        to: "recipient@example.com",
+        subject: "Welcome to our service!",
+        text: "Welcome! Thanks for signing up.",
+      });
+    }).pipe(
+      Effect.provide(TestEmailSending.layerConfig().pipe(Layer.provide(fetchLayer(request)))),
+      Effect.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromUnknown({
+            CLOUDFLARE_ACCOUNT_ID: "account-2",
+            CLOUDFLARE_API_TOKEN: "secret-token",
+          }),
+        ),
+      ),
+    ),
+  );
+
+  assert.deepStrictEqual(result.delivered, ["recipient@example.com"]);
+  assert.strictEqual(
+    seen[0],
+    "https://api.cloudflare.com/client/v4/accounts/account-2/email/sending/send",
+  );
 });

--- a/packages/effect-cf/tests/Email.test.ts
+++ b/packages/effect-cf/tests/Email.test.ts
@@ -1,12 +1,9 @@
 import { assert, expect, layer, test } from "@effect/vitest";
-import { ConfigProvider, Effect, Layer, Redacted } from "effect";
-import { FetchHttpClient } from "effect/unstable/http";
+import { Effect, Layer } from "effect";
 
 import { Binding, Email, WorkerEnvironment } from "../src/index";
 
 class TestEmail extends Email.Tag<TestEmail>()("test/TestEmail") {}
-
-class TestEmailSending extends Email.SendingTag<TestEmailSending>()("test/TestEmailSending") {}
 
 interface SendCall {
   readonly message: Email.EmailSendInput;
@@ -153,9 +150,6 @@ test("Send Email operations map rejected sends", async () => {
 const recipients = (count: number) =>
   Array.from({ length: count }, (_, index) => `user-${index}@example.com`);
 
-const fetchLayer = (request: typeof fetch) =>
-  FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch, request)));
-
 test("Send Email validates builder messages before calling the binding", async () => {
   const calls: Array<SendCall> = [];
 
@@ -186,7 +180,7 @@ test("Send Email validates builder messages before calling the binding", async (
     ),
   ).rejects.toMatchObject({
     _tag: "EmailValidationError",
-    source: "EMAIL",
+    binding: "EMAIL",
     operation: "send",
   });
 
@@ -282,221 +276,4 @@ test("Send Email surfaces Cloudflare error codes", async () => {
     operation: "send",
     code: "E_SENDER_NOT_VERIFIED",
   });
-});
-
-test("Email Sending payload converts Workers fields to the REST shape", () => {
-  const payload = Email.toSendingPayload({
-    from: { name: "Support Team", email: "support@example.com" },
-    to: ["plain@example.com", { name: "Jane Doe", email: "jane@example.com" }],
-    cc: "manager@example.com",
-    replyTo: { name: "Support", email: "help@example.com" },
-    subject: "Team update",
-    html: "<h1>Monthly update</h1>",
-    headers: { "X-Campaign-ID": "monthly" },
-    attachments: [
-      {
-        disposition: "inline",
-        contentId: "logo",
-        filename: "logo.png",
-        type: "image/png",
-        content: new Uint8Array([1, 2, 3]),
-      },
-    ],
-  });
-
-  assert.deepStrictEqual(payload, {
-    from: { address: "support@example.com", name: "Support Team" },
-    subject: "Team update",
-    to: ["plain@example.com", { address: "jane@example.com", name: "Jane Doe" }],
-    cc: "manager@example.com",
-    reply_to: { address: "help@example.com", name: "Support" },
-    html: "<h1>Monthly update</h1>",
-    attachments: [
-      {
-        content: "AQID",
-        filename: "logo.png",
-        type: "image/png",
-        disposition: "inline",
-        content_id: "logo",
-      },
-    ],
-    headers: { "X-Campaign-ID": "monthly" },
-  });
-});
-
-test("Email Sending client posts messages and decodes delivery status", async () => {
-  const seen: Array<{
-    readonly url: string;
-    readonly headers: Record<string, string>;
-    readonly body: unknown;
-  }> = [];
-  const request: typeof fetch = async (input, init) => {
-    const url = typeof input === "string" || input instanceof URL ? input.toString() : input.url;
-    const raw =
-      typeof init?.body === "string"
-        ? init.body
-        : init?.body instanceof Uint8Array
-          ? new TextDecoder().decode(init.body)
-          : "null";
-
-    seen.push({
-      url,
-      headers: Object.fromEntries(new Headers(init?.headers).entries()),
-      body: JSON.parse(raw) as unknown,
-    });
-
-    return Response.json({
-      success: true,
-      errors: [],
-      messages: [],
-      result: {
-        delivered: ["recipient@example.com"],
-        permanent_bounces: [],
-        queued: ["queued@example.com"],
-      },
-    });
-  };
-
-  const client = await Effect.runPromise(
-    Email.makeSendingClient({
-      accountId: "account-1",
-      apiToken: Redacted.make("secret-token"),
-    }).pipe(Effect.provide(fetchLayer(request))),
-  );
-
-  const result = await Effect.runPromise(
-    client.send({
-      from: "welcome@example.com",
-      to: "recipient@example.com",
-      subject: "Welcome to our service!",
-      text: "Welcome! Thanks for signing up.",
-    }),
-  );
-
-  assert.deepStrictEqual(result, {
-    delivered: ["recipient@example.com"],
-    permanentBounces: [],
-    queued: ["queued@example.com"],
-  });
-  assert.strictEqual(
-    seen[0]?.url,
-    "https://api.cloudflare.com/client/v4/accounts/account-1/email/sending/send",
-  );
-  assert.strictEqual(seen[0]?.headers.authorization, "Bearer secret-token");
-  assert.deepStrictEqual(seen[0]?.body, {
-    from: "welcome@example.com",
-    to: "recipient@example.com",
-    subject: "Welcome to our service!",
-    text: "Welcome! Thanks for signing up.",
-  });
-});
-
-test("Email Sending client validates messages before requesting the API", async () => {
-  let requested = false;
-  const request: typeof fetch = async () => {
-    requested = true;
-
-    return Response.json({ success: true, errors: [], result: null });
-  };
-
-  const client = await Effect.runPromise(
-    Email.makeSendingClient({
-      accountId: "account-1",
-      apiToken: Redacted.make("secret-token"),
-    }).pipe(Effect.provide(fetchLayer(request))),
-  );
-
-  await expect(
-    Effect.runPromise(
-      client.send({
-        from: "welcome@example.com",
-        to: "recipient@example.com",
-        subject: "Welcome to our service!",
-      }),
-    ),
-  ).rejects.toMatchObject({
-    _tag: "EmailValidationError",
-    source: "account-1",
-    operation: "send",
-  });
-
-  assert.strictEqual(requested, false);
-});
-
-test("Email Sending client reports Cloudflare API errors", async () => {
-  const request: typeof fetch = async () =>
-    Response.json(
-      {
-        success: false,
-        errors: [{ code: 10001, message: "email.sending.error.invalid_request_schema" }],
-        messages: [],
-        result: null,
-      },
-      { status: 400 },
-    );
-
-  const client = await Effect.runPromise(
-    Email.makeSendingClient({
-      accountId: "account-1",
-      apiToken: Redacted.make("secret-token"),
-    }).pipe(Effect.provide(fetchLayer(request))),
-  );
-
-  await expect(
-    Effect.runPromise(
-      client.send({
-        from: "welcome@example.com",
-        to: "recipient@example.com",
-        subject: "Welcome to our service!",
-        text: "Welcome! Thanks for signing up.",
-      }),
-    ),
-  ).rejects.toMatchObject({
-    _tag: "EmailSendingError",
-    accountId: "account-1",
-    status: 400,
-    errors: [{ code: 10001, message: "email.sending.error.invalid_request_schema" }],
-  });
-});
-
-test("Email Sending layer reads config through the active ConfigProvider", async () => {
-  const seen: Array<string> = [];
-  const request: typeof fetch = async (input) => {
-    seen.push(typeof input === "string" || input instanceof URL ? input.toString() : input.url);
-
-    return Response.json({
-      success: true,
-      errors: [],
-      result: { delivered: ["recipient@example.com"], permanent_bounces: [], queued: [] },
-    });
-  };
-
-  const result = await Effect.runPromise(
-    Effect.gen(function* () {
-      const sending = yield* TestEmailSending;
-
-      return yield* sending.send({
-        from: "welcome@example.com",
-        to: "recipient@example.com",
-        subject: "Welcome to our service!",
-        text: "Welcome! Thanks for signing up.",
-      });
-    }).pipe(
-      Effect.provide(TestEmailSending.layerConfig().pipe(Layer.provide(fetchLayer(request)))),
-      Effect.provide(
-        ConfigProvider.layer(
-          ConfigProvider.fromUnknown({
-            CLOUDFLARE_ACCOUNT_ID: "account-2",
-            CLOUDFLARE_API_TOKEN: "secret-token",
-          }),
-        ),
-      ),
-    ),
-  );
-
-  assert.deepStrictEqual(result.delivered, ["recipient@example.com"]);
-  assert.strictEqual(
-    seen[0],
-    "https://api.cloudflare.com/client/v4/accounts/account-2/email/sending/send",
-  );
 });

--- a/packages/effect-cf/tests/binding-ergonomics.test-d.ts
+++ b/packages/effect-cf/tests/binding-ergonomics.test-d.ts
@@ -217,7 +217,7 @@ const emailProgram = Effect.gen(function* () {
       subject: "Welcome",
       text: "Welcome to Example",
     }),
-  ).toEqualTypeOf<Effect.Effect<Email.EmailSendResult, Email.EmailOperationError>>();
+  ).toEqualTypeOf<Effect.Effect<Email.EmailSendResult, Email.EmailSendError>>();
 
   yield* email.send({
     from: "team@example.com",

--- a/packages/effect-cf/tests/binding-ergonomics.test-d.ts
+++ b/packages/effect-cf/tests/binding-ergonomics.test-d.ts
@@ -207,6 +207,23 @@ export class TransactionalEmail extends Email.Tag<TransactionalEmail>()("Transac
 
 export const TransactionalEmailLayer = TransactionalEmail.layer({ binding: "EMAIL" });
 
+export const UnvalidatedTransactionalEmailLayer = TransactionalEmail.layer({
+  binding: "EMAIL",
+  send: { validate: false },
+});
+
+expectTypeOf(UnvalidatedTransactionalEmailLayer).toEqualTypeOf(TransactionalEmailLayer);
+
+expectTypeOf<Email.EmailSendError>().toEqualTypeOf<
+  Email.EmailOperationError | Email.EmailValidationError
+>();
+
+expectTypeOf<Email.EmailOperationError["code"]>().toEqualTypeOf<
+  Email.EmailErrorCode | (string & {}) | undefined
+>();
+
+expectTypeOf(Email.validateMessage).returns.toEqualTypeOf<ReadonlyArray<Email.EmailViolation>>();
+
 const emailProgram = Effect.gen(function* () {
   const email = yield* TransactionalEmail;
 


### PR DESCRIPTION
## Summary

Improves the `Email` module for [Cloudflare Email Service](https://developers.cloudflare.com/email-service/get-started/send-emails/) sending. The `send_email` binding already accepted structured messages, so this makes that path Effect-native rather than a pass-through.

**Limit validation.** `send(...)` now checks structured messages against documented Email Sending limits before calling the binding: ≤50 combined `to`/`cc`/`bcc` recipients, ≤32 attachments, header name/value/total byte caps, ≤20 non-`X-` custom headers, required `from`/`subject`, at least one of `text`/`html`, and `contentId` on inline attachments. Violations fail with `EmailValidationError` listing every problem found, so a bad message costs no round trip. Opt out with `layer({ binding, send: { validate: false } })`.

**Typed error codes.** Cloudflare's `E_*` codes are surfaced on `EmailOperationError.code`, with the documented set exported as `emailErrorCodes` / `EmailErrorCode`. Limits are exported as `sendLimits`.

Raw RFC 5322 `EmailMessage` values are passed through untouched, so the legacy `cloudflare:email` path is unchanged.

Together these make both failure modes recoverable at the type level — see `examples/email/README.md`, where the two `catchTag` arms map a broken message to a 400 with its violations and a rate limit to a 429.

## Docs

- `examples/email/README.md` — domain onboarding, Wrangler config with `remote: true` for local dev, binding sender/recipient restrictions, and typed error recovery.
- Root `README.md` — an Email snippet alongside the other binding examples.
- `packages/effect-cf/README.md` — validation behavior, the opt-out, and a link to the example.

## Not covered

- **SMTP** — Workers cannot open the outbound SMTP connection it requires.
- **The 5 MiB message size limit** — the encoded MIME size is not knowable client side, and a wrong estimate would reject valid mail. Exposed as `sendLimits.maxMessageBytes` but not enforced; oversized messages fail at the binding with `E_CONTENT_TOO_LARGE`.
- **The REST API.** An earlier revision of this branch added an `Email.SendingTag` client for it; that was removed in 01e49c0. The binding already does the whole job, so a REST client would be a second path to the same capability carrying its own parallel vocabulary. `AnalyticsEngine` needs its SQL API client only because that binding is write-only — no such gap exists here. If a non-Worker use case shows up, it can land as its own PR.

## Breaking change to watch

`EmailClient.send` now fails with `EmailSendError` (`EmailOperationError | EmailValidationError`) instead of `EmailOperationError` alone. That widens the error channel, so exhaustive `catchTag` handling needs a new case. The changeset is `minor`.

## Validation

- `vp check` — 0 errors. The 2 reported warnings are pre-existing in `tests/ContainerNamespace.test.ts` and `tests/definitions.test.ts`, both untouched here.
- `vp test` — 32 files, 193 passed, 1 skipped. Includes 4 new `Email` tests covering limit validation, the aggregate violation list, the `validate: false` opt-out, and error-code extraction, plus type-level assertions in `binding-ergonomics.test-d.ts` for the send option, the error union, and `EmailOperationError.code`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)