### PR TITLE
fix: treat null workflow output as absent for non-complete statuses

### DIFF
--- a/.changeset/fix-workflow-null-output.md
+++ b/.changeset/fix-workflow-null-output.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": patch
+---
+
+Stop failing workflow status reads with `WorkflowResultDecodeError` when Cloudflare reports `output: null` for a non-complete instance. The wrapped `WorkflowInstance.status` now returns the real status (e.g. `errored`) with `Option.none()` output and the preserved `error`, while a completed workflow with a `Schema.Null` result still decodes `null` as `Option.some(null)`.

--- a/packages/effect-cf/src/WorkflowBinding.ts
+++ b/packages/effect-cf/src/WorkflowBinding.ts
@@ -177,8 +177,12 @@ export const makeClient = <
       status: operation("status", () => raw.status()).pipe(
         Effect.flatMap((status) =>
           Effect.gen(function* () {
+            // Cloudflare reports `output: null` as a no-output sentinel while an
+            // instance is not complete; only a complete instance may carry a real
+            // null result (e.g. Schema.Null).
             const output =
-              status.output === undefined
+              status.output === undefined ||
+              (status.output === null && status.status !== "complete")
                 ? Option.none<ResultValue>()
                 : Option.some(
                     yield* decodeResult(status.output).pipe(

--- a/packages/effect-cf/tests/WorkflowBinding.test.ts
+++ b/packages/effect-cf/tests/WorkflowBinding.test.ts
@@ -7,6 +7,68 @@ import { Effect, Option, Schema as S } from "effect";
 
 import { WorkflowBinding } from "../src/index";
 
+it.effect("returns an errored status with Option.none output when output is null", () => {
+  const workflowError = { name: "Error", message: "step failed" };
+  const rawInstance = {
+    id: "workflow-errored",
+    pause: async () => undefined,
+    resume: async () => undefined,
+    terminate: async () => undefined,
+    restart: async () => undefined,
+    status: async () => ({ status: "errored", error: workflowError, output: null }),
+    sendEvent: async () => undefined,
+  } as unknown as CloudflareWorkflowInstance;
+  const workflow = {
+    create: async () => rawInstance,
+    createBatch: async () => [rawInstance],
+    get: async () => rawInstance,
+  } as unknown as CloudflareWorkflow<unknown>;
+  const client = WorkflowBinding.makeClient({
+    binding: "TEST_WORKFLOW",
+    payload: S.Unknown,
+    result: S.Struct({ value: S.String }),
+  })(workflow);
+
+  return Effect.gen(function* () {
+    const instance = yield* client.get(rawInstance.id);
+    const status = yield* instance.status;
+
+    assert.strictEqual(status.status, "errored");
+    assert.isTrue(Option.isNone(status.output));
+    assert.deepStrictEqual(status.error, Option.some(workflowError));
+  });
+});
+
+it.effect("decodes a completed null output with a Null result schema as Option.some(null)", () => {
+  const rawInstance = {
+    id: "workflow-complete-null",
+    pause: async () => undefined,
+    resume: async () => undefined,
+    terminate: async () => undefined,
+    restart: async () => undefined,
+    status: async () => ({ status: "complete", error: null, output: null }),
+    sendEvent: async () => undefined,
+  } as unknown as CloudflareWorkflowInstance;
+  const workflow = {
+    create: async () => rawInstance,
+    createBatch: async () => [rawInstance],
+    get: async () => rawInstance,
+  } as unknown as CloudflareWorkflow<unknown>;
+  const client = WorkflowBinding.makeClient({
+    binding: "TEST_WORKFLOW",
+    payload: S.Unknown,
+    result: S.Null,
+  })(workflow);
+
+  return Effect.gen(function* () {
+    const instance = yield* client.get(rawInstance.id);
+    const status = yield* instance.status;
+
+    assert.strictEqual(status.status, "complete");
+    assert.deepStrictEqual(status.output, Option.some(null));
+  });
+});
+
 it.effect("normalizes a null Workflow status error to Option.none", () => {
   const rawInstance = {
     id: "workflow-1",


### PR DESCRIPTION
## Summary

- Fixes production failures like `Workflow result decode failed for binding "BASELINE_WORKFLOW" instance "...": Expected object` on effect-cf 0.23.0: reading `status` of a non-complete workflow instance no longer fails with `WorkflowResultDecodeError`.
- Cloudflare's `InstanceStatus` reports `output: null` as a no-output sentinel while an instance is queued/running/waiting/errored; `WorkflowBinding` decoded that `null` against the result schema (e.g. `Schema.Struct`), masking the real status and `status.error`. Null output now maps to `Option.none()` for non-complete statuses, and the errored status plus its `error` are surfaced.
- A completed workflow with a `Schema.Null` result schema still decodes `output: null` as `Option.some(null)`, so legitimate null results are not swallowed.

## Validation

- Red/green TDD: the new regression test (`returns an errored status with Option.none output when output is null`) first failed with `WorkflowResultDecodeError: Workflow result decode failed for binding "TEST_WORKFLOW" instance "workflow-errored": Expected object` — the exact production failure — then passed after the fix.
- `vp test packages/effect-cf/tests/WorkflowBinding.test.ts` — 3 tests passed (regression test, completed-`Schema.Null` guard test, existing null-error normalization test).
- `vp run check` — passed (exit 0).
- Patch changeset added for `effect-cf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)