### PR TITLE
chore: update dev-kit to 0.14.0 and adopt open-pull-request skill

### DIFF
--- a/.agents/skills/build-effect-apis/SKILL.md
+++ b/.agents/skills/build-effect-apis/SKILL.md
@@ -64,6 +64,28 @@ from another version.
   runs on Cloudflare Workers or uses `effect-cf`, bindings, Durable Objects,
   Queues, WebSockets, streaming, or raw byte routes.
 
+## Choose typed Schema codecs by default
+
+Match the codec to the static type at the call site. When decoding a value that
+is already typed as the schema's `Encoded` type, use `Schema.decodeEffect` or
+the typed `Schema.decodeSync`, `Schema.decodeExit`, `Schema.decodeOption`,
+`Schema.decodeResult`, or `Schema.decodePromise` variant. When encoding a value
+that is already typed as the schema's `Type`, use `Schema.encodeEffect` or the
+corresponding typed `Schema.encodeSync`, `Schema.encodeExit`,
+`Schema.encodeOption`, `Schema.encodeResult`, or `Schema.encodePromise` variant.
+
+Reserve `Schema.decodeUnknown*` and `Schema.encodeUnknown*` for genuinely
+untyped boundaries: values from `JSON.parse`, `Response.json`, external
+messages, or persistence APIs whose declared result is actually `unknown`.
+Never choose an unknown codec to bypass a `Schema.Class` or other static type
+mismatch. Map the source value or construct the correct schema `Type` first,
+then use the typed encoder; similarly, establish the correct `Encoded` value
+before using a typed decoder.
+
+This rule is toolchain-neutral. A repository may reinforce it with a lint
+warning and a documented local suppression for a justified untyped boundary,
+but the boundary and type reasoning remain the source of truth.
+
 ## Boundary rules
 
 - Let schemas own wire validation, encoding, status metadata, and branded IDs.

--- a/.agents/skills/build-effect-apis/references/verification.md
+++ b/.agents/skills/build-effect-apis/references/verification.md
@@ -11,6 +11,20 @@ test integration and command authority.
 - Assert each expected error carries the intended HTTP status and body encoding.
 - Compare or smoke-test generated OpenAPI when the public contract changes.
 
+## Unknown codec audit
+
+Inventory every `Schema.decodeUnknown*` and `Schema.encodeUnknown*` call in the
+changed scope. Record a concrete untyped-boundary justification for each one,
+such as `JSON.parse`, `Response.json`, an external message, or a persistence API
+whose declared result is actually `unknown`. Replace any call whose input is
+already the schema's `Encoded` or `Type` with the corresponding typed `Effect`,
+`Sync`, `Exit`, `Option`, `Result`, or `Promise` codec.
+
+An unknown codec is not a valid workaround for a `Schema.Class` or other static
+type mismatch: map or construct the correct typed value instead. If the
+repository enforces this policy with a lint warning, keep any necessary local
+suppression documented with the same concrete boundary justification.
+
 ## Server tests
 
 - Build every changed group and fail the test if an endpoint handler is missing.
@@ -47,4 +61,5 @@ Account for every changed endpoint across these columns:
 | Params, query, headers, payload, success, errors | Scope, provided services, errors | Identifier, invariants, workflow | Typed call shape, identity, cache/invalidation | Round-trip and boundary behavior |
 
 Completion means every changed endpoint has an entry in every applicable
-column and the repository's formatter, linter, typechecker, and tests pass.
+column, every unknown codec call has a concrete boundary justification, and the
+repository's formatter, linter, typechecker, and tests pass.

--- a/.agents/skills/build-effect-clis/SKILL.md
+++ b/.agents/skills/build-effect-clis/SKILL.md
@@ -1,30 +1,61 @@
 ---
 name: build-effect-clis
-description: Build and maintain command-line applications entirely with Effect. Use when creating or changing CLI commands, arguments, flags, subcommands, prompts, help, JSON output, dry-run or confirmation flows, platform services, child processes, Node/Bun entrypoints, or CLI integration tests.
+description: Write and maintain every executable script and command-line application in an Effect repository as an Effect program. Use when creating or changing any script, one-off automation, CI check, deploy/release/build glue, package-script entrypoint, CLI command, arguments, flags, prompts, child process, filesystem or environment workflow, Node/Bun entrypoint, or integration test—including extending an existing plain-TypeScript script.
 ---
 
