### PR TITLE
ci: require changesets only for published-package changes

### DIFF
--- a/.agents/skills/effect-cf-repo-pr-hygiene/SKILL.md
+++ b/.agents/skills/effect-cf-repo-pr-hygiene/SKILL.md
@@ -5,7 +5,7 @@ description: Use before creating or updating PRs, choosing PR titles, writing PR
 
 # PR Hygiene
 
-Make pull requests pass repository policy on the first try: use a Conventional Commit title, add a changeset, write consumer-quality release notes, and report validation accurately.
+Make pull requests pass repository policy on the first try: use a Conventional Commit title, add a changeset when the published package changes, write consumer-quality release notes, and report validation accurately.
 
 ## PR title
 
@@ -13,9 +13,7 @@ Use `<type>(optional-scope): <summary>`. Allowed types are `feat`, `fix`, `docs`
 
 ## Changesets
 
-Every PR must include a non-README file under `.changeset/`.
-
-Use a package changeset for published-package changes:
+Add a changeset only when the PR changes the published package (`packages/effect-cf/src` or its `package.json`):
 
 ```md
 ---
@@ -25,16 +23,13 @@ Use a package changeset for published-package changes:
 Add Effect-native Durable Object WebSocket helpers for typed hibernation attachments.
 ```
 
-Use an empty changeset for internal-only work:
-
-```md
----
----
-
-Update repository tooling without releasing package changes.
-```
+Internal-only PRs (CI, docs, examples, repository tooling, test-only changes) must not add a changeset. Never add an empty changeset: the release workflow publishes only when zero changeset files remain on main, so a leftover changeset silently converts a release into another Version Packages PR and the skipped version number is lost permanently.
 
 Choose `patch` for compatible fixes, `minor` for public additions, and `major` for breaking changes. Write release notes for consumers rather than describing implementation details.
+
+## Merging Version Packages PRs
+
+Merge a `Version Packages` PR alone, last, and freshly refreshed: after any other PR merges, wait for that merge's Release workflow run to finish updating the Version Packages PR before merging it. Merging a stale Version Packages PR leaves unconsumed changesets on main, which skips the publish and permanently orphans the version it names.
 
 ## PR body
 
@@ -43,7 +38,7 @@ Use `## Summary` and `## Validation` sections. List the validation commands actu
 ## Before creating or updating a PR
 
 1. Inspect `git status --short` and the full diff.
-2. Add or update the changeset.
+2. Add or update the changeset when the published package changed.
 3. Run `vp check` and relevant tests, normally `vp test`.
 4. Use a Conventional Commit PR title.
 5. Ensure the PR body matches the actual change and validation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,15 +46,19 @@ jobs:
           git fetch origin "$BASE_REF" --depth=1
           changed_files="$(git diff --name-only "origin/$BASE_REF"...HEAD)"
 
+          needs_changeset=false
           has_changeset=false
           while IFS= read -r file; do
