### PR TITLE
feat: add Vitest Workers pool helpers

### DIFF
--- a/.changeset/calm-workers-test.md
+++ b/.changeset/calm-workers-test.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add an `effect-cf/vitest` entrypoint with Effect-native Workers environment, fetch, queue, execution-context, and scoped Workflow testing helpers for Cloudflare's Vitest Workers pool.

--- a/bun.lock
+++ b/bun.lock
@@ -289,7 +289,7 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "devDependencies": {
         "@cloudflare/containers": "catalog:",
         "@cloudflare/vitest-pool-workers": "catalog:",
@@ -304,6 +304,7 @@
         "vitest": "catalog:",
       },
       "peerDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.16.15",
         "@cloudflare/workers-types": "^4.20260611.1",
         "@effect/sql-d1": "4.0.0-beta.105",
         "@effect/sql-pg": "4.0.0-beta.105",
@@ -311,6 +312,7 @@
         "effect": "4.0.0-beta.105",
       },
       "optionalPeers": [
+        "@cloudflare/vitest-pool-workers",
         "@cloudflare/workers-types",
         "@effect/sql-pg",
       ],

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -43,6 +43,66 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `Workflow` - typed Workflow entrypoints, steps, starter clients, and instance types
 - `Rpc` - Cloudflare RPC type helpers and scoped disposal utilities
 - `WorkerConfig` - Effect `Config` helpers backed by Cloudflare `env`
+- `effect-cf/vitest` - Effect-native runners and scoped test helpers for Cloudflare's Vitest Workers pool
+
+## Vitest Workers Pool
+
+Install and configure
+[`@cloudflare/vitest-pool-workers`](https://github.com/cloudflare/workers-sdk/tree/main/packages/vitest-pool-workers#readme),
+then import the test-only helpers from `effect-cf/vitest`. The `fetch` runner
+constructs the Worker with the current test environment and waits for all
+`waitUntil` work before completing the Effect.
+
+```ts
+import { assert, it } from "@effect/vitest";
+import { Config, Effect } from "effect";
+import * as PoolWorkers from "effect-cf/vitest";
+
+import WorkerEntrypoint from "../src/index";
+
+it.effect("serves a request", () =>
+  Effect.gen(function* () {
+    const response = yield* PoolWorkers.fetch(
+      WorkerEntrypoint,
+      new Request("https://worker.test/health"),
+    );
+
+    assert.strictEqual(response.status, 200);
+  }),
+);
+
+it.effect("reads Wrangler vars", () =>
+  Config.string("APP_NAME").pipe(
+    Effect.tap((appName) => assert.strictEqual(appName, "test-app")),
+    Effect.provide(PoolWorkers.layer),
+  ),
+);
+```
+
+Queue consumers can be invoked with typed message bodies while retaining the
+pool's acknowledgement and retry result:
+
+```ts
+it.effect("acknowledges a job", () =>
+  Effect.gen(function* () {
+    const { result } = yield* PoolWorkers.queue(MyQueueConsumer, "jobs", [
+      {
+        id: "job-1",
+        timestamp: new Date(),
+        attempts: 1,
+        body: { accountId: "account-1" },
+      },
+    ]);
+
+    assert.deepStrictEqual(result.explicitAcks, ["job-1"]);
+  }),
+);
+```
+
+`withExecutionContext` supports lower-level tests that need a native
+`ExecutionContext`. `introspectWorkflow` and `introspectWorkflowInstance`
+acquire the pool's disposable Workflow introspectors in the current Effect
+scope, so use them inside `Effect.scoped`.
 
 ## Worker Example
 

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/HyperdrivePg.mjs",
       "default": "./dist/HyperdrivePg.mjs"
     },
