### PR TITLE
chore: ignore local worktree directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ Session.vim
 # dev-kit managed paths
 .repos/
 .dev-kit/
+
+# Local Git worktrees
+.worktrees/


### PR DESCRIPTION
## Summary

- ignore the repository-local `.worktrees/` directory

## Validation

- `vp check` (passes with 5 existing lint warnings)
- `vp test` not run; change only affects Git ignore metadata