+            if [[ "$file" == packages/effect-cf/src/* || "$file" == packages/effect-cf/package.json ]]; then
+              needs_changeset=true
+            fi
             if [[ "$file" == .changeset/*.md && "$file" != ".changeset/README.md" ]]; then
               has_changeset=true
-              break
             fi
           done <<<"$changed_files"
 
-          if [[ "$has_changeset" != true ]]; then
-            echo "Every PR must include a changeset file under .changeset/. Use an empty changeset for non-release changes."
+          if [[ "$needs_changeset" == true && "$has_changeset" != true ]]; then
+            echo "PRs that change packages/effect-cf/src or its package.json must include a changeset under .changeset/."
+            echo "Internal-only PRs need no changeset. Never add an empty changeset: a pending changeset on main silently blocks the next release publish."
             exit 1
           fi

--- a/dev-kit.lock.json
+++ b/dev-kit.lock.json
@@ -74,12 +74,12 @@
       "target": "agents",
       "mode": "copy",
       "kind": "directory",
-      "digest": "sha256:b56eae01cbd217c62597f883f22213b810374605301c143d9d7b7864af4e0cb4",
+      "digest": "sha256:29213ca0b1179936b79a7293465fb36438c4d725e9d8c2630b431174af567899",
       "catalog": {
         "package": "@effect-cf/repo",
         "version": "0.0.0",
         "skill": "pr-hygiene",
-        "digest": "sha256:9b80526abdf0d3dbd96044578872c6b07cc1b9b9c70727c75eb8220886865166"
+        "digest": "sha256:b3d50061943c0affefb82ecb9472f6d10104e7b72650d137d5a24e4a54b8028c"
       }
     },
     {
@@ -162,7 +162,7 @@
         "package": "@effect-cf/repo",
         "version": "0.0.0",
         "skill": "pr-hygiene",
-        "digest": "sha256:9b80526abdf0d3dbd96044578872c6b07cc1b9b9c70727c75eb8220886865166"
+        "digest": "sha256:b3d50061943c0affefb82ecb9472f6d10104e7b72650d137d5a24e4a54b8028c"
       }
     },
     {

--- a/tools/effect-cf-repo/skills/pr-hygiene/SKILL.md
+++ b/tools/effect-cf-repo/skills/pr-hygiene/SKILL.md
@@ -5,7 +5,7 @@ description: Use before creating or updating PRs, choosing PR titles, writing PR
 
 # PR Hygiene
 
-Make pull requests pass repository policy on the first try: use a Conventional Commit title, add a changeset, write consumer-quality release notes, and report validation accurately.
+Make pull requests pass repository policy on the first try: use a Conventional Commit title, add a changeset when the published package changes, write consumer-quality release notes, and report validation accurately.
 
 ## PR title
 
@@ -13,9 +13,7 @@ Use `<type>(optional-scope): <summary>`. Allowed types are `feat`, `fix`, `docs`
 
 ## Changesets
 
-Every PR must include a non-README file under `.changeset/`.
-
-Use a package changeset for published-package changes:
+Add a changeset only when the PR changes the published package (`packages/effect-cf/src` or its `package.json`):
 
 ```md
 ---
@@ -25,16 +23,13 @@ Use a package changeset for published-package changes:
 Add Effect-native Durable Object WebSocket helpers for typed hibernation attachments.
 ```
 
-Use an empty changeset for internal-only work:
-
-```md
----
----
-
-Update repository tooling without releasing package changes.
-```
+Internal-only PRs (CI, docs, examples, repository tooling, test-only changes) must not add a changeset. Never add an empty changeset: the release workflow publishes only when zero changeset files remain on main, so a leftover changeset silently converts a release into another Version Packages PR and the skipped version number is lost permanently.
 
 Choose `patch` for compatible fixes, `minor` for public additions, and `major` for breaking changes. Write release notes for consumers rather than describing implementation details.
+
+## Merging Version Packages PRs
+
+Merge a `Version Packages` PR alone, last, and freshly refreshed: after any other PR merges, wait for that merge's Release workflow run to finish updating the Version Packages PR before merging it. Merging a stale Version Packages PR leaves unconsumed changesets on main, which skips the publish and permanently orphans the version it names.
 
 ## PR body
 
@@ -43,7 +38,7 @@ Use `## Summary` and `## Validation` sections. List the validation commands actu
 ## Before creating or updating a PR
 
 1. Inspect `git status --short` and the full diff.
-2. Add or update the changeset.
+2. Add or update the changeset when the published package changed.
 3. Run `vp check` and relevant tests, normally `vp test`.
 4. Use a Conventional Commit PR title.
 5. Ensure the PR body matches the actual change and validation.


### PR DESCRIPTION
## Summary

The changesets action publishes only when zero changeset files remain on main. The repository policy of requiring a changeset on every PR — empty ones for internal work — meant empty changesets routinely sat on main, and any Version Packages PR merged while one was present silently opened another Version Packages PR instead of publishing. This skipped the 0.19.0 and 0.21.0 releases entirely (versioned on main, never published to npm, no tag, no GitHub release — 0.21.0 carried the breaking-rename notes).

- Scope the CI changeset check to PRs that touch `packages/effect-cf/src` or its `package.json`; internal-only PRs (CI, docs, examples, tooling, tests) no longer need a changeset, and the failure message now warns against empty changesets instead of recommending them.
- Update the `pr-hygiene` skill source (`tools/effect-cf-repo`) to match, and add a "Merging Version Packages PRs" section: merge them alone, last, and only after the previous merge's Release run has refreshed them (the 0.21.0 skip was triggered by merging the Version PR 11 seconds after another PR).
- `dev-kit apply` regenerated the managed skill copy and lock.

This PR intentionally has no changeset — it validates the new rule on itself.

## Validation

- `dev-kit plan` / `apply` — single expected copy update, second plan clean
- bash logic of the new check verified against this PR's own file list (no `packages/effect-cf` paths → no changeset required)
- No package code touched, so `vp test` / `vp check` were not run beyond the pre-commit hook's staged checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)