-# Build Effect CLIs
+# Build Effect Scripts and CLIs
 
-Treat a CLI as an Effect application: the `Command` tree owns the user-facing
-contract, handlers adapt decoded input into application workflows, services own
-capabilities, and the executable entrypoint supplies platform Layers and runs
-the program. Do not introduce a separate CLI framework for new command work.
+## Effect-first scope
+
+Every executable script and CLI in an Effect repository is an Effect program.
+This includes one-off scripts, CI checks, deploy/release/build glue, files under
+`scripts/`, package-script targets, migrations, and application entrypoints—not
+only polished command-line tools.
+
+Apply this rule when modifying code as well as when creating it. When a task
+touches an existing plain-TypeScript script, convert the whole script to Effect
+in the same change; matching the surrounding file's style or minimizing the
+diff is not a valid exception. Prefer the repository's established Effect
+patterns, including those in sibling scripts, over legacy patterns in the file
+being converted.
+
+Leave a script outside Effect only for a good, concrete technical or user
+constraint that makes Effect unsuitable. Explicitly state that reason before
+proceeding and in the final handoff, and keep the exception as narrow as
+possible. Convenience, one-off status, and existing plain-TypeScript style are
+not sufficient reasons.
+
+Use Effect platform services for filesystem, path, environment, terminal, and
+child-process work. Raw `node:*` or Bun runtime imports, `process.env`, `fs`,
+`path`, `child_process`, and synchronous helpers such as `execFileSync` do not
+belong in script workflows. If the installed Effect platform has no required
+capability, isolate the runtime call in an explicit boundary adapter whose API
+returns an Effect with typed errors, and document why that adapter is required.
+
+Treat each executable as an Effect application. For a CLI, the `Command` tree
+owns the user-facing contract, handlers adapt decoded input into application
+workflows, services own capabilities, and the executable entrypoint supplies
+platform Layers and runs the program. A fixed automation script with no public
+arguments may export an Effect workflow directly instead of inventing a
+`Command` tree. Do not introduce a separate CLI framework for command work.
 
 Effect CLI and process APIs are version-sensitive. Read the target repository's
 `node_modules/effect/AGENTS.md` completely, follow its CLI and child-process
 references, and confirm exact signatures from the installed declarations before
 editing.
 
-## Build the command boundary
+## Build the executable boundary
 
 1. Inventory the existing executable entrypoints, package scripts, command
    tree, shared flags, prompts, application services, platform Layers, output
    modes, and subprocess helpers. Finish when every way to invoke and test the
-   CLI is known.
-2. Read [command-design.md](references/command-design.md). Define arguments and
-   flags with `Argument` and `Flag`, compose commands with `Command`, and give
-   every public input useful help. Use `Effect.fn` handlers and yield the root
-   command when a subcommand needs shared parent input.
+   affected scripts or CLI is known, including sibling Effect scripts whose
+   patterns should replace legacy plain-TypeScript style.
+2. When the executable accepts public arguments or flags, read
+   [command-design.md](references/command-design.md). Define arguments and flags
+   with `Argument` and `Flag`, compose commands with `Command`, and give every
+   public input useful help. Use `Effect.fn` handlers and yield the root command
+   when a subcommand needs shared parent input.
 3. Keep handlers thin. Decode user and file input at the boundary, enforce
    cross-input invariants, then call an application service. Keep persistence,
    network calls, orchestration, retries, and transactions in services.
@@ -32,15 +63,15 @@ editing.
    platform failures into application-owned errors near the adapter that knows
    what the operation means. Let defects remain defects.
 5. Read [entrypoints-and-testing.md](references/entrypoints-and-testing.md).
