### PR TITLE
ci: use GitHub App for changesets PRs

### DIFF
--- a/.changeset/quiet-bots-work.md
+++ b/.changeset/quiet-bots-work.md
@@ -1,0 +1,4 @@
+---
+---
+
+Use the Changesets GitHub App for automated release pull requests.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Let changesets/action configure git credentials with github.token.
+          # Let changesets/action configure git credentials with the app token.
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # setup-bun action v2.2.0
       - uses: voidzero-dev/setup-vp@143f5f385f39b1b753ffed1a01ad443811855c8b # v1.16.1
@@ -39,12 +39,20 @@ jobs:
       - run: vp run effect-cf#build
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
           version: vp run changeset:version
           publish: vp run changeset:publish
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Mint a repository-scoped `danieljvdm-changesets` installation token during releases.
- Use the app token for Changesets git operations and release PR creation so pull request workflows run automatically.
- Add an empty changeset for this internal automation update.

## Validation

- `vp fmt --check .github/workflows/release.yml .changeset/quiet-bots-work.md`
- Workflow YAML parsed successfully.
- Confirmed the app can mint a token with `contents: write` and `pull_requests: write` for `danieljvdm/effect-cf`; revoked the test token afterward.
- `vp run check`: package build passed, then the command stopped on 315 formatting issues under the untracked `.worktrees/dan-effect-review` directory.
- `vp check`: blocked by the same untracked nested worktree.
- `vp test`: stopped because Vite+ recursively discovered the nested worktree and its full Effect source checkout. GitHub CI runs from a clean checkout without that local directory.