### PR TITLE
fix: route Worker fetch responses through HttpEffect.toHandled

### DIFF
--- a/.changeset/worker-fetch-tohandled.md
+++ b/.changeset/worker-fetch-tohandled.md
@@ -1,0 +1,11 @@
+---
+"effect-cf": patch
+---
+
+Route `Worker.make` fetch handlers through `HttpEffect.toHandled`, matching the first-party Effect HTTP adapters.
+
+- Pre-response handlers (`HttpEffect.appendPreResponseHandler`, and things built on it such as `HttpApiBuilder.securitySetCookie`) now run before `HttpServerResponse` results are rendered. Previously they were silently dropped, which broke cookie-based auth flows on Workers.
+- Streaming response bodies keep request-scoped resources alive until the stream completes, instead of finalizing them as soon as the `Response` is returned.
+- `HttpServerResponse` bodies are suppressed for `HEAD` requests.
+- Handler failures are now rendered as HTTP error responses (with the cause reported) instead of rejecting the `fetch` promise. Note that exceptions no longer escape `fetch`, so `passThroughOnException` will not trigger origin fallback for Effect-level failures.
+- Native `Response` values returned from a fetch handler continue to bypass all response processing, including pre-response handlers — WebSocket upgrade responses and app-level `HttpEffect.toHandled` wrappers pass through untouched.

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -9,7 +9,7 @@ import {
   type Schema as S,
   type Scope,
 } from "effect";
-import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import { HttpEffect, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 
 import type * as Binding from "./Binding";
 import { WorkerConfig, WorkerEnvironment, type WorkerEnv } from "./Environment";
@@ -196,14 +196,41 @@ export const renderHttpResponse = <A extends HttpServerResponse.HttpServerRespon
 
 const renderFetchSuccess = <E, R>(
   effect: Effect.Effect<WorkerFetchSuccess, E, R>,
-): Effect.Effect<Response, E, R> =>
-  Effect.flatMap(effect, (response) =>
-    response instanceof Response
-      ? Effect.succeed(response)
-      : Effect.map(Effect.context<never>(), (context) =>
-          HttpServerResponse.toWeb(response, { context }),
-        ),
-  );
+): Effect.Effect<Response, E, Exclude<R, Scope.Scope> | HttpServerRequest.HttpServerRequest> =>
+  Effect.suspend(() => {
+    // Native `Response` values bypass all HTTP response processing (including
+    // pre-response handlers), so app-level `HttpEffect.toHandled` wrappers and
+    // WebSocket upgrade responses pass through untouched.
+    let nativeResponse: Response | undefined;
+    let webResponse: Response | undefined;
+
+    const handled = HttpEffect.toHandled(
+      Effect.flatMap(effect, (response) => {
+        if (response instanceof Response) {
+          nativeResponse = response;
+
+          return Effect.succeed(HttpServerResponse.empty());
+        }
+
+        return Effect.succeed(response);
+      }),
+      (request, response) =>
+        nativeResponse !== undefined
+          ? Effect.void
+          : Effect.map(Effect.context<never>(), (context) => {
+              webResponse = HttpServerResponse.toWeb(HttpEffect.scopeTransferToStream(response), {
+                withoutBody: request.method === "HEAD",
+                context,
+              });
+            }),
+    );
+
+    // `toHandled` re-fails with the original cause after rendering the error
+    // response, so both branches return the response captured above.
+    const captured = () => nativeResponse ?? webResponse ?? new Response(null, { status: 500 });
+
+    return Effect.matchCause(handled, { onFailure: captured, onSuccess: captured });
+  });
 
 const isWorkerOptions = <ROut, REvent, EventLayerError, Rpc extends WorkerRpc<ROut | REvent>>(
   options: WorkerOptions<ROut, REvent, EventLayerError, Rpc> | WorkerHandler<ROut>,

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -233,6 +233,24 @@ test("Worker.fetch renders handler failures as HTTP error responses", async () =
   expect(response.status).toBe(500);
 });
 