-   Export the command tree without running it, wire one Node or Bun entrypoint,
-   and verify help, parsing, successful execution, expected failure, JSON
-   output, and every dry-run or confirmation path.
+   Export the command tree or fixed script workflow without running it, wire
+   one Node or Bun entrypoint, and verify the applicable success, expected
+   failure, help, parsing, JSON, dry-run, and confirmation paths.
 
 ## Optional branches
 
 - Read [processes-and-platform.md](references/processes-and-platform.md) when a
-  command reads files, inspects the environment, starts child processes,
-  streams their output, or differs between Node and Bun.
+  script or command reads files, inspects the environment, starts child
+  processes, streams their output, or differs between Node and Bun.
 - Use `Prompt` only for an intentionally interactive path. Keep required inputs
   expressible as arguments or flags so automation never depends on a terminal.
 - Add `--dry-run` for commands that mutate important state and `--yes` for

--- a/.agents/skills/build-effect-clis/agents/openai.yaml
+++ b/.agents/skills/build-effect-clis/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Build Effect CLIs"
-  short_description: "Build typed Effect command-line applications"
-  default_prompt: "Use $build-effect-clis to build a typed Effect CLI with clear commands, platform boundaries, and tests."
+  display_name: "Build Effect Scripts and CLIs"
+  short_description: "Write every script and CLI with Effect"
+  default_prompt: "Use $build-effect-clis to write or modify this script or CLI as an Effect program with explicit platform boundaries and tests."

--- a/.agents/skills/build-effect-clis/references/entrypoints-and-testing.md
+++ b/.agents/skills/build-effect-clis/references/entrypoints-and-testing.md
@@ -4,6 +4,11 @@ Separate command definition from execution. Importing a command module in a test
 or another program must not parse `process.argv`, start fibers, or terminate the
 process.
 
