### PR TITLE
feat: extend ContainerNamespace and accept Effects in DurableObjectState.waitUntil

### DIFF
--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: tdd
+description: Test-driven development. Use when the user wants to build features or fix bugs test-first, mentions "red-green-refactor", or wants integration tests.
+---
+
+# Test-Driven Development
+
+TDD is the red → green loop. This skill is the reference that makes that loop produce tests worth keeping: what a good test is, where tests go, the anti-patterns, and the rules of the loop. Every section applies on every cycle — consult them before and during the loop, not after.
+
+When exploring the codebase, read `CONTEXT.md` (if it exists) so test names and interface vocabulary match the project's domain language, and respect ADRs in the area you're touching.
+
+## What a good test is
+
+Tests verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't. A good test reads like a specification — "user can checkout with valid cart" tells you exactly what capability exists — and survives refactors because it doesn't care about internal structure.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Seams — where tests go
+
+A **seam** is the public boundary you test at: the interface where you observe behavior without reaching inside. Tests live at seams, never against internals.
+
+**Test only at pre-agreed seams.** Before writing any test, write down the seams under test and confirm them with the user. No test is written at an unconfirmed seam. You can't test everything — agreeing the seams up front is how testing effort lands on the critical paths and complex logic instead of every edge case.
+
+Ask: "What's the public interface, and which seams should we test?"
+
+## Anti-patterns
+
+- **Implementation-coupled** — mocks internal collaborators, tests private methods, or verifies through a side channel (querying the database instead of using the interface). The tell: the test breaks when you refactor but behavior hasn't changed.
+- **Tautological** — the assertion recomputes the expected value the way the code does (`expect(add(a, b)).toBe(a + b)`, a snapshot derived by hand the same way, a constant asserted equal to itself), so it passes by construction and can never disagree with the code. Expected values must come from an independent source of truth — a known-good literal, a worked example, the spec.
+- **Horizontal slicing** — writing all tests first, then all implementation. Bulk tests verify _imagined_ behavior: you test the _shape_ of things rather than user-facing behavior, the tests go insensitive to real changes, and you commit to test structure before understanding the implementation. Work in **vertical slices** instead — one test → one implementation → repeat, each test a **tracer bullet** that responds to what the last cycle taught you.
+
+## Rules of the loop
+
+- **Red before green.** Write the failing test first, then only enough code to pass it. Don't anticipate future tests or add speculative features.
+- **One slice at a time.** One seam, one test, one minimal implementation per cycle.
+- **Refactoring is not part of the loop.** It belongs to the review stage (see the `code-review` skill), not the red → green implementation cycle.

--- a/.agents/skills/tdd/agents/openai.yaml
+++ b/.agents/skills/tdd/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "TDD"
+  short_description: "Test-driven red-green-refactor"

--- a/.agents/skills/tdd/mocking.md
+++ b/.agents/skills/tdd/mocking.md
@@ -1,0 +1,59 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/.agents/skills/tdd/tests.md
+++ b/.agents/skills/tdd/tests.md
@@ -1,0 +1,77 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```
+
+**Tautological tests**: Expected value restates the implementation, so the test passes by construction.
+
+```typescript
+// BAD: Expected value is recomputed the way the code computes it
+test("calculateTotal sums line items", () => {
+  const items = [{ price: 10 }, { price: 5 }];
+  const expected = items.reduce((sum, i) => sum + i.price, 0);
+  expect(calculateTotal(items)).toBe(expected);
+});
+
+// GOOD: Expected value is an independent, known literal
+test("calculateTotal sums line items", () => {
+  expect(calculateTotal([{ price: 10 }, { price: 5 }])).toBe(15);
+});
+```

--- a/.changeset/container-namespace-caller-primitives.md
+++ b/.changeset/container-namespace-caller-primitives.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Extend the `ContainerNamespace` client with the remaining caller-side Container primitives: `waitForPort` (preserving the native retry-count result), the runtime host-policy operations (`setAllowedHosts`, `setDeniedHosts`, `allowHost`, `denyHost`, `removeAllowedHost`, `removeDeniedHost`), and numeric stop signals alongside the named ones. `ContainerNamespace.Tag` now accepts an optional exact native namespace type (for example `DurableObjectNamespace<CodexSandbox>`) so `rawUnsafe` on the namespace and on named instances preserves the exact native namespace and stub types, including extra subclass methods. Existing consumers compile unchanged via default type parameters.

--- a/.changeset/durable-object-state-effect-wait-until.md
+++ b/.changeset/durable-object-state-effect-wait-until.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+`DurableObjectState.waitUntil` now also accepts an Effect, running it in the background with the caller's Effect context and the same failure modes as `WorkerContext.waitUntil` (`"observe"` logs or routes failures to `onFailure`; `"propagate"` also rejects the native `waitUntil` promise). The existing Promise form is unchanged, so Durable Objects no longer need to capture a Context and call `Effect.runPromiseWith` to schedule background Effects.

--- a/.claude/skills/tdd
+++ b/.claude/skills/tdd
@@ -1,0 +1,1 @@
+../../.agents/skills/tdd

--- a/dev-kit.jsonc
+++ b/dev-kit.jsonc
@@ -7,6 +7,7 @@
     "open-pull-request",
     "cloudflare",
     "@effect-cf/repo#pr-hygiene",
+    "tdd",
   ],
   "setup": {
     "agentInstructions": { "enabled": true },

--- a/dev-kit.lock.json
+++ b/dev-kit.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "toolVersion": "0.14.0",
-  "manifestDigest": "sha256:d0062ee25430667652f25392e4684a4db953cca99cb3874ad0a6e9c55ef7f7bb",
+  "manifestDigest": "sha256:59daada55c27a503f1cb45ca64547c793a69152ec8726847d760ee56588b641b",
   "setup": {
     "effectSource": {
       "packageName": "effect",
@@ -101,6 +101,20 @@
       "digest": "sha256:b722b785a969463ed093ff517f461193d38442eb5e9ae607e0964f2f521529f5"
     },
     {
+      "resourceId": "skill:tdd@agents",
+      "path": ".agents/skills/tdd",
+      "skill": "tdd",
+      "target": "agents",
+      "mode": "copy",
+      "kind": "directory",
+      "digest": "sha256:ea2d26eda005b10a2de4bdb7de44d33072f2a8e82dbf670952ce30a9c2d7c475",
+      "catalog": {
+        "source": "mattpocock-skills",
+        "repository": "https://github.com/mattpocock/skills.git",
+        "resolved": "2ab958093e83e0ec752e6c1c5932da465bf23e0c"
+      }
+    },
+    {
       "resourceId": "skill:testing@agents",
       "path": ".agents/skills/testing",
       "skill": "testing",
@@ -191,6 +205,20 @@
       "mode": "symlink",
       "kind": "symlink",
       "digest": "sha256:7fb29cd1804361f3d09fa0925109d56daa20bc8b038a8d0ee23c85052f11708e"
+    },
+    {
+      "resourceId": "skill:tdd@claude",
+      "path": ".claude/skills/tdd",
+      "skill": "tdd",
+      "target": "claude",
+      "mode": "symlink",
+      "kind": "symlink",
+      "digest": "sha256:398300a0bb92f35b234df99037308cbda7d5e10fe9b082902faf7bf8f5a47984",
+      "catalog": {
+        "source": "mattpocock-skills",
+        "repository": "https://github.com/mattpocock/skills.git",
+        "resolved": "2ab958093e83e0ec752e6c1c5932da465bf23e0c"
+      }
     },
     {
       "resourceId": "skill:testing@claude",

--- a/examples/containers/README.md
+++ b/examples/containers/README.md
@@ -70,7 +70,17 @@ Durable Object namespace:
 }
 ```
 
