### PR TITLE
ci: only run changeset publish on Version Packages merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,11 @@ jobs:
         uses: changesets/action@v1
         with:
           version: vp run changeset:version
-          publish: vp run changeset:publish
+          # Attempt npm publish only when merging a Version Packages PR. On
+          # other pushes the publish path is a no-op that depends on an npm
+          # registry read, which can serve stale version lists and fail the
+          # run with "cannot publish over previously published versions".
+          publish: ${{ startsWith(github.event.head_commit.message, 'Version Packages') && 'vp run changeset:publish' || '' }}
           github-token: ${{ steps.app-token.outputs.token }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

The Release workflow attempted `changeset publish` on every push to main. On non-release pushes that path is supposed to be a graceful no-op, but it depends on an npm registry read (`npm info effect-cf`): after the 0.22.0 release, GitHub's runners were persistently served a stale version list (still missing 0.22.0 77 minutes after publish, reproduced on re-run of https://github.com/danieljvdm/effect-cf/actions/runs/31411695617), so changesets retried the publish and npm's authoritative write path failed the run with "cannot publish over previously published versions".

Gate the action's `publish` input on the head commit being a `Version Packages` merge (empty `publish` makes changesets/action skip the publish path entirely). Ordinary merges now only maintain the Version Packages PR, so a red Release run means a real publish failure again. Real releases are unaffected: on a Version Packages merge the version genuinely isn't on npm, so even a stale read makes the correct decision.

No changeset — CI-only change, per the policy from #74.

## Validation

- Reproduced the failure mode and confirmed the stale-read diagnosis via the run logs and a consistent `npm info` from a machine with the same npm version (11.13.0)
- Expression-only workflow change; changesets/action treats an empty `publish` input as "not configured" (its publish branch requires a non-empty script)
- Merging this PR itself exercises the new gate: the resulting Release run should be green with no publish attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)