+For a fixed CI or automation script with no public command syntax, export its
+Effect workflow and provide platform Layers only in a thin executable module;
+it does not need an artificial `Command` tree. Use the same `runMain` boundary,
+typed failures, platform services, and import-safety rules shown below.
+
 ```ts
 // src/cli/command.ts
 export const command = root.pipe(Command.withSubcommands([deploy, status]));

--- a/.agents/skills/build-effect-clis/references/processes-and-platform.md
+++ b/.agents/skills/build-effect-clis/references/processes-and-platform.md
@@ -1,8 +1,9 @@
 # Processes and platform services
 
 Use Effect platform services inside CLI workflows. Keep direct `node:*`, Bun
-globals, `process`, filesystem calls, and shell execution at explicit adapters
-or the executable boundary.
+globals, `process`, filesystem calls, and shell execution inside explicit
+boundary adapters. The executable boundary itself should use Effect platform
+runtime and service APIs.
 
 ## Own subprocess behavior in a service
 

--- a/.agents/skills/open-pull-request/SKILL.md
+++ b/.agents/skills/open-pull-request/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: open-pull-request
+description: Open pull requests with conventional commits, terse context-complete English descriptions, and verified proof of work. Use whenever preparing or opening a pull request, including checking commit history, drafting the title or body, and attaching screenshots or other evidence.
+---
+
+# Open a Pull Request
+
+Produce a PR that a reviewer can understand and trust without access to the
+task conversation.
+
+## Prepare the branch
+
+1. Read the repository's contribution instructions and PR template. Identify
+   the intended base branch, then inspect the full commit range, diff, and
+   working tree. Finish when the PR scope contains no accidental changes and
+   the description will cover the branch as it exists, not merely the latest
+   task.
+2. Use Conventional Commits for every commit you create and for the PR title:
+   `type(scope): imperative summary`. Follow repository-specific types and
+   scopes, and omit the scope when it adds no useful context. Otherwise use a
+   precise standard type such as `feat`, `fix`, `refactor`, `docs`, `test`,
+   `build`, `ci`, or `chore`. Keep each commit to one logical concern. Rewrite
+   only commits you created and know are unshared; get approval before
+   rewriting user-authored or published history.
+3. Run the repository's required validation on the final branch state. Record
+   the exact commands and results, then collect the strongest available proof
+   of the changed behavior. Finish when every claim in the PR can be traced to
+   the diff, a check result, or an artifact.
+
+## Write for the reviewer
+
+Write terse, plain English for someone with little context. Lead with the
+observable outcome and add only the minimum reason needed to understand it.
+Prefer short bullets and concrete nouns. Expand uncommon acronyms. Describe
+behavior and impact rather than narrating files, implementation steps, or the
+task conversation.
+
+Use the repository's required template when present. Otherwise use this small
+shape and omit empty sections:
+
+```md
+## Summary
+
+- <What changes for a user, operator, or developer>
+- <Why it matters, only when the first bullet does not make that clear>
+
+## Proof
+
+- `<validation command>` — passed
+- <Screenshot, sample output, or other verified artifact>
+```
+
+Keep the summary to one to three bullets. Make the title specific enough to
+stand alone in release notes and conventional enough to become the squash
+commit without editing.
+
+## Show proof of work
+
+Proof is something the reviewer can inspect, not an assertion that the change
+works.
+
+- For a runnable UI or visual feature, capture and attach a screenshot or short
+  recording of the actual final state. Use a representative viewport, add a
+  short caption, and check the artifact for secrets or personal data.
+- For CLI, API, or automation behavior, include concise terminal output, a
+  request/response example, generated artifact, or execution log when it proves
+  more than the validation command alone.
+- For a bug fix or behavior change, prefer before/after evidence when it is
+  practical and materially clarifies the result.
+- For internal-only changes, exact passing validation commands may be the most
+  useful proof.
+
+Include only evidence that was actually produced and verified. When expected
+visual proof cannot be produced, state the concrete reason briefly instead of
+silently substituting a claim. Preserve terse descriptions by choosing the
+smallest set of evidence that proves the outcome.
+
+## Open and verify
+
+Open the PR against the intended base with the conventional title and prepared
+body. Then read back the rendered PR and verify the base/head branches, title,
+description, links, screenshots, and check results. Finish only when the PR is
+reviewable as rendered and return its URL.

--- a/.agents/skills/open-pull-request/agents/openai.yaml
+++ b/.agents/skills/open-pull-request/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Open Pull Request"
+  short_description: "Open clear, evidence-backed pull requests"
+  default_prompt: "Use $open-pull-request to prepare and open a clear pull request with conventional commits and proof of work."

--- a/.claude/skills/open-pull-request
+++ b/.claude/skills/open-pull-request
@@ -1,0 +1,1 @@
+../../.agents/skills/open-pull-request

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.31.0",
         "@cloudflare/vitest-pool-workers": "catalog:",
-        "@danieljvdm/dev-kit": "0.13.0",
+        "@danieljvdm/dev-kit": "0.14.0",
         "@effect-cf/repo": "workspace:*",
         "@effect/tsgo": "0.33.0",
         "@types/bun": "^1.3.14",
@@ -289,7 +289,7 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.18.0",
+      "version": "0.22.0",
       "devDependencies": {
         "@cloudflare/containers": "catalog:",
         "@cloudflare/vitest-pool-workers": "catalog:",
@@ -304,12 +304,14 @@
         "vitest": "catalog:",
       },
       "peerDependencies": {
-        "@effect/sql-d1": "^4.0.0-beta.105",
-        "@effect/sql-pg": "^4.0.0-beta.105",
-        "@effect/sql-sqlite-do": "^4.0.0-beta.105",
-        "effect": "^4.0.0-beta.105",
+        "@cloudflare/workers-types": "^4.20260611.1",
+        "@effect/sql-d1": "4.0.0-beta.105",
+        "@effect/sql-pg": "4.0.0-beta.105",
+        "@effect/sql-sqlite-do": "4.0.0-beta.105",
+        "effect": "4.0.0-beta.105",
       },
       "optionalPeers": [
+        "@cloudflare/workers-types",
         "@effect/sql-pg",
       ],
     },
@@ -407,7 +409,7 @@
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
-    "@danieljvdm/dev-kit": ["@danieljvdm/dev-kit@0.13.0", "", { "dependencies": { "@effect/platform-bun": "4.0.0-beta.105", "@stylistic/eslint-plugin": "5.10.0", "effect": "4.0.0-beta.105", "jsonc-parser": "3.3.1", "semver": "7.8.5" }, "peerDependencies": { "oxfmt": ">=0.60.0 <0.61.0", "oxlint": ">=1.75.0 <2.0.0", "vite-plus": ">=0.2.6 <0.3.0" }, "optionalPeers": ["oxfmt", "oxlint", "vite-plus"], "bin": { "dev-kit": "bin/dev-kit.mjs" } }, "sha512-ANmaKcNvtUtHj111OKNPE5/+HuTGEPzzsoR30crCIhOuLq6llni0ylF33067oCy4qkphkKMS6MXcf3hBRYv/7w=="],
+    "@danieljvdm/dev-kit": ["@danieljvdm/dev-kit@0.14.0", "", { "dependencies": { "@effect/platform-bun": "4.0.0-beta.105", "@stylistic/eslint-plugin": "5.10.0", "effect": "4.0.0-beta.105", "jsonc-parser": "3.3.1", "semver": "7.8.5" }, "peerDependencies": { "oxfmt": ">=0.60.0 <0.61.0", "oxlint": ">=1.75.0 <2.0.0", "vite-plus": ">=0.2.6 <0.3.0" }, "optionalPeers": ["oxfmt", "oxlint", "vite-plus"], "bin": { "dev-kit": "bin/dev-kit.mjs" } }, "sha512-uAONpbsS+MycSU2maDScEJjRgH1CmGlvTnJP+QRwSa68uDMc/kAiRmvBm4UJXoEs7l9i1XQVlIyya5HY4MncFA=="],
 
     "@effect-cf/example-contracts": ["@effect-cf/example-contracts@workspace:examples/chat/packages/contracts"],
 

--- a/dev-kit.jsonc
+++ b/dev-kit.jsonc
@@ -1,6 +1,13 @@
 {
   "$schema": "./node_modules/@danieljvdm/dev-kit/schema/dev-kit.schema.json",
-  "include": ["dev-kit", "effect", "testing", "cloudflare", "@effect-cf/repo#pr-hygiene"],
+  "include": [
+    "dev-kit",
+    "effect",
+    "testing",
+    "open-pull-request",
+    "cloudflare",
+    "@effect-cf/repo#pr-hygiene",
+  ],
   "setup": {
     "agentInstructions": { "enabled": true },
     "claudeInstructions": { "enabled": true },

--- a/dev-kit.lock.json
+++ b/dev-kit.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "toolVersion": "0.13.0",
-  "manifestDigest": "sha256:a7d718ff59f40a508a5d15198ff9dcc6ea3a096139b237d57525499bcd3d0388",
+  "toolVersion": "0.14.0",
+  "manifestDigest": "sha256:d0062ee25430667652f25392e4684a4db953cca99cb3874ad0a6e9c55ef7f7bb",
   "setup": {
     "effectSource": {
       "packageName": "effect",
@@ -24,7 +24,7 @@
       "target": "agents",
       "mode": "copy",
       "kind": "directory",
-      "digest": "sha256:eeb369f5bb47886f5a4869540f3f5664fbb28b03a6cc5f6ea287db8ca3a6545d"
+      "digest": "sha256:a2c7c8bdcda9c2fd07b7b11db1636a42ac8ba26d6a8753316590d03cccf2177c"
     },
     {
       "resourceId": "skill:build-effect-clis@agents",
@@ -33,7 +33,7 @@
       "target": "agents",
       "mode": "copy",
       "kind": "directory",
-      "digest": "sha256:0a4ba7f621f4fe472528931b55f987d93fc5e300cce7378accfbea84e2363337"
+      "digest": "sha256:7b301376e71dcc3c040bd31cbac72296ee8c9896fd355f365ec0fff4a1fa7b6c"
     },
     {
       "resourceId": "skill:cloudflare@agents",
@@ -90,6 +90,15 @@
       "mode": "copy",
       "kind": "directory",
       "digest": "sha256:c9b42fee517f1077152ccf7231adf5912c048179368bc78837edea2a61815286"
+    },
+    {
+      "resourceId": "skill:open-pull-request@agents",
+      "path": ".agents/skills/open-pull-request",
+      "skill": "open-pull-request",
+      "target": "agents",
+      "mode": "copy",
+      "kind": "directory",
+      "digest": "sha256:b722b785a969463ed093ff517f461193d38442eb5e9ae607e0964f2f521529f5"
     },
     {
       "resourceId": "skill:testing@agents",
@@ -173,6 +182,15 @@
       "mode": "symlink",
       "kind": "symlink",
       "digest": "sha256:057d09728194631224706ae6afbf877107388501832bf0f3e2c6516c7d55f242"
+    },
+    {
+      "resourceId": "skill:open-pull-request@claude",
+      "path": ".claude/skills/open-pull-request",
+      "skill": "open-pull-request",
+      "target": "claude",
+      "mode": "symlink",
+      "kind": "symlink",
+      "digest": "sha256:7fb29cd1804361f3d09fa0925109d56daa20bc8b038a8d0ee23c85052f11708e"
     },
     {
       "resourceId": "skill:testing@claude",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
     "@cloudflare/vitest-pool-workers": "catalog:",
-    "@danieljvdm/dev-kit": "0.13.0",
+    "@danieljvdm/dev-kit": "0.14.0",
     "@effect-cf/repo": "workspace:*",
     "@effect/tsgo": "0.33.0",
     "@types/bun": "^1.3.14",


### PR DESCRIPTION
## Summary

- Update `@danieljvdm/dev-kit` 0.13.0 → 0.14.0 and adopt the release's new bundled `open-pull-request` skill (conventional commits, terse context-complete PR descriptions, verified proof of work) — a good fit alongside this repo's PR-title policy CI and the repo-local `pr-hygiene` skill, which keeps owning repo-specific title/changeset rules.
- Sync managed skill content: `build-effect-clis` now covers every executable script and CI/deploy/build automation in an Effect repository; `build-effect-apis` gains typed-Schema-codec guidance and an unknown-codec audit.
- Refresh the stale `bun.lock` workspace entry for `effect-cf` 0.22.0 (version and peer-dependency metadata had drifted from the committed `package.json`).

### Feature adoption audit (0.12 → 0.14)

All seven bundled skills are now selected (`dev-kit`, the `effect` family — `effect-ts`, `effect-architecture-audit`, `build-effect-apis`, `build-effect-clis` —, `testing`, `open-pull-request`) plus the package-qualified `@effect-cf/repo#pr-hygiene`. Every setup capability is enabled and verified converged: `agentInstructions` (with installed-Effect `node_modules/effect/AGENTS.md` pointer), `claudeInstructions` symlink, `effectSource`, `effectTsgo` (0.33.0 / TypeScript 7.0.2), Vite+ hooks, and the quality workflow with its required `effect-cf#build` before-check. `vite.config.ts` composes `createRecommendedVitePlusConfig` with workspace typecheck over all 21 code-bearing packages (the `containers`/`email` examples are README-only placeholders). The 0.14 manifest schema is unchanged, so no new setup options exist.