+Named instances also expose `waitForPort` (returning the native retry count),
+`stop` with a named or numeric signal, and the runtime host-policy operations
+(`setAllowedHosts`, `setDeniedHosts`, `allowHost`, `denyHost`,
+`removeAllowedHost`, `removeDeniedHost`). These forward the native remote
+calls; the Container entrypoint still owns hostname policy and outbound
+handlers.
+
 Use the namespace or named instance `rawUnsafe` Effect only for a native SDK
-operation that effect-cf does not expose. Container responses are not
-status-checked or transformed, so HTTP errors and WebSocket upgrade responses
-retain native Cloudflare behavior.
+operation that effect-cf does not expose. Passing the exact namespace type as
+the second `ContainerNamespace.Tag` type parameter (for example
+`DurableObjectNamespace<RendererContainer>`) makes `rawUnsafe` preserve that
+exact namespace and stub type, including extra subclass methods. Container
+responses are not status-checked or transformed, so HTTP errors and WebSocket
+upgrade responses retain native Cloudflare behavior.

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -87,6 +87,12 @@ export const readCounter = Effect.gen(function* () {
 
 Define Wrangler bindings and migrations in the consuming application. Durable Object namespace bindings are provided with `YourObject.layer({ binding })`, and consumers use `const namespace = yield* YourObject`.
 
+`DurableObjectState.waitUntil` accepts either a raw Promise or an Effect. The
+Effect form runs in the background with the caller's Effect context and the
+same failure modes as `WorkerContext.waitUntil`, so Durable Objects can
+schedule background Effects (for example a pump consuming an outbound
+WebSocket) without capturing a Context and calling `Effect.runPromiseWith`.
+
 ## Container Example
 
 Container entrypoints remain owned by `@cloudflare/containers`; `effect-cf`

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -118,11 +118,29 @@ export default Worker.make(RenderersLive, {
 ```
 
 The instance client exposes `state`, `fetch`, `start`,
-`startAndWaitForPorts`, `stop`, `destroy`, and the Effect-valued native
-`rawUnsafe` stub.
+`startAndWaitForPorts`, `waitForPort`, `stop` (named or numeric signals),
+`destroy`, the runtime host-policy operations (`setAllowedHosts`,
+`setDeniedHosts`, `allowHost`, `denyHost`, `removeAllowedHost`,
+`removeDeniedHost`), and the Effect-valued native `rawUnsafe` stub.
+Host-policy operations only forward the native remote calls; applications
+continue to own hostname policy and outbound handlers.
 Responses are returned unchanged, including non-2xx and WebSocket upgrade
 responses. If the Container uses outbound interception, also export
 `ContainerProxy` from `@cloudflare/containers`.
+
+`ContainerNamespace.Tag` accepts an optional second type parameter carrying
+the exact native namespace type. `rawUnsafe` on the namespace and on named
+instances then preserves that exact type, including extra subclass methods,
+instead of the minimal structural shape:
+
+```ts
+class Sandboxes extends ContainerNamespace.Tag<Sandboxes, DurableObjectNamespace<CodexSandbox>>()(
+  "Sandboxes",
+) {}
+
+// Effect<DurableObjectStub<CodexSandbox>, ContainerOperationError, Sandboxes>
+const stub = Sandboxes.byName("codex").rawUnsafe;
+```
 
 See [`examples/containers/README.md`](../../examples/containers/README.md) for
 the corresponding Wrangler configuration and entrypoint responsibilities.

--- a/packages/effect-cf/src/ContainerNamespace.ts
+++ b/packages/effect-cf/src/ContainerNamespace.ts
@@ -6,8 +6,11 @@ import * as ErrorMessage from "./internal/ErrorMessage";
 
 const expectedContainerNamespace = "Container namespace binding with getByName()";
 
-/** Signal accepted by Cloudflare Container instances. */
+/** Named signal accepted by Cloudflare Container instances. */
 export type ContainerSignal = "SIGKILL" | "SIGINT" | "SIGTERM";
+
+/** Named or numeric signal accepted by Container `stop()`. */
+export type ContainerStopSignal = ContainerSignal | number;
 
 /** Per-instance Container startup configuration. */
 export interface ContainerStartOptions {
@@ -63,8 +66,15 @@ export interface ContainerStub {
   getState(): Promise<ContainerState>;
   start(options?: ContainerStartOptions, waitOptions?: ContainerWaitOptions): Promise<void>;
   startAndWaitForPorts(options?: ContainerStartAndWaitForPortsOptions): Promise<void>;
-  stop(signal?: ContainerSignal): Promise<void>;
+  waitForPort(options: ContainerWaitOptions): Promise<number>;
+  stop(signal?: ContainerStopSignal): Promise<void>;
   destroy(): Promise<void>;
+  setAllowedHosts(hosts: Array<string>): Promise<void>;
+  setDeniedHosts(hosts: Array<string>): Promise<void>;
+  allowHost(hostname: string): Promise<void>;
+  denyHost(hostname: string): Promise<void>;
+  removeAllowedHost(hostname: string): Promise<void>;
+  removeDeniedHost(hostname: string): Promise<void>;
 }
 
 /** Native Container namespace binding shape. */
@@ -74,6 +84,11 @@ export interface ContainerNamespaceResource {
     options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
   ): ContainerStub;
 }
+
+/** Exact native stub type produced by a Container namespace binding. */
+export type ContainerStubOf<Namespace extends ContainerNamespaceResource> = ReturnType<
+  Namespace["getByName"]
+>;
 
 /** Container namespace binding metadata. */
 export interface ContainerNamespaceDefinition {
@@ -94,8 +109,8 @@ export class ContainerOperationError extends Data.TaggedError("ContainerOperatio
 }
 
 /** Effect-wrapped client for one named Container instance. */
-export interface ContainerInstanceClient {
-  readonly rawUnsafe: Effect.Effect<ContainerStub, ContainerOperationError>;
+export interface ContainerInstanceClient<Stub extends ContainerStub = ContainerStub> {
+  readonly rawUnsafe: Effect.Effect<Stub, ContainerOperationError>;
   readonly state: Effect.Effect<ContainerState, ContainerOperationError>;
   readonly fetch: (
     input: RequestInfo | URL,
@@ -108,29 +123,51 @@ export interface ContainerInstanceClient {
   readonly startAndWaitForPorts: (
     options?: ContainerStartAndWaitForPortsOptions,
   ) => Effect.Effect<void, ContainerOperationError>;
-  readonly stop: (signal?: ContainerSignal) => Effect.Effect<void, ContainerOperationError>;
+  readonly waitForPort: (
+    options: ContainerWaitOptions,
+  ) => Effect.Effect<number, ContainerOperationError>;
+  readonly stop: (signal?: ContainerStopSignal) => Effect.Effect<void, ContainerOperationError>;
   readonly destroy: Effect.Effect<void, ContainerOperationError>;
+  readonly setAllowedHosts: (
+    hosts: ReadonlyArray<string>,
+  ) => Effect.Effect<void, ContainerOperationError>;
+  readonly setDeniedHosts: (
+    hosts: ReadonlyArray<string>,
+  ) => Effect.Effect<void, ContainerOperationError>;
+  readonly allowHost: (hostname: string) => Effect.Effect<void, ContainerOperationError>;
+  readonly denyHost: (hostname: string) => Effect.Effect<void, ContainerOperationError>;
+  readonly removeAllowedHost: (hostname: string) => Effect.Effect<void, ContainerOperationError>;
+  readonly removeDeniedHost: (hostname: string) => Effect.Effect<void, ContainerOperationError>;
 }
 
 /** Effect client for a Container namespace binding. */
-export interface ContainerNamespaceClient {
+export interface ContainerNamespaceClient<
+  Namespace extends ContainerNamespaceResource = ContainerNamespaceResource,
+> {
   readonly definition: ContainerNamespaceDefinition;
   readonly getByName: (
     name: string,
     options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
-  ) => Effect.Effect<ContainerInstanceClient, ContainerOperationError>;
+  ) => Effect.Effect<ContainerInstanceClient<ContainerStubOf<Namespace>>, ContainerOperationError>;
   readonly byName: (
     name: string,
     options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
-  ) => ContainerInstanceClient;
-  readonly rawUnsafe: Effect.Effect<ContainerNamespaceResource>;
+  ) => ContainerInstanceClient<ContainerStubOf<Namespace>>;
+  readonly rawUnsafe: Effect.Effect<Namespace>;
 }
 
-export type ContainerNamespaceStaticClient<R> = {
+export type ContainerNamespaceStaticClient<
+  R,
+  Namespace extends ContainerNamespaceResource = ContainerNamespaceResource,
+> = {
   readonly getByName: (
     name: string,
     options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
-  ) => Effect.Effect<ContainerInstanceClient, ContainerOperationError, R>;
+  ) => Effect.Effect<
+    ContainerInstanceClient<ContainerStubOf<Namespace>>,
+    ContainerOperationError,
+    R
+  >;
   readonly byName: (
     name: string,
     options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
@@ -147,21 +184,44 @@ export type ContainerNamespaceStaticClient<R> = {
     readonly startAndWaitForPorts: (
       options?: ContainerStartAndWaitForPortsOptions,
     ) => Effect.Effect<void, ContainerOperationError, R>;
-    readonly stop: (signal?: ContainerSignal) => Effect.Effect<void, ContainerOperationError, R>;
+    readonly waitForPort: (
+      options: ContainerWaitOptions,
+    ) => Effect.Effect<number, ContainerOperationError, R>;
+    readonly stop: (
+      signal?: ContainerStopSignal,
+    ) => Effect.Effect<void, ContainerOperationError, R>;
     readonly destroy: Effect.Effect<void, ContainerOperationError, R>;
-    readonly rawUnsafe: Effect.Effect<ContainerStub, ContainerOperationError, R>;
+    readonly setAllowedHosts: (
+      hosts: ReadonlyArray<string>,
+    ) => Effect.Effect<void, ContainerOperationError, R>;
+    readonly setDeniedHosts: (
+      hosts: ReadonlyArray<string>,
+    ) => Effect.Effect<void, ContainerOperationError, R>;
+    readonly allowHost: (hostname: string) => Effect.Effect<void, ContainerOperationError, R>;
+    readonly denyHost: (hostname: string) => Effect.Effect<void, ContainerOperationError, R>;
+    readonly removeAllowedHost: (
+      hostname: string,
+    ) => Effect.Effect<void, ContainerOperationError, R>;
+    readonly removeDeniedHost: (
+      hostname: string,
+    ) => Effect.Effect<void, ContainerOperationError, R>;
+    readonly rawUnsafe: Effect.Effect<ContainerStubOf<Namespace>, ContainerOperationError, R>;
   };
-  readonly rawUnsafe: Effect.Effect<ContainerNamespaceResource, never, R>;
+  readonly rawUnsafe: Effect.Effect<Namespace, never, R>;
 };
 
 export type LayerOptions = {
   readonly binding: string;
 };
 
-export interface TagClass<Self, Id extends string>
+export interface TagClass<
+  Self,
+  Id extends string,
+  Namespace extends ContainerNamespaceResource = ContainerNamespaceResource,
+>
   extends
-    Context.ServiceClass<Self, `effect-cf/Container/${Id}`, ContainerNamespaceClient>,
-    ContainerNamespaceStaticClient<Self> {
+    Context.ServiceClass<Self, `effect-cf/Container/${Id}`, ContainerNamespaceClient<Namespace>>,
+    ContainerNamespaceStaticClient<Self, Namespace> {
   readonly id: Id;
   readonly layer: (
     options: LayerOptions,
@@ -189,14 +249,34 @@ const tryContainerPromise = <A>(
       }),
   });
 
-const makeInstanceClient = (
+const makeInstanceClient = <Stub extends ContainerStub>(
   definition: ContainerNamespaceDefinition,
   instance: string,
-  stub: ContainerStub,
-): ContainerInstanceClient => {
+  stub: Stub,
+): ContainerInstanceClient<Stub> => {
   const spanOptions = (operation: string) => ({
     attributes: { binding: definition.binding, instance, operation },
   });
+  const hostListOperation = (operation: "setAllowedHosts" | "setDeniedHosts") =>
+    Effect.fn(
+      `ContainerNamespace.${operation}`,
+      spanOptions(operation),
+    )(function* (hosts: ReadonlyArray<string>) {
+      return yield* tryContainerPromise(definition, instance, operation, () =>
+        stub[operation]([...hosts]),
+      );
+    });
+  const hostnameOperation = (
+    operation: "allowHost" | "denyHost" | "removeAllowedHost" | "removeDeniedHost",
+  ) =>
+    Effect.fn(
+      `ContainerNamespace.${operation}`,
+      spanOptions(operation),
+    )(function* (hostname: string) {
+      return yield* tryContainerPromise(definition, instance, operation, () =>
+        stub[operation](hostname),
+      );
+    });
 
   return {
     rawUnsafe: Effect.succeed(stub),
@@ -238,15 +318,29 @@ const makeInstanceClient = (
         stub.startAndWaitForPorts(options),
       );
     }),
+    waitForPort: Effect.fn(
+      "ContainerNamespace.waitForPort",
+      spanOptions("waitForPort"),
+    )(function* (options: ContainerWaitOptions) {
+      return yield* tryContainerPromise(definition, instance, "waitForPort", () =>
+        stub.waitForPort(options),
+      );
+    }),
     stop: Effect.fn(
       "ContainerNamespace.stop",
       spanOptions("stop"),
-    )(function* (signal?: ContainerSignal) {
+    )(function* (signal?: ContainerStopSignal) {
       return yield* tryContainerPromise(definition, instance, "stop", () => stub.stop(signal));
     }),
     destroy: tryContainerPromise(definition, instance, "destroy", () => stub.destroy()).pipe(
       Effect.withSpan("ContainerNamespace.destroy", spanOptions("destroy")),
     ),
+    setAllowedHosts: hostListOperation("setAllowedHosts"),
+    setDeniedHosts: hostListOperation("setDeniedHosts"),
+    allowHost: hostnameOperation("allowHost"),
+    denyHost: hostnameOperation("denyHost"),
+    removeAllowedHost: hostnameOperation("removeAllowedHost"),
+    removeDeniedHost: hostnameOperation("removeDeniedHost"),
   };
 };
 
@@ -257,13 +351,22 @@ export const isContainerNamespaceResource = (value: unknown): value is Container
 
 export const makeClient =
   (definition: ContainerNamespaceDefinition) =>
-  (namespace: ContainerNamespaceResource): ContainerNamespaceClient => {
+  <Namespace extends ContainerNamespaceResource>(
+    namespace: Namespace,
+  ): ContainerNamespaceClient<Namespace> => {
     const getByName = (
       name: string,
       options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
     ) =>
       Effect.try({
-        try: () => makeInstanceClient(definition, name, namespace.getByName(name, options)),
+        try: () =>
+          makeInstanceClient(
+            definition,
+            name,
+            // getByName has a single call signature, so its return type is
+            // exactly the namespace's stub type.
+            namespace.getByName(name, options) as ContainerStubOf<Namespace>,
+          ),
         catch: (cause) =>
           new ContainerOperationError({
             binding: definition.binding,
@@ -276,7 +379,7 @@ export const makeClient =
     const byName = (
       name: string,
       options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
-    ): ContainerInstanceClient => {
+    ): ContainerInstanceClient<ContainerStubOf<Namespace>> => {
       const instance = getByName(name, options);
 
       return {
@@ -287,8 +390,20 @@ export const makeClient =
           Effect.flatMap(instance, (client) => client.start(startOptions, waitOptions)),
         startAndWaitForPorts: (startOptions) =>
           Effect.flatMap(instance, (client) => client.startAndWaitForPorts(startOptions)),
+        waitForPort: (waitOptions) =>
+          Effect.flatMap(instance, (client) => client.waitForPort(waitOptions)),
         stop: (signal) => Effect.flatMap(instance, (client) => client.stop(signal)),
         destroy: Effect.flatMap(instance, (client) => client.destroy),
+        setAllowedHosts: (hosts) =>
+          Effect.flatMap(instance, (client) => client.setAllowedHosts(hosts)),
+        setDeniedHosts: (hosts) =>
+          Effect.flatMap(instance, (client) => client.setDeniedHosts(hosts)),
+        allowHost: (hostname) => Effect.flatMap(instance, (client) => client.allowHost(hostname)),
+        denyHost: (hostname) => Effect.flatMap(instance, (client) => client.denyHost(hostname)),
+        removeAllowedHost: (hostname) =>
+          Effect.flatMap(instance, (client) => client.removeAllowedHost(hostname)),
+        removeDeniedHost: (hostname) =>
+          Effect.flatMap(instance, (client) => client.removeDeniedHost(hostname)),
       };
     };
 
@@ -300,13 +415,21 @@ export const makeClient =
     };
   };
 
-export const layer = <Self>(
-  tag: Context.Service<Self, ContainerNamespaceClient>,
+export const layer = <Self, Namespace extends ContainerNamespaceResource>(
+  tag: Context.Service<Self, ContainerNamespaceClient<Namespace>>,
   definition: ContainerNamespaceDefinition,
 ) =>
-  Binding.layer(tag, definition.binding, isContainerNamespaceResource, makeClient(definition), {
-    expected: expectedContainerNamespace,
-  });
+  Binding.layer(
+    tag,
+    definition.binding,
+    // Runtime validation stays structural; the exact namespace type is
+    // asserted by the consumer's binding declaration, like env typing.
+    isContainerNamespaceResource as (value: unknown) => value is Namespace,
+    makeClient(definition),
+    {
+      expected: expectedContainerNamespace,
+    },
+  );
 
 export const make = <Id extends string>(id: Id) => Tag<ContainerNamespaceService<Id>>()<Id>(id);
 
@@ -321,9 +444,9 @@ export interface ContainerNamespaceService<Id extends string> {
 
 /** Creates a typed Effect service for a Cloudflare Container namespace. */
 export const Tag =
-  <Self>() =>
+  <Self, Namespace extends ContainerNamespaceResource = ContainerNamespaceResource>() =>
   <Id extends string>(id: Id) => {
-    const tag = Context.Service<Self, ContainerNamespaceClient>()(
+    const tag = Context.Service<Self, ContainerNamespaceClient<Namespace>>()(
       `effect-cf/Container/${id}` as const,
     );
     const makeLayer = (definition: LayerOptions) => layer(tag, definition);
@@ -352,9 +475,25 @@ export const Tag =
         Effect.flatMap(getByName(name, options), (instance) =>
           instance.startAndWaitForPorts(startOptions),
         ),
-      stop: (signal?: ContainerSignal) =>
+      waitForPort: (waitOptions: ContainerWaitOptions) =>
+        Effect.flatMap(getByName(name, options), (instance) => instance.waitForPort(waitOptions)),
+      stop: (signal?: ContainerStopSignal) =>
         Effect.flatMap(getByName(name, options), (instance) => instance.stop(signal)),
       destroy: Effect.flatMap(getByName(name, options), (instance) => instance.destroy),
+      setAllowedHosts: (hosts: ReadonlyArray<string>) =>
+        Effect.flatMap(getByName(name, options), (instance) => instance.setAllowedHosts(hosts)),
+      setDeniedHosts: (hosts: ReadonlyArray<string>) =>
+        Effect.flatMap(getByName(name, options), (instance) => instance.setDeniedHosts(hosts)),
+      allowHost: (hostname: string) =>
+        Effect.flatMap(getByName(name, options), (instance) => instance.allowHost(hostname)),
+      denyHost: (hostname: string) =>
+        Effect.flatMap(getByName(name, options), (instance) => instance.denyHost(hostname)),
+      removeAllowedHost: (hostname: string) =>
+        Effect.flatMap(getByName(name, options), (instance) =>
+          instance.removeAllowedHost(hostname),
+        ),
+      removeDeniedHost: (hostname: string) =>
+        Effect.flatMap(getByName(name, options), (instance) => instance.removeDeniedHost(hostname)),
       rawUnsafe: Effect.flatMap(getByName(name, options), (instance) => instance.rawUnsafe),
     });
 
@@ -366,7 +505,7 @@ export const Tag =
       getByName,
       byName,
       rawUnsafe,
-    }) as TagClass<Self, Id>;
+    }) as TagClass<Self, Id, Namespace>;
   };
 
 export const ContainerNamespace = Tag;

--- a/packages/effect-cf/src/DurableObjectState.ts
+++ b/packages/effect-cf/src/DurableObjectState.ts
@@ -2,6 +2,8 @@ import { Cause, Context, Effect, Exit } from "effect";
 
 import { fromDurableObjectStorage, type DurableObjectStorage } from "./DurableObjectStorage";
 import { fromWebSocket, type DurableWebSocket } from "./DurableObjectWebSocket";
+import type { WorkerContextWaitUntilOptions } from "./Worker";
+import { makeWaitUntilScheduler } from "./internal/WorkerContext";
 
 /**
  * Effect-friendly wrapper around Cloudflare `DurableObjectState`.
@@ -15,6 +17,16 @@ export interface DurableObjectStateService {
   readonly storage: DurableObjectStorage;
   /** Registers background work with Cloudflare's lifecycle. */
   waitUntil(promise: Promise<unknown>): Effect.Effect<void>;
+  /**
+   * Runs a background Effect via Cloudflare's `waitUntil` with the caller's
+   * Effect context, mirroring `WorkerContext.waitUntil` failure modes:
+   * `"observe"` (default) logs or routes failures to `onFailure`, while
+   * `"propagate"` also rejects the native `waitUntil` promise.
+   */
+  waitUntil<A, E, R, R2 = never>(
+    effect: Effect.Effect<A, E, R>,
+    options?: WorkerContextWaitUntilOptions<E, R2>,
+  ): Effect.Effect<void, never, R | R2>;
   /**
    * Runs an Effect inside Cloudflare's `blockConcurrencyWhile` gate.
    *
@@ -72,45 +84,60 @@ export class DurableObjectState extends Context.Service<
  */
 export const fromDurableObjectState = (
   state: globalThis.DurableObjectState,
-): DurableObjectStateService => ({
-  raw: state,
-  id: state.id,
-  storage: fromDurableObjectStorage(state.storage),
-  waitUntil: (promise: Promise<unknown>) => Effect.sync(() => state.waitUntil(promise)),
-  blockConcurrencyWhile: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-    Effect.context<R>().pipe(
-      Effect.flatMap((context) =>
-        Effect.promise(() =>
-          state.blockConcurrencyWhile(() => runPromiseExitPreservingTypedFailures(context, effect)),
+): DurableObjectStateService => {
+  const scheduleWaitUntil = makeWaitUntilScheduler("DurableObjectState.waitUntil", (promise) =>
+    state.waitUntil(promise),
+  );
+  const waitUntil = (<A, E, R, R2 = never>(
+    input: Promise<unknown> | Effect.Effect<A, E, R>,
+    options?: WorkerContextWaitUntilOptions<E, R2>,
+  ) =>
+    Effect.isEffect(input)
+      ? scheduleWaitUntil(input, options, options?.mode ?? "observe")
+      : Effect.sync(() => state.waitUntil(input))) as DurableObjectStateService["waitUntil"];
+
+  return {
+    raw: state,
+    id: state.id,
+    storage: fromDurableObjectStorage(state.storage),
+    waitUntil,
+    blockConcurrencyWhile: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      Effect.context<R>().pipe(
+        Effect.flatMap((context) =>
+          Effect.promise(() =>
+            state.blockConcurrencyWhile(() =>
+              runPromiseExitPreservingTypedFailures(context, effect),
+            ),
+          ),
+        ),
+        Effect.flatten,
+      ),
+    blockConcurrencyWhileOrReset: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      Effect.context<R>().pipe(
+        Effect.flatMap((context) =>
+          Effect.promise(() =>
+            state.blockConcurrencyWhile(() => Effect.runPromiseWith(context)(effect)),
+          ),
         ),
       ),
-      Effect.flatten,
+    acceptWebSocket: (ws: DurableWebSocket, tags?: Array<string>) =>
+      Effect.sync(() => state.acceptWebSocket(ws.raw, tags)),
+    getWebSockets: (tag?: string) =>
+      Effect.sync(() => state.getWebSockets(tag).map((socket) => fromWebSocket(socket))),
+    setWebSocketAutoResponse: (pair?: WebSocketRequestResponsePair) =>
+      Effect.sync(() => state.setWebSocketAutoResponse(pair)),
+    getWebSocketAutoResponse: Effect.sync(() => state.getWebSocketAutoResponse()),
+    getWebSocketAutoResponseTimestamp: (ws: DurableWebSocket) =>
+      Effect.sync(() => state.getWebSocketAutoResponseTimestamp(ws.raw)),
+    setHibernatableWebSocketEventTimeout: (timeoutMs?: number) =>
+      Effect.sync(() => state.setHibernatableWebSocketEventTimeout(timeoutMs)),
+    getHibernatableWebSocketEventTimeout: Effect.sync(() =>
+      state.getHibernatableWebSocketEventTimeout(),
     ),
-  blockConcurrencyWhileOrReset: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-    Effect.context<R>().pipe(
-      Effect.flatMap((context) =>
-        Effect.promise(() =>
-          state.blockConcurrencyWhile(() => Effect.runPromiseWith(context)(effect)),
-        ),
-      ),
-    ),
-  acceptWebSocket: (ws: DurableWebSocket, tags?: Array<string>) =>
-    Effect.sync(() => state.acceptWebSocket(ws.raw, tags)),
-  getWebSockets: (tag?: string) =>
-    Effect.sync(() => state.getWebSockets(tag).map((socket) => fromWebSocket(socket))),
-  setWebSocketAutoResponse: (pair?: WebSocketRequestResponsePair) =>
-    Effect.sync(() => state.setWebSocketAutoResponse(pair)),
-  getWebSocketAutoResponse: Effect.sync(() => state.getWebSocketAutoResponse()),
-  getWebSocketAutoResponseTimestamp: (ws: DurableWebSocket) =>
-    Effect.sync(() => state.getWebSocketAutoResponseTimestamp(ws.raw)),
-  setHibernatableWebSocketEventTimeout: (timeoutMs?: number) =>
-    Effect.sync(() => state.setHibernatableWebSocketEventTimeout(timeoutMs)),
-  getHibernatableWebSocketEventTimeout: Effect.sync(() =>
-    state.getHibernatableWebSocketEventTimeout(),
-  ),
-  getTags: (ws: DurableWebSocket) => Effect.sync(() => state.getTags(ws.raw)),
-  abort: (reason?: string) => Effect.sync(() => state.abort(reason)),
-});
+    getTags: (ws: DurableWebSocket) => Effect.sync(() => state.getTags(ws.raw)),
+    abort: (reason?: string) => Effect.sync(() => state.abort(reason)),
+  };
+};
 
 const runPromiseExitPreservingTypedFailures = async <A, E, R>(
   context: Context.Context<R>,

--- a/packages/effect-cf/src/internal/WorkerContext.ts
+++ b/packages/effect-cf/src/internal/WorkerContext.ts
@@ -13,16 +13,14 @@ const causeError = <E>(cause: Cause.Cause<E>) => {
 };
 
 const failureHandler = <E, R>(
+  label: string,
   cause: Cause.Cause<E>,
   options: WorkerContextWaitUntilOptions<E, R> | undefined,
 ) =>
-  (
-    options?.onFailure?.(cause) ??
-    Effect.logError("WorkerContext.waitUntil failed", Cause.pretty(cause))
-  ).pipe(
+  (options?.onFailure?.(cause) ?? Effect.logError(`${label} failed`, Cause.pretty(cause))).pipe(
     Effect.catchCause((handlerCause) =>
       Effect.logError(
-        "WorkerContext.waitUntil failure handler failed",
+        `${label} failure handler failed`,
         Cause.pretty(cause),
         Cause.pretty(handlerCause),
       ),
@@ -30,18 +28,19 @@ const failureHandler = <E, R>(
   );
 
 /**
- * Builds the `WorkerContext` service from a native `ExecutionContext`.
+ * Builds a `waitUntil` scheduler for any Cloudflare lifecycle that accepts
+ * background promises (`ExecutionContext`, `DurableObjectState`).
  *
  * Background effects capture the calling fiber's context via `Effect.context`
- * before being handed to `ctx.waitUntil`, so the default module-level
- * `Effect.runPromiseExit` runner is sufficient; entrypoints may still pass a
- * runtime-bound runner.
+ * before being registered, so the default module-level `Effect.runPromiseExit`
+ * runner is sufficient; entrypoints may still pass a runtime-bound runner.
  */
-export const fromExecutionContext = (
-  ctx: globalThis.ExecutionContext,
+export const makeWaitUntilScheduler = (
+  label: string,
+  register: (promise: Promise<unknown>) => void,
   runPromiseExit: RunWaitUntilEffect = (effect) => Effect.runPromiseExit(effect),
-): WorkerContextService => {
-  const schedule = <A, E, R, R2 = never>(
+) => {
+  return <A, E, R, R2 = never>(
     effect: Effect.Effect<A, E, R>,
     options: WorkerContextWaitUntilOptions<E, R2> | undefined,
     mode: "observe" | "propagate",
@@ -51,17 +50,14 @@ export const fromExecutionContext = (
         Effect.sync(() => {
           const runHandler = (cause: Cause.Cause<E>) =>
             runPromiseExit(
-              Effect.scoped(Effect.provideContext(failureHandler(cause, options), context)),
+              Effect.scoped(Effect.provideContext(failureHandler(label, cause, options), context)),
             ).then((exit) => {
               if (Exit.isFailure(exit)) {
-                console.error(
-                  "WorkerContext.waitUntil failure handler failed",
-                  Cause.pretty(exit.cause),
-                );
+                console.error(`${label} failure handler failed`, Cause.pretty(exit.cause));
               }
             });
 
-          ctx.waitUntil(
+          register(
             runPromiseExit(Effect.scoped(Effect.provideContext(effect, context))).then(
               async (exit) => {
                 if (Exit.isSuccess(exit)) {
@@ -79,6 +75,20 @@ export const fromExecutionContext = (
         }),
       ),
     );
+};
+
+/**
+ * Builds the `WorkerContext` service from a native `ExecutionContext`.
+ */
+export const fromExecutionContext = (
+  ctx: globalThis.ExecutionContext,
+  runPromiseExit: RunWaitUntilEffect = (effect) => Effect.runPromiseExit(effect),
+): WorkerContextService => {
+  const schedule = makeWaitUntilScheduler(
+    "WorkerContext.waitUntil",
+    (promise) => ctx.waitUntil(promise),
+    runPromiseExit,
+  );
 
   return {
     raw: ctx,

--- a/packages/effect-cf/tests/ContainerNamespace.test.ts
+++ b/packages/effect-cf/tests/ContainerNamespace.test.ts
@@ -8,10 +8,16 @@ import { Binding, ContainerNamespace, WorkerEnvironment, type WorkerEnv } from "
 class TestContainers extends ContainerNamespace.Tag<TestContainers>()("TestContainers") {}
 
 type Call =
+  | { readonly operation: "allowHost"; readonly hostname: string }
+  | { readonly operation: "denyHost"; readonly hostname: string }
   | { readonly operation: "destroy" }
   | { readonly operation: "fetch"; readonly input: RequestInfo | URL; readonly init?: RequestInit }
   | { readonly operation: "getByName"; readonly name: string }
   | { readonly operation: "getState" }
+  | { readonly operation: "removeAllowedHost"; readonly hostname: string }
+  | { readonly operation: "removeDeniedHost"; readonly hostname: string }
+  | { readonly operation: "setAllowedHosts"; readonly hosts: ReadonlyArray<string> }
+  | { readonly operation: "setDeniedHosts"; readonly hosts: ReadonlyArray<string> }
   | {
       readonly operation: "start";
       readonly options?: ContainerNamespace.ContainerStartOptions;
@@ -21,11 +27,16 @@ type Call =
       readonly operation: "startAndWaitForPorts";
       readonly options?: ContainerNamespace.ContainerStartAndWaitForPortsOptions;
     }
-  | { readonly operation: "stop"; readonly signal?: ContainerNamespace.ContainerSignal };
+  | { readonly operation: "stop"; readonly signal?: ContainerNamespace.ContainerStopSignal }
+  | {
+      readonly operation: "waitForPort";
+      readonly options: ContainerNamespace.ContainerWaitOptions;
+    };
 
 const makeFake = (options?: {
   readonly fetchFailure?: unknown;
   readonly stopFailure?: unknown;
+  readonly waitForPortFailure?: unknown;
 }) => {
   const calls: Array<Call> = [];
   const response = new Response("container", {
@@ -60,6 +71,32 @@ const makeFake = (options?: {
       if (options?.stopFailure !== undefined) {
         throw options.stopFailure;
       }
+    },
+    waitForPort: async (waitOptions) => {
+      calls.push({ operation: "waitForPort", options: waitOptions });
+      if (options?.waitForPortFailure !== undefined) {
+        throw options.waitForPortFailure;
+      }
+
+      return 2;
+    },
+    setAllowedHosts: async (hosts) => {
+      calls.push({ operation: "setAllowedHosts", hosts });
+    },
+    setDeniedHosts: async (hosts) => {
+      calls.push({ operation: "setDeniedHosts", hosts });
+    },
+    allowHost: async (hostname) => {
+      calls.push({ operation: "allowHost", hostname });
+    },
+    denyHost: async (hostname) => {
+      calls.push({ operation: "denyHost", hostname });
+    },
+    removeAllowedHost: async (hostname) => {
+      calls.push({ operation: "removeAllowedHost", hostname });
+    },
+    removeDeniedHost: async (hostname) => {
+      calls.push({ operation: "removeDeniedHost", hostname });
     },
   };
   const namespace: ContainerNamespace.ContainerNamespaceResource = {
@@ -121,6 +158,8 @@ it.effect("supports static byName helpers", () => {
       status: "healthy",
     });
     yield* instance.start();
+    assert.strictEqual(yield* instance.waitForPort({ portToCheck: 8080 }), 2);
+    yield* instance.allowHost("api.example.com");
     yield* instance.stop();
     yield* instance.destroy;
     assert.strictEqual(yield* instance.rawUnsafe, fake.stub);
@@ -128,6 +167,54 @@ it.effect("supports static byName helpers", () => {
     const namespace = yield* TestContainers.rawUnsafe;
 
     assert.strictEqual(namespace, fake.namespace);
+  }).pipe(Effect.provide(fake.live));
+});
+
+it.effect("waits for ports and manages host policy on named instances", () => {
+  const fake = makeFake();
+
+  return Effect.gen(function* () {
+    const containers = yield* TestContainers;
+    const instance = yield* containers.getByName("sandbox-1");
+    const retries = yield* instance.waitForPort({ portToCheck: 8080, retries: 3 });
+
+    yield* instance.setAllowedHosts(["api.example.com", "cdn.example.com"]);
+    yield* instance.allowHost("registry.example.com");
+    yield* instance.removeAllowedHost("cdn.example.com");
+    yield* instance.setDeniedHosts(["evil.example.com"]);
+    yield* instance.denyHost("worse.example.com");
+    yield* instance.removeDeniedHost("evil.example.com");
+    yield* instance.stop(9);
+
+    assert.strictEqual(retries, 2);
+    assert.deepStrictEqual(fake.calls, [
+      { operation: "getByName", name: "sandbox-1" },
+      { operation: "waitForPort", options: { portToCheck: 8080, retries: 3 } },
+      { operation: "setAllowedHosts", hosts: ["api.example.com", "cdn.example.com"] },
+      { operation: "allowHost", hostname: "registry.example.com" },
+      { operation: "removeAllowedHost", hostname: "cdn.example.com" },
+      { operation: "setDeniedHosts", hosts: ["evil.example.com"] },
+      { operation: "denyHost", hostname: "worse.example.com" },
+      { operation: "removeDeniedHost", hostname: "evil.example.com" },
+      { operation: "stop", signal: 9 },
+    ]);
+  }).pipe(Effect.provide(fake.live));
+});
+
+it.effect("maps rejected waitForPort calls to ContainerOperationError", () => {
+  const cause = new Error("port never opened");
+  const fake = makeFake({ waitForPortFailure: cause });
+
+  return Effect.gen(function* () {
+    const error = yield* Effect.flip(
+      TestContainers.byName("sandbox-2").waitForPort({ portToCheck: 8080 }),
+    );
+
+    assert.instanceOf(error, ContainerNamespace.ContainerOperationError);
+    assert.strictEqual(error.binding, "CONTAINERS");
+    assert.strictEqual(error.instance, "sandbox-2");
+    assert.strictEqual(error.operation, "waitForPort");
+    assert.strictEqual(error.cause, cause);
   }).pipe(Effect.provide(fake.live));
 });
 
@@ -257,5 +344,41 @@ it("tracks the service requirement in the static API", () => {
 
   expectTypeOf(TestContainers.byName("render-4").fetch("https://container.test/")).toEqualTypeOf<
     Effect.Effect<Response, ContainerNamespace.ContainerOperationError, TestContainers>
+  >();
+
+  expectTypeOf(TestContainers.byName("render-4").waitForPort({ portToCheck: 8080 })).toEqualTypeOf<
+    Effect.Effect<number, ContainerNamespace.ContainerOperationError, TestContainers>
+  >();
+
+  expectTypeOf(
+    TestContainers.byName("render-4").setAllowedHosts(["api.example.com"] as const),
+  ).toEqualTypeOf<
+    Effect.Effect<void, ContainerNamespace.ContainerOperationError, TestContainers>
+  >();
+});
+
+type CodexSandbox = CloudflareContainer & {
+  runCode(source: string): Promise<string>;
+};
+type SandboxNamespace = globalThis.DurableObjectNamespace<CodexSandbox>;
+type SandboxStub = ReturnType<SandboxNamespace["getByName"]>;
+
+class Sandboxes extends ContainerNamespace.Tag<Sandboxes, SandboxNamespace>()("Sandboxes") {}
+
+it("preserves exact native namespace and stub types through rawUnsafe", () => {
+  expectTypeOf(Sandboxes.rawUnsafe).toEqualTypeOf<
+    Effect.Effect<SandboxNamespace, never, Sandboxes>
+  >();
+
+  expectTypeOf(Sandboxes.byName("codex").rawUnsafe).toEqualTypeOf<
+    Effect.Effect<SandboxStub, ContainerNamespace.ContainerOperationError, Sandboxes>
+  >();
+
+  expectTypeOf(Sandboxes.getByName("codex")).toEqualTypeOf<
+    Effect.Effect<
+      ContainerNamespace.ContainerInstanceClient<SandboxStub>,
+      ContainerNamespace.ContainerOperationError,
+      Sandboxes
+    >
   >();
 });

--- a/packages/effect-cf/tests/DurableObjectState.test.ts
+++ b/packages/effect-cf/tests/DurableObjectState.test.ts
@@ -66,6 +66,53 @@ it.effect("blockConcurrencyWhileOrReset intentionally rejects the callback on fa
   }),
 );
 
+it.effect("waitUntil runs background Effects with the caller's context", () =>
+  Effect.gen(function* () {
+    const { state, tracker } = makeRawDurableObjectState();
+    const service = DurableObjectState.fromDurableObjectState(state);
+    const completed: Array<string> = [];
+
+    yield* service
+      .waitUntil(
+        Effect.gen(function* () {
+          const { message } = yield* Effect.service(FailureMessage);
+
+          completed.push(message);
+        }),
+      )
+      .pipe(Effect.provideService(FailureMessage, { message: "background done" }));
+
+    assert.strictEqual(tracker.waitUntilPromises.length, 1);
+    yield* Effect.promise(() => Promise.all(tracker.waitUntilPromises));
+    assert.deepStrictEqual(completed, ["background done"]);
+
+    yield* service.waitUntil(Promise.resolve("raw"));
+    assert.strictEqual(tracker.waitUntilPromises.length, 2);
+  }),
+);
+
+it.effect("waitUntil propagate mode rejects the native waitUntil promise", () =>
+  Effect.gen(function* () {
+    const { state, tracker } = makeRawDurableObjectState();
+    const service = DurableObjectState.fromDurableObjectState(state);
+
+    yield* service.waitUntil(Effect.fail("background failure"), {
+      mode: "propagate",
+      onFailure: () => Effect.void,
+    });
+
+    assert.strictEqual(tracker.waitUntilPromises.length, 1);
+    const rejected = yield* Effect.promise(() =>
+      tracker.waitUntilPromises[0]!.then(
+        () => false,
+        () => true,
+      ),
+    );
+
+    assert.isTrue(rejected);
+  }),
+);
+
 it.effect("wraps hibernation metadata and abort helpers", () =>
   Effect.gen(function* () {
     const { state, tracker } = makeRawDurableObjectState();
@@ -111,6 +158,7 @@ interface BlockConcurrencyTracker {
   sockets: Array<WebSocket>;
   hibernatableTimeout: number | null;
   readonly abortReasons: Array<string | undefined>;
+  readonly waitUntilPromises: Array<Promise<unknown>>;
 }
 
 function makeRawDurableObjectState(): {
@@ -127,12 +175,15 @@ function makeRawDurableObjectState(): {
     sockets: [],
     hibernatableTimeout: null,
     abortReasons: [],
+    waitUntilPromises: [],
   };
 
   const state = {
     id: {} as globalThis.DurableObjectId,
     storage: makeRawDurableObjectStorage(),
-    waitUntil: () => {},
+    waitUntil: (promise: Promise<unknown>) => {
+      tracker.waitUntilPromises.push(promise);
+    },
     blockConcurrencyWhile: async <T>(callback: () => Promise<T>) => {
       tracker.calls += 1;
 


### PR DESCRIPTION
## Summary

Two consumer-driven additions from a Kommunikasie audit:

**ContainerNamespace caller-side primitives**
- `waitForPort(options: ContainerWaitOptions): Effect<number, ContainerOperationError>` on the instance, deferred, and static clients, preserving the native retry-count result.
- Runtime host-policy operations on all client surfaces: `setAllowedHosts`, `setDeniedHosts`, `allowHost`, `denyHost`, `removeAllowedHost`, `removeDeniedHost`. These only forward the native remote calls; applications continue to own hostname policy and outbound handlers. Public inputs are readonly; the wrapper copies where the native signature requires mutable arrays.
- `stop` accepts numeric signals (`ContainerStopSignal = ContainerSignal | number`), matching the installed `@cloudflare/containers@0.3.7` SDK.
- `ContainerNamespace.Tag<Self, Namespace>` takes an optional exact native namespace type (e.g. `DurableObjectNamespace<CodexSandbox>`); `rawUnsafe` on the namespace and named instances preserves that exact type, including extra subclass methods. Defaults keep existing consumers compiling unchanged.

**DurableObjectState.waitUntil accepts Effects**
- Overloads `waitUntil` to also take an Effect, run in the background with the caller's Effect context and the same `observe`/`propagate` failure modes as `WorkerContext.waitUntil` (implementation shared via an extracted scheduler). The Promise form is unchanged. This removes the need for consumers to capture a Context and call `Effect.runPromiseWith` to schedule background Effects from Durable Objects.

Also refreshes the stale `bun.lock` (main's lockfile predated the Version Packages 0.22.0 bump).

Two minor changesets included.

## Validation

- `vp run check` — pass
- `vp test` — 33 files, 227 passed, 1 pre-existing skip
- TDD: new behavioral/type tests were observed failing for the expected missing-API reasons before implementation (runtime failures + `vp run typecheck` exit 1), then green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)