+test("Worker.fetch applies pre-response handlers to rendered error responses", async () => {
+  const Live = Worker.make(Layer.empty, {
+    fetch: Effect.gen(function* () {
+      yield* HttpEffect.appendPreResponseHandler((_request, response) =>
+        Effect.succeed(HttpServerResponse.setHeader(response, "cache-control", "no-store")),
+      );
+
+      return yield* Effect.fail(new Error("boom"));
+    }),
+  });
+  const worker = new Live(makeExecutionContext(), {} as Cloudflare.Env);
+
+  const response = await worker.fetch(new Request("https://worker.test/auth"));
+
+  expect(response.status).toBe(500);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+});
+
 test("Worker.renderHttpResponse converts HttpServerResponse values explicitly", async () => {
   const Live = Worker.make(Layer.empty, {
     fetch: Worker.renderHttpResponse(

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -1,4 +1,4 @@
-import { Clock, Config, ConfigProvider, Context, Effect, Layer, Stream } from "effect";
+import { Clock, Config, ConfigProvider, Context, Data, Effect, Layer, Stream } from "effect";
 import { HttpEffect, HttpServerResponse } from "effect/unstable/http";
 import { expect, test } from "vite-plus/test";
 
@@ -11,6 +11,8 @@ class RenderValue extends Context.Service<RenderValue, string>()(
 class EventValue extends Context.Service<EventValue, string>()(
   "effect-cf/test/WorkerBoundary/EventValue",
 ) {}
+
+class BoomError extends Data.TaggedError("BoomError") {}
 
 const makeExecutionContext = () =>
   ({
@@ -224,7 +226,7 @@ test("Worker.fetch keeps request-scoped resources alive while streaming bodies",
 
 test("Worker.fetch renders handler failures as HTTP error responses", async () => {
   const Live = Worker.make(Layer.empty, {
-    fetch: Effect.fail(new Error("boom")),
+    fetch: Effect.fail(new BoomError()),
   });
   const worker = new Live(makeExecutionContext(), {} as Cloudflare.Env);
 
@@ -240,7 +242,7 @@ test("Worker.fetch applies pre-response handlers to rendered error responses", a
         Effect.succeed(HttpServerResponse.setHeader(response, "cache-control", "no-store")),
       );
 
-      return yield* Effect.fail(new Error("boom"));
+      return yield* new BoomError();
     }),
   });
   const worker = new Live(makeExecutionContext(), {} as Cloudflare.Env);

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -1,5 +1,5 @@
 import { Clock, Config, ConfigProvider, Context, Effect, Layer, Stream } from "effect";
-import { HttpServerResponse } from "effect/unstable/http";
+import { HttpEffect, HttpServerResponse } from "effect/unstable/http";
 import { expect, test } from "vite-plus/test";
 
 import { DurableObject, Worker, WorkerConfig } from "../src/index";
@@ -128,6 +128,109 @@ test("Worker.fetch renders Effect HttpServerResponse values", async () => {
   );
 
   await expect(contextStreamResponse.text()).resolves.toBe("from-context");
+});
+
+test("Worker.fetch runs pre-response handlers on HttpServerResponse results", async () => {
+  const Live = Worker.make(Layer.empty, {
+    fetch: Effect.gen(function* () {
+      yield* HttpEffect.appendPreResponseHandler((_request, response) =>
+        Effect.succeed(
+          response.pipe(
+            HttpServerResponse.setHeader("cache-control", "no-store"),
+            HttpServerResponse.setCookieUnsafe("challenge", "abc"),
+          ),
+        ),
+      );
+
+      return HttpServerResponse.text("signed-in", { status: 202 });
+    }),
+  });
+  const worker = new Live(makeExecutionContext(), {} as Cloudflare.Env);
+
+  const response = await worker.fetch(new Request("https://worker.test/auth"));
+
+  expect(response.status).toBe(202);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect((response.headers as Headers & { getSetCookie(): Array<string> }).getSetCookie()).toEqual([
+    "challenge=abc",
+  ]);
+  await expect(response.text()).resolves.toBe("signed-in");
+});
+
+test("Worker.fetch bypasses pre-response handlers for native Response results", async () => {
+  const Live = Worker.make(Layer.empty, {
+    fetch: Effect.gen(function* () {
+      yield* HttpEffect.appendPreResponseHandler((_request, response) =>
+        Effect.succeed(HttpServerResponse.setCookieUnsafe(response, "challenge", "abc")),
+      );
+
+      return new Response("already-handled", {
+        headers: { "set-cookie": "challenge=from-app" },
+      });
+    }),
+  });
+  const worker = new Live(makeExecutionContext(), {} as Cloudflare.Env);
+
+  const response = await worker.fetch(new Request("https://worker.test/"));
+
+  expect((response.headers as Headers & { getSetCookie(): Array<string> }).getSetCookie()).toEqual([
+    "challenge=from-app",
+  ]);
+  await expect(response.text()).resolves.toBe("already-handled");
+});
+
+test("Worker.fetch suppresses HttpServerResponse bodies for HEAD requests", async () => {
+  const Live = Worker.make(Layer.empty, {
+    fetch: Effect.succeed(HttpServerResponse.text("body", { headers: { "x-test": "yes" } })),
+  });
+  const worker = new Live(makeExecutionContext(), {} as Cloudflare.Env);
+
+  const response = await worker.fetch(new Request("https://worker.test/", { method: "HEAD" }));
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("x-test")).toBe("yes");
+  expect(response.body).toBeNull();
+});
+
+test("Worker.fetch keeps request-scoped resources alive while streaming bodies", async () => {
+  const events: Array<string> = [];
+
+  const Live = Worker.make(Layer.empty, {
+    fetch: Effect.gen(function* () {
+      yield* Effect.acquireRelease(
+        Effect.sync(() => events.push("acquire")),
+        () => Effect.sync(() => events.push("release")),
+      );
+
+      return HttpServerResponse.stream(
+        Stream.make("chunk-1", "chunk-2").pipe(
+          Stream.tap((chunk) =>
+            Effect.sync(() =>
+              events.push(events.includes("release") ? `${chunk}-after-release` : chunk),
+            ),
+          ),
+          Stream.encodeText,
+        ),
+      );
+    }),
+  });
+  const worker = new Live(makeExecutionContext(), {} as Cloudflare.Env);
+
+  const response = await worker.fetch(new Request("https://worker.test/stream"));
+
+  await expect(response.text()).resolves.toBe("chunk-1chunk-2");
+  await expect.poll(() => events).toEqual(["acquire", "chunk-1", "chunk-2", "release"]);
+});
+
+test("Worker.fetch renders handler failures as HTTP error responses", async () => {
+  const Live = Worker.make(Layer.empty, {
+    fetch: Effect.fail(new Error("boom")),
+  });
+  const worker = new Live(makeExecutionContext(), {} as Cloudflare.Env);
+
+  const response = await worker.fetch(new Request("https://worker.test/"));
+
+  expect(response.status).toBe(500);
 });
 
 test("Worker.renderHttpResponse converts HttpServerResponse values explicitly", async () => {


### PR DESCRIPTION
## Summary

`Worker.make` rendered `HttpServerResponse` results with `HttpServerResponse.toWeb` directly, while every first-party Effect adapter routes through `HttpEffect.toHandled`. This silently skipped:

- **Pre-response handlers** — anything registered via `HttpEffect.appendPreResponseHandler`, most notably `HttpApiBuilder.securitySetCookie`, never ran. Cookie-based auth flows built on `HttpApi` were unconditionally broken on Workers (reported by a consuming app whose email-OTP sign-in never emitted its challenge cookie). The failure is masked in test suites that use `HttpRouter.toWebHandler`, which does run handlers.
- **Streaming scope transfer** — request-scoped resources backing a streaming body were finalized as soon as the `Response` was returned, before the body was consumed.
- **HEAD body suppression** — `toWeb` was never passed `withoutBody`.
- **Error rendering** — handler failures rejected the `fetch` promise instead of rendering an HTTP error response.

The fetch handler now runs inside `HttpEffect.toHandled`, which fixes all four. Two compatibility guarantees are kept deliberately and covered by tests:

- Native `Response` values returned from a handler bypass **all** response processing — pre-response handlers are not applied to them even when registered, so WebSocket upgrade (101) responses and app-level `toHandled` workarounds pass through untouched with no duplicate `Set-Cookie`.
- On the failure path, the rendered error response is captured from the `handleResponse` callback rather than lost to `toHandled`'s re-failed cause.

Behavior change worth noting: since failures now render as responses, exceptions no longer escape `fetch`, so `passThroughOnException` will not trigger origin fallback for Effect-level failures. This matches the first-party adapters and is called out in the changeset.

## Validation

- `vp test` — 190 passed, 1 skipped across 32 files (includes 5 new `WorkerBoundary` tests, written red→green). The 1 reported typecheck error in `tests/Cache.test.ts` is pre-existing; verified identical on clean `main` via stash.
- `vp check` — 0 errors; the 2 warnings (`tests/definitions.test.ts`, `tests/ContainerNamespace.test.ts`) are pre-existing.
- `vp fmt` / `vp lint --fix` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)