Deliberately excluded: narrower Cloudflare catalog skills (`workers-best-practices`, `durable-objects`, `wrangler`, etc.) — the broad `cloudflare` umbrella remains intentionally right because `effect-cf` binds essentially the whole platform (KV, D1, R2, Queues, Workflows, Durable Objects, Hyperdrive, Vectorize, Workers AI, Browser Rendering, Images, Email, Containers, Analytics Engine); stacking focused duplicates would only overlap its triggers. Expo/animation/design catalog skills have no repository evidence.

The five TS-Go severity exceptions tracked by #63 are preserved: current counts are still nonzero (`anyUnknownInErrorContext` 150, `unsafeEffectTypeAssertion` 22, `promiseInEffectSuccess` 10, `multipleEffectProvide` 7, `unknownInEffectCatch` 4), so none can be tightened to `warning` without turning `vp run typecheck` red.

No changeset: internal-only tooling change, `packages/effect-cf/src` and its `package.json` are untouched.

## Validation

- `dev-kit plan` → 4 intended changes; `dev-kit apply`; second `dev-kit plan` → "Already up to date"
- `bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked` → "Dev kit up to date", tracked tree unchanged
- `vp run check` — passed (exit 0; format, lint, tests, Effect TS-Go typecheck, with `effect-cf#build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