+    "./vitest": {
+      "types": "./dist/Vitest.d.mts",
+      "import": "./dist/Vitest.mjs",
+      "default": "./dist/Vitest.mjs"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -53,6 +58,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.16.15",
     "@cloudflare/workers-types": "^4.20260611.1",
     "@effect/sql-d1": "4.0.0-beta.105",
     "@effect/sql-pg": "4.0.0-beta.105",
@@ -60,6 +66,9 @@
     "effect": "4.0.0-beta.105"
   },
   "peerDependenciesMeta": {
+    "@cloudflare/vitest-pool-workers": {
+      "optional": true
+    },
     "@cloudflare/workers-types": {
       "optional": true
     },

--- a/packages/effect-cf/src/Vitest.ts
+++ b/packages/effect-cf/src/Vitest.ts
@@ -1,0 +1,141 @@
+/**
+ * Effect-native helpers for tests running in Cloudflare's Vitest Workers pool.
+ *
+ * Import this module through the `effect-cf/vitest` subpath. It is intended to
+ * run inside the Workers test runtime, where `cloudflare:test` is available.
+ */
+import { env } from "cloudflare:workers";
+import {
+  createExecutionContext,
+  createMessageBatch,
+  getQueueResult,
+  introspectWorkflow as introspectWorkflowPromise,
+  introspectWorkflowInstance as introspectWorkflowInstancePromise,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { ConfigProvider, Effect, Layer } from "effect";
+
+import { WorkerConfig, WorkerEnvironment, type WorkerEnv } from "./Environment";
+
+const currentEnv: WorkerEnv = env;
+
+/**
+ * Provides the Workers pool environment as both {@link WorkerEnvironment} and
+ * the active Effect `ConfigProvider`.
+ */
+export const layer: Layer.Layer<WorkerEnvironment> = Layer.mergeAll(
+  Layer.succeed(WorkerEnvironment, currentEnv),
+  ConfigProvider.layer(WorkerConfig.providerFromEnv(currentEnv)),
+);
+
+/** Constructor shape shared by Effect-backed Worker entrypoints. */
+export interface WorkerConstructor<Instance> {
+  new (context: globalThis.ExecutionContext, env: WorkerEnv): Instance;
+}
+
+/**
+ * Creates an `ExecutionContext` and drains all `waitUntil` work before the
+ * returned effect completes, including when `use` fails or is interrupted.
+ */
+export const withExecutionContext = Effect.fn("effect-cf/vitest/withExecutionContext")(function* <
+  A,
+  E,
+  R,
+>(use: (context: globalThis.ExecutionContext) => Effect.Effect<A, E, R>) {
+  return yield* Effect.acquireUseRelease(Effect.sync(createExecutionContext), use, (context) =>
+    Effect.promise(() => waitOnExecutionContext(context)),
+  );
+});
+
+interface FetchWorker {
+  fetch(request: Request): Promise<Response>;
+}
+
+/**
+ * Invokes an Effect-backed Worker fetch handler and drains its `waitUntil`
+ * work before returning the response.
+ */
+export const fetch = Effect.fn("effect-cf/vitest/fetch")(function* <Instance extends FetchWorker>(
+  Worker: WorkerConstructor<Instance>,
+  request: Request,
+  workerEnv: WorkerEnv = currentEnv,
+) {
+  return yield* withExecutionContext(
+    Effect.fnUntraced(function* (context) {
+      const worker = new Worker(context, workerEnv);
+
+      return yield* Effect.promise(() => worker.fetch(request));
+    }),
+  );
+});
+
+interface QueueWorker {
+  queue(batch: globalThis.MessageBatch): Promise<void>;
+}
+
+/** Input message accepted by Pool Workers' `createMessageBatch` helper. */
+export type QueueMessage<Body> = {
+  readonly id: string;
+  readonly timestamp: Date;
+  readonly attempts: number;
+} & ({ readonly body: Body } | { readonly serializedBody: ArrayBuffer | ArrayBufferView });
+
+/** Acknowledgement and retry result returned by Pool Workers. */
+export type QueueResult = Awaited<ReturnType<typeof getQueueResult>>;
+
+/** Result of invoking a queue consumer through {@link queue}. */
+export interface QueueRunResult<Body> {
+  readonly batch: globalThis.MessageBatch<Body>;
+  readonly result: QueueResult;
+}
+
+/**
+ * Invokes an Effect-backed queue consumer, drains its `waitUntil` work, and
+ * returns Pool Workers' acknowledgement and retry result.
+ */
+export const queue = Effect.fn("effect-cf/vitest/queue")(function* <
+  Body,
+  Instance extends QueueWorker,
+>(
+  Worker: WorkerConstructor<Instance>,
+  queueName: string,
+  messages: ReadonlyArray<QueueMessage<Body>>,
+  workerEnv: WorkerEnv = currentEnv,
+): Effect.fn.Return<QueueRunResult<Body>> {
+  return yield* withExecutionContext(
+    Effect.fnUntraced(function* (context) {
+      const batch = createMessageBatch<Body>(queueName, [...messages]);
+      const worker = new Worker(context, workerEnv);
+
+      yield* Effect.promise(() => worker.queue(batch));
+
+      const result = yield* Effect.promise(() => getQueueResult(batch, context));
+
+      return { batch, result } satisfies QueueRunResult<Body>;
+    }),
+  );
+});
+
+type WorkflowBinding = Parameters<typeof introspectWorkflowPromise>[0];
+
+/**
+ * Acquires a Workflow introspector that is disposed when the surrounding
+ * Effect scope closes.
+ */
+export const introspectWorkflow = Effect.fn("effect-cf/vitest/introspectWorkflow")(function* (
+  workflow: WorkflowBinding,
+) {
+  return yield* Effect.acquireDisposable(Effect.promise(() => introspectWorkflowPromise(workflow)));
+});
+
+/**
+ * Acquires a Workflow instance introspector that is disposed when the
+ * surrounding Effect scope closes.
+ */
+export const introspectWorkflowInstance = Effect.fn("effect-cf/vitest/introspectWorkflowInstance")(
+  function* (workflow: WorkflowBinding, instanceId: string) {
+    return yield* Effect.acquireDisposable(
+      Effect.promise(() => introspectWorkflowInstancePromise(workflow, instanceId)),
+    );
+  },
+);

--- a/packages/effect-cf/tests/Vitest.worker.test.ts
+++ b/packages/effect-cf/tests/Vitest.worker.test.ts
@@ -1,0 +1,103 @@
+import { env } from "cloudflare:workers";
+import { assert, it } from "@effect/vitest";
+import { Config, Effect, Layer, Schema as S } from "effect";
+
+import { QueueDefinition, Worker, WorkerEnvironment } from "../src/index";
+import * as PoolWorkers from "../src/Vitest";
+
+it.effect("provides the Workers environment and config", () =>
+  Effect.gen(function* () {
+    const workerEnv = yield* WorkerEnvironment;
+    const appName = yield* Config.string("APP_NAME");
+
+    assert.strictEqual(workerEnv, env);
+    assert.strictEqual(appName, "effect-cf-tests");
+  }).pipe(Effect.provide(PoolWorkers.layer)),
+);
+
+it.effect("drains waitUntil work", () =>
+  Effect.gen(function* () {
+    let completed = false;
+
+    yield* PoolWorkers.withExecutionContext((context) =>
+      Effect.sync(() => {
+        context.waitUntil(
+          Promise.resolve().then(() => {
+            completed = true;
+          }),
+        );
+      }),
+    );
+
+    assert.strictEqual(completed, true);
+  }),
+);
+
+it.effect("drains waitUntil work when the test effect fails", () =>
+  Effect.gen(function* () {
+    let completed = false;
+
+    const error = yield* PoolWorkers.withExecutionContext((context) =>
+      Effect.gen(function* () {
+        context.waitUntil(
+          new Promise<void>((resolve) => {
+            setTimeout(() => {
+              completed = true;
+              resolve();
+            }, 1);
+          }),
+        );
+
+        return yield* Effect.fail("expected failure");
+      }),
+    ).pipe(Effect.flip);
+
+    assert.strictEqual(error, "expected failure");
+    assert.strictEqual(completed, true);
+  }),
+);
+
+it.effect("invokes an Effect Worker fetch handler", () => {
+  const TestWorker = Worker.make(Layer.empty, {
+    fetch: Effect.gen(function* () {
+      const request = yield* Worker.NativeRequest;
+
+      return new Response(new URL(request.url).pathname, { status: 201 });
+    }),
+  });
+
+  return Effect.gen(function* () {
+    const response = yield* PoolWorkers.fetch(TestWorker, new Request("https://worker.test/hello"));
+
+    assert.strictEqual(response.status, 201);
+    assert.strictEqual(yield* Effect.promise(() => response.text()), "/hello");
+  });
+});
+
+const TestQueue = QueueDefinition.make("VitestQueue", {
+  message: S.Struct({ value: S.String }),
+});
+
+const TestQueueConsumer = TestQueue.make(Layer.empty, {
+  queue: (batch) =>
+    Effect.forEach(batch.messages, (message) => message.ack, {
+      discard: true,
+    }),
+});
+
+it.effect("invokes a typed queue consumer and reports acknowledgements", () =>
+  Effect.gen(function* () {
+    const message: PoolWorkers.QueueMessage<{ readonly value: string }> = {
+      id: "message-1",
+      timestamp: new Date("2026-01-01T00:00:00Z"),
+      attempts: 1,
+      body: { value: "hello" },
+    };
+
+    const { batch, result } = yield* PoolWorkers.queue(TestQueueConsumer, "test-queue", [message]);
+
+    assert.strictEqual(batch.queue, "test-queue");
+    assert.deepStrictEqual(result.explicitAcks, ["message-1"]);
+    assert.deepStrictEqual(result.retryMessages, []);
+  }),
+);

--- a/packages/effect-cf/tests/wrangler.jsonc
+++ b/packages/effect-cf/tests/wrangler.jsonc
@@ -4,6 +4,9 @@
   "main": "./worker-fixture.ts",
   "compatibility_date": "2026-04-24",
   "compatibility_flags": ["nodejs_compat"],
+  "vars": {
+    "APP_NAME": "effect-cf-tests",
+  },
   "durable_objects": {
     "bindings": [
       {

--- a/packages/effect-cf/vite.config.ts
+++ b/packages/effect-cf/vite.config.ts
@@ -53,9 +53,9 @@ export default defineConfig({
     ],
   },
   pack: {
-    entry: ["src/index.ts", "src/HyperdrivePg.ts"],
+    entry: ["src/index.ts", "src/HyperdrivePg.ts", "src/Vitest.ts"],
     deps: {
-      neverBundle: ["cloudflare:workers"],
+      neverBundle: ["cloudflare:test", "cloudflare:workers"],
     },
     dts: {
       tsgo: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,13 @@ import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { createRecommendedVitePlusConfig } from "@danieljvdm/dev-kit/vite-plus";
 import { defineConfig } from "vite-plus";
 
-const testExcludes = ["**/node_modules/**", "**/dist/**", "**/.git/**", ".repos/**"];
+const testExcludes = [
+  "**/node_modules/**",
+  "**/dist/**",
+  "**/.git/**",
+  ".repos/**",
+  ".worktrees/**",
+];
 
 // Every workspace package exposes a pure `typecheck` script backed by the
 // Effect-patched TypeScript-Go compiler.


### PR DESCRIPTION
## Summary

- Add an effect-cf/vitest entrypoint with Effect-native environment, execution-context, fetch, queue, and scoped Workflow helpers.
- Publish and document the optional Vitest Workers pool integration with typed consumer examples.
- Exclude linked worktrees from root Vitest discovery.

## Validation

- vp run check — passed: build, formatting, 34 test files with 232 passing and 1 skipped, and all workspace typechecks.
- vp lint — 0 errors; 5 existing warnings.