### PR TITLE
fix: encode RPC values through canonical JSON codecs at the wire boundary

### DIFF
--- a/.changeset/rpc-json-wire-codec.md
+++ b/.changeset/rpc-json-wire-codec.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Encode RPC method schemas through their canonical JSON codec at the Workers RPC boundary. Declaration schemas such as `Schema.Result` keep their container instance in their encoded form, so Durable Object, Worker entrypoint, and service binding RPC methods declared with them crashed in production with `DataCloneError` even though local same-isolate calls worked. Wire values are now plain JSON in both directions: clients encode arguments and decode results back into real instances, servers decode arguments and encode results, and codec failures still surface as tagged errors naming the definition and method. The `Method.EncodedArgs` and `Method.EncodedSuccess` utility types now report the JSON wire form.

--- a/packages/effect-cf/src/DurableObjectDefinition.ts
+++ b/packages/effect-cf/src/DurableObjectDefinition.ts
@@ -38,15 +38,10 @@ export namespace Method {
       ? [S.Schema.Type<Head>, ...ArgsFromSchemas<Tail>]
       : Array<S.Schema.Type<Args[number]>>;
 
-  type EncodedArgsFromSchemas<Args extends ReadonlyArray<ServiceFreeSchema>> =
-    Args extends readonly []
-      ? []
-      : Args extends readonly [
-            infer Head extends ServiceFreeSchema,
-            ...infer Tail extends ReadonlyArray<ServiceFreeSchema>,
-          ]
-        ? [S.Codec.Encoded<Head>, ...EncodedArgsFromSchemas<Tail>]
-        : Array<S.Codec.Encoded<Args[number]>>;
+  /** Method schemas cross the wire through their canonical JSON codec. */
+  type EncodedArgsFromSchemas<Args extends ReadonlyArray<ServiceFreeSchema>> = {
+    [Index in keyof Args]: S.Json;
+  };
 
   export type Args<Self extends Any> = ArgsFromSchemas<Self["args"]>;
 
@@ -54,7 +49,7 @@ export namespace Method {
 
   export type Success<Self extends Any> = S.Schema.Type<Self["success"]>;
 
-  export type EncodedSuccess<Self extends Any> = S.Codec.Encoded<Self["success"]>;
+  export type EncodedSuccess<Self extends Any> = S.Json;
 }
 
 export type Methods = Record<string, Method.Any>;

--- a/packages/effect-cf/src/RpcDefinition.ts
+++ b/packages/effect-cf/src/RpcDefinition.ts
@@ -154,6 +154,14 @@ export type ReservedMethodName =
 
 export type ServiceFreeSchema = S.Codec<any, any, never, never>;
 
+/**
+ * Workers RPC structured-clones every value that crosses an isolate boundary
+ * and rejects class instances. Declaration schemas such as `Schema.Result`
+ * keep their container instance in their `Encoded` form, so the declared
+ * schemas are lowered to their canonical JSON codec before touching the wire.
+ */
+const wireCodec = <Schema extends S.Constraint>(schema: Schema) => S.toCodecJson(schema);
+
 export interface Method<
   Args extends ReadonlyArray<ServiceFreeSchema> = ReadonlyArray<ServiceFreeSchema>,
   Success extends ServiceFreeSchema = ServiceFreeSchema,
@@ -174,15 +182,10 @@ export namespace Method {
       ? [S.Schema.Type<Head>, ...ArgsFromSchemas<Tail>]
       : Array<S.Schema.Type<Args[number]>>;
 
-  type EncodedArgsFromSchemas<Args extends ReadonlyArray<ServiceFreeSchema>> =
-    Args extends readonly []
-      ? []
-      : Args extends readonly [
-            infer Head extends ServiceFreeSchema,
-            ...infer Tail extends ReadonlyArray<ServiceFreeSchema>,
-          ]
-        ? [S.Codec.Encoded<Head>, ...EncodedArgsFromSchemas<Tail>]
-        : Array<S.Codec.Encoded<Args[number]>>;
+  /** Method schemas cross the wire through their canonical JSON codec. */
+  type EncodedArgsFromSchemas<Args extends ReadonlyArray<ServiceFreeSchema>> = {
+    [Index in keyof Args]: S.Json;
+  };
 
   export type Args<Self extends Any> = ArgsFromSchemas<Self["args"]>;
 
@@ -190,7 +193,7 @@ export namespace Method {
 
   export type Success<Self extends Any> = S.Schema.Type<Self["success"]>;
 
-  export type EncodedSuccess<Self extends Any> = S.Codec.Encoded<Self["success"]>;
+  export type EncodedSuccess<Self extends Any> = S.Json;
 }
 
 export type Methods = Record<string, Method.Any>;
@@ -274,7 +277,10 @@ export const decodeArgs = Effect.fnUntraced(function* <
   }
 
   const decoded = yield* (
-    S.decodeUnknownEffect(S.Tuple(methodDefinition.args))(args) as Effect.Effect<unknown, unknown>
+    S.decodeUnknownEffect(wireCodec(S.Tuple(methodDefinition.args)))(args) as Effect.Effect<
+      unknown,
+      unknown
+    >
   ).pipe(
     Effect.mapError(
       (cause) =>
@@ -312,7 +318,10 @@ export const encodeArgs = Effect.fnUntraced(function* <
   }
 
   const encoded = yield* (
-    S.encodeUnknownEffect(S.Tuple(methodDefinition.args))(args) as Effect.Effect<unknown, unknown>
+    S.encodeUnknownEffect(wireCodec(S.Tuple(methodDefinition.args)))(args) as Effect.Effect<
+      unknown,
+      unknown
+    >
   ).pipe(
     Effect.mapError(
       (cause) =>
@@ -338,7 +347,7 @@ export const encodeSuccess = <
   const methodDefinition = definition.methods[methodName];
 
   return (
-    S.encodeEffect(methodDefinition.success)(value) as Effect.Effect<
+    S.encodeUnknownEffect(wireCodec(methodDefinition.success))(value) as Effect.Effect<
       Method.EncodedSuccess<Self["methods"][MethodName]>,
       unknown
     >
@@ -365,7 +374,7 @@ export const decodeSuccess = <
   const methodDefinition = definition.methods[methodName];
 
   return (
-    S.decodeUnknownEffect(methodDefinition.success)(value) as Effect.Effect<
+    S.decodeUnknownEffect(wireCodec(methodDefinition.success))(value) as Effect.Effect<
       Method.Success<Self["methods"][MethodName]>,
       unknown
     >

--- a/packages/effect-cf/src/WorkerDefinition.ts
+++ b/packages/effect-cf/src/WorkerDefinition.ts
@@ -37,15 +37,10 @@ export namespace Method {
       ? [S.Schema.Type<Head>, ...ArgsFromSchemas<Tail>]
       : Array<S.Schema.Type<Args[number]>>;
 
-  type EncodedArgsFromSchemas<Args extends ReadonlyArray<ServiceFreeSchema>> =
-    Args extends readonly []
-      ? []
-      : Args extends readonly [
-            infer Head extends ServiceFreeSchema,
-            ...infer Tail extends ReadonlyArray<ServiceFreeSchema>,
-          ]
-        ? [S.Codec.Encoded<Head>, ...EncodedArgsFromSchemas<Tail>]
-        : Array<S.Codec.Encoded<Args[number]>>;
+  /** Method schemas cross the wire through their canonical JSON codec. */
+  type EncodedArgsFromSchemas<Args extends ReadonlyArray<ServiceFreeSchema>> = {
+    [Index in keyof Args]: S.Json;
+  };
 
   export type Args<Self extends Any> = ArgsFromSchemas<Self["args"]>;
 
@@ -53,7 +48,7 @@ export namespace Method {
 
   export type Success<Self extends Any> = S.Schema.Type<Self["success"]>;
 
-  export type EncodedSuccess<Self extends Any> = S.Codec.Encoded<Self["success"]>;
+  export type EncodedSuccess<Self extends Any> = S.Json;
 }
 
 export type Methods = Record<string, Method.Any>;

--- a/packages/effect-cf/tests/definitions.test.ts
+++ b/packages/effect-cf/tests/definitions.test.ts
@@ -1,6 +1,16 @@
 import { assert, expect, it, layer, test } from "@effect/vitest";
 import type { WorkflowStep } from "cloudflare:workers";
-import { Cause, Context, Effect, Exit, Layer, Option, Schema as S, type Scope } from "effect";
+import {
+  Cause,
+  Context,
+  Effect,
+  Exit,
+  Layer,
+  Option,
+  Result,
+  Schema as S,
+  type Scope,
+} from "effect";
 
 import {
   type DurableObjectNamespace,
@@ -705,6 +715,129 @@ test("definition-backed Worker RPC validates encoded success values", async () =
 
         assert.strictEqual(received, "hello");
         assert.strictEqual(value, "HELLO");
+      }),
+    );
+  });
+}
+
+{
+  class TaskPayload extends S.Class<TaskPayload>("TaskPayload")({
+    id: S.String,
+    attempts: S.Number,
+  }) {}
+
+  class TaskFailure extends S.TaggedError<TaskFailure>()("TaskFailure", {
+    reason: S.String,
+    cause: S.Defect(),
+  }) {}
+
+  const TaskRoom = DurableObjectDefinition.make("TaskRoom", {
+    complete: DurableObjectDefinition.method({
+      args: [TaskPayload] as const,
+      success: S.Result(TaskPayload, TaskFailure),
+    }),
+  });
+
+  // Workers RPC structured-clones every value crossing an isolate boundary and
+  // rejects anything that is not a plain object/array/primitive, so wire
+  // values must not carry prototypes (`Result`, Schema classes, live causes).
+  const expectStructuredCloneSafe = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(expectStructuredCloneSafe);
+
+      return;
+    }
+
+    if (typeof value === "object" && value !== null) {
+      expect(Object.getPrototypeOf(value)).toBe(Object.prototype);
+      Object.values(value).forEach(expectStructuredCloneSafe);
+    }
+  };
+
+  const makeState = () =>
+    ({
+      id: { toString: () => "task-room" },
+      storage: {},
+      waitUntil: () => undefined,
+    }) as unknown as globalThis.DurableObjectState;
+
+  test("Durable Object RPC methods return schema-encoded plain values over the wire", async () => {
+    const Live = TaskRoom.make(Layer.empty, {
+      rpc: {
+        complete: (payload) =>
+          Effect.result(
+            payload.attempts > 2
+              ? Effect.fail(
+                  new TaskFailure({ reason: "too many attempts", cause: new Error("boom") }),
+                )
+              : Effect.succeed(new TaskPayload({ id: payload.id, attempts: payload.attempts + 1 })),
+          ),
+      },
+    });
+    const instance = new Live(makeState(), {} as Cloudflare.Env);
+
+    const succeeded: unknown = await (
+      instance as unknown as { complete(payload: unknown): Promise<unknown> }
+    ).complete({ id: "task-1", attempts: 0 });
+
+    assert.strictEqual(Result.isResult(succeeded), false);
+    expectStructuredCloneSafe(succeeded);
+    assert.deepStrictEqual(succeeded, {
+      _tag: "Success",
+      success: { id: "task-1", attempts: 1 },
+    });
+
+    const failed: unknown = await (
+      instance as unknown as { complete(payload: unknown): Promise<unknown> }
+    ).complete({ id: "task-1", attempts: 3 });
+
+    expectStructuredCloneSafe(failed);
+    expect(failed).toMatchObject({
+      _tag: "Failure",
+      failure: { _tag: "TaskFailure", reason: "too many attempts" },
+    });
+  });
+
+  const receivedArgs: Array<unknown> = [];
+  const stub = {
+    id: {} as DurableObjectId,
+    fetch: async () => new Response("ok"),
+    complete: async (...args: Array<unknown>) => {
+      receivedArgs.push(...args);
+
+      return { _tag: "Success", success: { id: "task-1", attempts: 1 } };
+    },
+  };
+  const namespace = {
+    newUniqueId: () => ({}) as DurableObjectId,
+    idFromName: () => ({}) as DurableObjectId,
+    idFromString: () => ({}) as DurableObjectId,
+    jurisdiction: () => namespace,
+    get: () => stub,
+    getByName: () => stub,
+  };
+  const env = {
+    TASK_ROOMS: namespace,
+  } as unknown as Cloudflare.Env;
+
+  layer(
+    TaskRoom.layer({ binding: "TASK_ROOMS" }).pipe(
+      Layer.provide(Layer.succeed(WorkerEnvironment, env)),
+    ),
+  )("definition-backed Durable Object RPC with declaration schemas", (it) => {
+    it.effect("sends encoded args and decodes wire results into instances", () =>
+      Effect.gen(function* () {
+        receivedArgs.length = 0;
+
+        const result = yield* TaskRoom.byName("main").complete(
+          new TaskPayload({ id: "task-1", attempts: 0 }),
+        );
+
+        assert.deepStrictEqual(receivedArgs, [{ id: "task-1", attempts: 0 }]);
+        expectStructuredCloneSafe(receivedArgs[0]);
+        assert.ok(Result.isSuccess(result));
+        assert.instanceOf(result.success, TaskPayload);
+        assert.deepStrictEqual(result.success, new TaskPayload({ id: "task-1", attempts: 1 }));
       }),
     );
   });


### PR DESCRIPTION
## Summary

Definition-backed RPC method schemas were only applied as plain `Type ↔ Encoded` codecs at the transport boundary. For declaration schemas the encoded form is still a class instance — `Schema.Result(success, failure)` encodes its contents but keeps the live `Result` container — so the value handed to Workers RPC was not structured-clone-safe.

**Production incident (reve-ai/kommunikasie, effect-cf 0.20.1, workerd):** TaskRpc Durable Object methods declared with `Schema.Result` and implemented with `Effect.result(...)` failed on every call with `DataCloneError code 25: Could not serialize object of type "Object"`, even though the DO completed its work. The failure is invisible in local dev because same-isolate DO calls skip serialization. kommunikasie PR #44 worked around it app-side by replacing `Schema.Result` with plain value unions — that workaround stays compatible with this fix (plain JSON schemas encode/decode unchanged), but the footgun is gone.

The fix lowers every declared method schema to its canonical JSON codec (`Schema.toCodecJson`) inside the shared `RpcDefinition` helpers (`decodeArgs` / `encodeArgs` / `encodeSuccess` / `decodeSuccess`), so:

- Servers (Durable Object and Worker entrypoint wrappers) decode incoming args with the declared `args` schemas and encode handler results with the declared `success` schema — what crosses the wire is plain JSON.
- Clients (Durable Object namespace and service binding providers, including `call` / `scopedCall` / direct `byName` clients) encode outgoing args and decode results, so callers get real `Result` values, Schema class instances, etc. back.
- All surfaces that share these helpers (Durable Object RPC, worker-to-worker service bindings, Worker entrypoint RPC) are covered by the one change.
- Codec failures still surface as tagged errors naming the definition, method, and direction (`RpcArgumentDecodeError`, `RpcSuccessEncodeError`, …), not defects. `Schema.Defect` fields already encode to JSON, so error `cause` payloads are clone-safe.
- `Method.EncodedArgs` / `Method.EncodedSuccess` now report the JSON wire form.

The regression test reproduces the incident shape red/green: a Durable Object method declared with `Schema.Result(Schema.Class, Schema.TaggedError)` (the error carrying a live `cause`). Before the fix, the server-side wire value was a live `Result` instance (the exact value workerd refuses to clone) and the client failed to decode the plain wire form with "Expected Result". The test asserts every wire value is prototype-free plain JSON in both directions and that the caller receives a decoded `Result` containing a real class instance.

## Validation

- `vp test` — 33 files, 218 passed / 1 skipped (node + workers pool projects), typecheck clean
- `vp check` — 0 errors (5 pre-existing warnings)
- `vp run typecheck` — clean
- New tests were confirmed failing before the fix (live `Result` crossing the wire; client decode error) and passing after

🤖 Generated with [Claude Code](https://claude.com/claude-code)