### PR TITLE
refactor: remove legacy compatibility paths

### DIFF
--- a/.changeset/tidy-legacy-paths.md
+++ b/.changeset/tidy-legacy-paths.md
@@ -1,5 +1,5 @@
 ---
-"effect-cf": major
+"effect-cf": minor
 ---
 
 Remove compatibility APIs. Use `WorkerConfig.providerLayer`,

--- a/.changeset/tidy-legacy-paths.md
+++ b/.changeset/tidy-legacy-paths.md
@@ -1,0 +1,7 @@
+---
+"effect-cf": major
+---
+
+Remove compatibility APIs. Use `WorkerConfig.providerLayer`,
+`AnalyticsEngine.writeDataPoint` or `writeDataPoints`, and
+`DurableObjectAlarm.processDue`; Email sends now require structured builder messages.

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, Cach
 
 ## Install
 
-`effect-cf` currently targets Effect 4 beta.
+`effect-cf` targets Effect `4.0.0-beta.105`.
 
 ```bash
-bun add effect-cf "effect@^4.0.0-beta.65"
+bun add effect-cf "effect@4.0.0-beta.105"
 ```
 
 ```bash
-pnpm add effect-cf "effect@^4.0.0-beta.65"
+pnpm add effect-cf "effect@4.0.0-beta.105"
 ```
 
 ```bash
-npm install effect-cf "effect@^4.0.0-beta.65"
+npm install effect-cf "effect@4.0.0-beta.105"
 ```
 
 ## Design
@@ -189,12 +189,12 @@ const program = Effect.gen(function* () {
     doubles: [1],
   });
 
-  yield* analytics.writeBatch(
+  yield* analytics.writeDataPoints(
     [
       { indexes: ["example.com"], blobs: ["/pricing", "US"], doubles: [1] },
       { indexes: ["example.com"], blobs: ["/docs", "CA"], doubles: [1] },
     ],
-    { onInvalid: "drop", batchSize: 100 },
+    { onInvalid: "drop" },
   );
 });
 ```

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, Cach
 
 ## Install
 
-`effect-cf` targets Effect `4.0.0-beta.105`.
+`effect-cf` targets Effect `^4.0.0-beta.105`.
 
 ```bash
-bun add effect-cf "effect@4.0.0-beta.105"
+bun add effect-cf "effect@^4.0.0-beta.105"
 ```
 
 ```bash
-pnpm add effect-cf "effect@4.0.0-beta.105"
+pnpm add effect-cf "effect@^4.0.0-beta.105"
 ```
 
 ```bash
-npm install effect-cf "effect@4.0.0-beta.105"
+npm install effect-cf "effect@^4.0.0-beta.105"
 ```
 
 ## Design

--- a/bun.lock
+++ b/bun.lock
@@ -289,7 +289,7 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.23.1",
+      "version": "0.24.0",
       "devDependencies": {
         "@cloudflare/containers": "catalog:",
         "@cloudflare/vitest-pool-workers": "catalog:",
@@ -306,10 +306,10 @@
       "peerDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.21.3",
         "@cloudflare/workers-types": "^4.20260611.1",
-        "@effect/sql-d1": "4.0.0-beta.105",
-        "@effect/sql-pg": "4.0.0-beta.105",
-        "@effect/sql-sqlite-do": "4.0.0-beta.105",
-        "effect": "4.0.0-beta.105",
+        "@effect/sql-d1": "^4.0.0-beta.105",
+        "@effect/sql-pg": "^4.0.0-beta.105",
+        "@effect/sql-sqlite-do": "^4.0.0-beta.105",
+        "effect": "^4.0.0-beta.105",
       },
       "optionalPeers": [
         "@cloudflare/vitest-pool-workers",

--- a/examples/chat/workers/api/src/index.ts
+++ b/examples/chat/workers/api/src/index.ts
@@ -23,7 +23,7 @@ const ApiConfig = Config.all({
 });
 
 const layer = Layer.mergeAll(
-  WorkerConfig.layer,
+  WorkerConfig.providerLayer,
   AnalyticsWorker.layer({ binding: "ANALYTICS_WORKER" }),
   ChatRoom.layer({ binding: "CHAT_ROOM" }),
   UserCache.layer({ binding: "USER_CACHE" }),

--- a/examples/email/README.md
+++ b/examples/email/README.md
@@ -87,7 +87,3 @@ and let Cloudflare reject the message instead.
 Total message size is exposed as `Email.sendLimits.maxMessageBytes` but is not
 checked locally, because the encoded MIME size is only known once Cloudflare
 composes the message. Oversized messages fail with `E_CONTENT_TOO_LARGE`.
-
-Raw RFC 5322 messages built with `EmailMessage` from `cloudflare:email` are
-passed to the binding untouched, so existing Email Routing code keeps working
-alongside structured sends.

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -4,18 +4,18 @@ Effect-native Cloudflare primitives for Workers, Durable Objects, Containers, bi
 
 ## Install
 
-`effect-cf` currently targets Effect 4 beta.
+`effect-cf` targets Effect `4.0.0-beta.105`.
 
 ```bash
-bun add effect-cf "effect@^4.0.0-beta.65"
+bun add effect-cf "effect@4.0.0-beta.105"
 ```
 
 ```bash
-pnpm add effect-cf "effect@^4.0.0-beta.65"
+pnpm add effect-cf "effect@4.0.0-beta.105"
 ```
 
 ```bash
-npm install effect-cf "effect@^4.0.0-beta.65"
+npm install effect-cf "effect@4.0.0-beta.105"
 ```
 
 ## Goal
@@ -491,7 +491,7 @@ Onboard the sending domain under **Compute > Email Service > Email Sending**, th
 }
 ```
 
-Messages that violate a documented limit fail with `EmailValidationError` carrying every violation, without calling the binding. Use `layer({ binding, send: { validate: false } })` to skip validation and let Cloudflare reject the message instead. Raw RFC 5322 `EmailMessage` values are always passed through untouched, so the legacy `cloudflare:email` API keeps working.
+Messages that violate a documented limit fail with `EmailValidationError` carrying every violation, without calling the binding. Use `layer({ binding, send: { validate: false } })` to skip validation and let Cloudflare reject the message instead.
 
 Cloudflare's total message size limit is exposed as `Email.sendLimits.maxMessageBytes` but is not enforced, because the encoded MIME size is only known once Cloudflare composes the message. Oversized messages fail at the binding with `E_CONTENT_TOO_LARGE`.
 
@@ -511,7 +511,6 @@ export const RequestAnalyticsLayer = RequestAnalytics.layer({
   binding: "REQUEST_ANALYTICS",
   write: {
     onInvalid: "error",
-    batchSize: 100,
   },
 });
 
@@ -526,7 +525,7 @@ export const recordPageView = (request: Request) =>
       doubles: [1],
     });
 
-    yield* analytics.writeBatch(
+    yield* analytics.writeDataPoints(
       [
         {
           indexes: [url.hostname],

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -4,18 +4,18 @@ Effect-native Cloudflare primitives for Workers, Durable Objects, Containers, bi
 
 ## Install
 
-`effect-cf` targets Effect `4.0.0-beta.105`.
+`effect-cf` targets Effect `^4.0.0-beta.105`.
 
 ```bash
-bun add effect-cf "effect@4.0.0-beta.105"
+bun add effect-cf "effect@^4.0.0-beta.105"
 ```
 
 ```bash
-pnpm add effect-cf "effect@4.0.0-beta.105"
+pnpm add effect-cf "effect@^4.0.0-beta.105"
 ```
 
 ```bash
-npm install effect-cf "effect@4.0.0-beta.105"
+npm install effect-cf "effect@^4.0.0-beta.105"
 ```
 
 ## Goal

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -60,10 +60,10 @@
   "peerDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.21.3",
     "@cloudflare/workers-types": "^4.20260611.1",
-    "@effect/sql-d1": "4.0.0-beta.105",
-    "@effect/sql-pg": "4.0.0-beta.105",
-    "@effect/sql-sqlite-do": "4.0.0-beta.105",
-    "effect": "4.0.0-beta.105"
+    "@effect/sql-d1": "^4.0.0-beta.105",
+    "@effect/sql-pg": "^4.0.0-beta.105",
+    "@effect/sql-sqlite-do": "^4.0.0-beta.105",
+    "effect": "^4.0.0-beta.105"
   },
   "peerDependenciesMeta": {
     "@cloudflare/vitest-pool-workers": {

--- a/packages/effect-cf/src/AnalyticsEngine.ts
+++ b/packages/effect-cf/src/AnalyticsEngine.ts
@@ -132,15 +132,7 @@ export interface AnalyticsEngineWriteOptions {
   readonly onInvalid?: AnalyticsEngineInvalidWritePolicy;
 }
 
-export interface AnalyticsEngineWriteBatchOptions extends AnalyticsEngineWriteOptions {
-  /**
-   * Maximum points per native batch call. Values are clamped to Cloudflare's
-   * per-invocation limit.
-   */
-  readonly batchSize?: number;
-}
-
-export type AnalyticsEngineWritePolicy = AnalyticsEngineWriteBatchOptions;
+export type AnalyticsEngineWritePolicy = AnalyticsEngineWriteOptions;
 
 export interface AnalyticsEngineQueryResult<Row = AnalyticsEngineQueryRow> {
   readonly meta: ReadonlyArray<AnalyticsEngineQueryColumn>;
@@ -167,17 +159,9 @@ export interface AnalyticsEngineClient {
     dataPoint?: AnalyticsEngineDataPoint,
     options?: AnalyticsEngineWriteOptions,
   ) => Effect.Effect<void, AnalyticsEngineWriteError>;
-  readonly write: (
-    dataPoint?: AnalyticsEngineDataPoint,
-    options?: AnalyticsEngineWriteOptions,
-  ) => Effect.Effect<void, AnalyticsEngineWriteError>;
   readonly writeDataPoints: (
     dataPoints: ReadonlyArray<AnalyticsEngineDataPoint>,
-    options?: AnalyticsEngineWriteBatchOptions,
-  ) => Effect.Effect<void, AnalyticsEngineWriteError>;
-  readonly writeBatch: (
-    dataPoints: ReadonlyArray<AnalyticsEngineDataPoint>,
-    options?: AnalyticsEngineWriteBatchOptions,
+    options?: AnalyticsEngineWriteOptions,
   ) => Effect.Effect<void, AnalyticsEngineWriteError>;
   readonly rawUnsafe: Effect.Effect<AnalyticsEngineBinding>;
   readonly definition: AnalyticsEngineDefinition;
@@ -320,20 +304,11 @@ const tryAnalyticsEngineSync = <A>(
     catch: (cause) => analyticsEngineError(binding, operation, cause),
   });
 
-const normalizeBatchSize = (batchSize: number | undefined) => {
-  if (batchSize === undefined || !Number.isFinite(batchSize) || batchSize <= 0) {
-    return writeLimits.maxDataPointsPerInvocation;
-  }
-
-  return Math.min(Math.floor(batchSize), writeLimits.maxDataPointsPerInvocation);
-};
-
 const resolveWritePolicy = (
   defaults: AnalyticsEngineWritePolicy | undefined,
-  options: AnalyticsEngineWriteBatchOptions | undefined,
+  options: AnalyticsEngineWriteOptions | undefined,
 ) => ({
   onInvalid: options?.onInvalid ?? defaults?.onInvalid ?? "error",
-  batchSize: normalizeBatchSize(options?.batchSize ?? defaults?.batchSize),
 });
 
 const fieldPath = (prefix: string, field: string) => (prefix === "" ? field : `${prefix}.${field}`);
@@ -544,23 +519,10 @@ const writeChunks = (
   operation: string,
   dataset: AnalyticsEngineBinding,
   dataPoints: ReadonlyArray<AnalyticsEngineDataPoint>,
-  batchSize: number,
 ): Effect.Effect<void, AnalyticsEngineOperationError> =>
   Effect.gen(function* () {
-    const writeDataPoints = Reflect.get(dataset, "writeDataPoints");
-
-    for (let index = 0; index < dataPoints.length; index += batchSize) {
-      const chunk = dataPoints.slice(index, index + batchSize);
-
-      if (typeof writeDataPoints === "function") {
-        yield* tryAnalyticsEngineSync(binding, operation, () =>
-          writeDataPoints.call(dataset, chunk),
-        );
-      } else {
-        for (const point of chunk) {
-          yield* tryAnalyticsEngineSync(binding, operation, () => dataset.writeDataPoint(point));
-        }
-      }
+    for (const point of dataPoints) {
+      yield* tryAnalyticsEngineSync(binding, operation, () => dataset.writeDataPoint(point));
     }
   });
 
@@ -747,7 +709,7 @@ export const makeClient =
 
     const writeDataPoints = Effect.fn("AnalyticsEngine.writeDataPoints")(function* (
       dataPoints: ReadonlyArray<AnalyticsEngineDataPoint>,
-      options?: AnalyticsEngineWriteBatchOptions,
+      options?: AnalyticsEngineWriteOptions,
     ) {
       const policy = resolveWritePolicy(defaults, options);
       const validPoints = yield* validateDataPoints(
@@ -757,21 +719,13 @@ export const makeClient =
         policy,
       );
 
-      yield* writeChunks(
-        definition.binding,
-        "writeDataPoints",
-        dataset,
-        validPoints,
-        policy.batchSize,
-      );
+      yield* writeChunks(definition.binding, "writeDataPoints", dataset, validPoints);
     });
 
     return {
       definition,
       writeDataPoint,
-      write: writeDataPoint,
       writeDataPoints,
-      writeBatch: writeDataPoints,
       rawUnsafe: Effect.succeed(dataset),
     };
   };

--- a/packages/effect-cf/src/DurableObjectAlarm.ts
+++ b/packages/effect-cf/src/DurableObjectAlarm.ts
@@ -457,8 +457,6 @@ export const processDue = <R = never, E = never, OnFailureR = never, OnFailureE 
     return yield* durableObjectAlarm.processDueAlarms(handle, options);
   });
 
-export const process = processDue;
-
 export type AlarmPayloadSchema = S.Codec<any, any, never, never>;
 
 export type AlarmFailurePolicy = "ordered" | "retry" | "skip-and-advance-repeat";

--- a/packages/effect-cf/src/Email.ts
+++ b/packages/effect-cf/src/Email.ts
@@ -1,7 +1,6 @@
 import type {
   EmailAddress as CloudflareEmailAddress,
   EmailAttachment as CloudflareEmailAttachment,
-  EmailMessage as CloudflareEmailMessage,
   EmailSendResult as CloudflareEmailSendResult,
   SendEmail as CloudflareSendEmail,
 } from "@cloudflare/workers-types";
@@ -110,9 +109,7 @@ export interface EmailDefinition {
 
 export type EmailAddress = CloudflareEmailAddress;
 export type EmailAttachment = CloudflareEmailAttachment;
-export type EmailMessage = CloudflareEmailMessage;
 export type EmailMessageBuilder = Parameters<CloudflareSendEmail["send"]>[0];
-export type EmailSendInput = EmailMessage | EmailMessageBuilder;
 export type EmailSendResult = CloudflareEmailSendResult;
 export type EmailBinding = CloudflareSendEmail;
 export type EmailRecipients = string | EmailAddress | ReadonlyArray<string | EmailAddress>;
@@ -124,14 +121,11 @@ export interface EmailSendOptions {
 }
 
 interface EmailRuntimeBinding {
-  readonly send: (message: EmailSendInput) => Promise<EmailSendResult>;
+  readonly send: (message: EmailMessageBuilder) => Promise<EmailSendResult>;
 }
 
 export interface EmailClient {
-  readonly send: {
-    (message: EmailMessage): Effect.Effect<EmailSendResult, EmailSendError>;
-    (builder: EmailMessageBuilder): Effect.Effect<EmailSendResult, EmailSendError>;
-  };
+  readonly send: (message: EmailMessageBuilder) => Effect.Effect<EmailSendResult, EmailSendError>;
   readonly rawUnsafe: Effect.Effect<EmailBinding>;
   readonly definition: EmailDefinition;
 }
@@ -199,29 +193,6 @@ const tryEmailPromise = <A>(
     try: evaluate,
     catch: (cause) => emailError(binding, operation, cause),
   });
-
-const builderFields = [
-  "subject",
-  "html",
-  "text",
-  "cc",
-  "bcc",
-  "replyTo",
-  "attachments",
-  "headers",
-] as const;
-
-/**
- * Distinguishes structured Email Sending messages from raw MIME `EmailMessage`
- * values, which only carry envelope `from` and `to` addresses.
- */
-export const isEmailMessageBuilder = (message: EmailSendInput): message is EmailMessageBuilder => {
-  if (typeof message !== "object" || message === null) {
-    return false;
-  }
-
-  return builderFields.some((field) => Reflect.get(message, field) !== undefined);
-};
 
 const byteLength = (value: string) => textEncoder.encode(value).byteLength;
 
@@ -469,13 +440,13 @@ export const makeClient =
   (email: EmailBinding): EmailClient => {
     const runtime = email as EmailRuntimeBinding;
     const validate = options?.validate ?? true;
-    const send = Effect.fn("Email.send")(function* (message: EmailSendInput) {
-      if (validate && isEmailMessageBuilder(message)) {
+    const send = Effect.fn("Email.send")(function* (message: EmailMessageBuilder) {
+      if (validate) {
         yield* validateSendInput(definition.binding, "send", message);
       }
 
       return yield* tryEmailPromise(definition.binding, "send", () => runtime.send(message));
-    }) as EmailClient["send"];
+    });
 
     return {
       definition,

--- a/packages/effect-cf/src/Environment.ts
+++ b/packages/effect-cf/src/Environment.ts
@@ -41,7 +41,7 @@ type ScalarConfigKey = Extract<
  * const program = Effect.gen(function* () {
  *   const config = yield* AppConfig;
  *   // ...
- * }).pipe(Effect.provide(WorkerConfig.layer));
+ * }).pipe(Effect.provide(WorkerConfig.providerLayer));
  * ```
  *
  * Keys are constrained to scalar `Cloudflare.Env` properties (`string`,
@@ -108,9 +108,6 @@ export namespace WorkerConfig {
    */
   export const providerLayer: Layer.Layer<never, never, WorkerEnvironment> =
     ConfigProvider.layer(provider);
-
-  /** Alias for `providerLayer` for concise use in worker layers. */
-  export const layer: Layer.Layer<never, never, WorkerEnvironment> = providerLayer;
 
   /** Build a `ConfigProvider` layer with a custom `env` conversion function. */
   export const layerWith = (

--- a/packages/effect-cf/tests/AnalyticsEngine.test.ts
+++ b/packages/effect-cf/tests/AnalyticsEngine.test.ts
@@ -12,38 +12,20 @@ class RequestAnalyticsQuery extends AnalyticsEngine.QueryTag<RequestAnalyticsQue
 
 interface FakeAnalyticsEngineDataset extends AnalyticsEngine.AnalyticsEngineBinding {
   readonly points: Array<AnalyticsEngine.AnalyticsEngineDataPoint | undefined>;
-  readonly batches: Array<Array<AnalyticsEngine.AnalyticsEngineDataPoint>>;
-  readonly writeDataPoints?: (
-    dataPoints: ReadonlyArray<AnalyticsEngine.AnalyticsEngineDataPoint>,
-  ) => void;
 }
 
 const makeFakeAnalyticsEngineDataset = (
   writeDataPoint?: (dataPoint?: AnalyticsEngine.AnalyticsEngineDataPoint) => void,
-  options?: {
-    readonly nativeWriteDataPoints?: boolean;
-  },
 ): FakeAnalyticsEngineDataset => {
   const points: Array<AnalyticsEngine.AnalyticsEngineDataPoint | undefined> = [];
-  const batches: Array<Array<AnalyticsEngine.AnalyticsEngineDataPoint>> = [];
 
   return {
     points,
-    batches,
     writeDataPoint:
       writeDataPoint ??
       ((dataPoint) => {
         points.push(dataPoint);
       }),
-    ...(options?.nativeWriteDataPoints === true
-      ? {
-          writeDataPoints: (
-            dataPoints: ReadonlyArray<AnalyticsEngine.AnalyticsEngineDataPoint>,
-          ) => {
-            batches.push([...dataPoints]);
-          },
-        }
-      : {}),
   } as FakeAnalyticsEngineDataset;
 };
 
@@ -74,7 +56,11 @@ layer(analyticsLayer(makeFakeAnalyticsEngineDataset()))("AnalyticsEngine", (it) 
         blobs: ["/home", "US", null],
         doubles: [1, 42],
       });
-      yield* analytics.write({ indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] });
+      yield* analytics.writeDataPoint({
+        indexes: ["example.com"],
+        blobs: ["/pricing"],
+        doubles: [1],
+      });
 
       assert.deepStrictEqual((raw as FakeAnalyticsEngineDataset).points, [
         {
@@ -257,24 +243,25 @@ test("AnalyticsEngine hard-error policy can override a drop layer policy", async
   assert.deepStrictEqual(dataset.points, []);
 });
 
-test("AnalyticsEngine batches writeDataPoints through the native batch API when available", async () => {
-  const dataset = makeFakeAnalyticsEngineDataset(undefined, { nativeWriteDataPoints: true });
+test("AnalyticsEngine writes every point in a batch through the native binding", async () => {
+  const dataset = makeFakeAnalyticsEngineDataset();
 
   await Effect.runPromise(
     Effect.gen(function* () {
       const analytics = yield* RequestAnalytics;
 
-      yield* analytics.writeDataPoints(
-        [{ indexes: ["one"] }, { indexes: ["two"] }, { indexes: ["three"] }],
-        { batchSize: 2 },
-      );
+      yield* analytics.writeDataPoints([
+        { indexes: ["one"] },
+        { indexes: ["two"] },
+        { indexes: ["three"] },
+      ]);
     }).pipe(Effect.provide(analyticsLayer(dataset))),
   );
 
-  assert.deepStrictEqual(dataset.points, []);
-  assert.deepStrictEqual(dataset.batches, [
-    [{ indexes: ["one"] }, { indexes: ["two"] }],
-    [{ indexes: ["three"] }],
+  assert.deepStrictEqual(dataset.points, [
+    { indexes: ["one"] },
+    { indexes: ["two"] },
+    { indexes: ["three"] },
   ]);
 });
 
@@ -290,7 +277,7 @@ test("AnalyticsEngine enforces the per-invocation data point limit", async () =>
       Effect.gen(function* () {
         const analytics = yield* RequestAnalytics;
 
-        yield* analytics.writeBatch(dataPoints);
+        yield* analytics.writeDataPoints(dataPoints);
       }).pipe(Effect.provide(analyticsLayer(dataset))),
     ),
   ).rejects.toMatchObject({
@@ -321,7 +308,7 @@ test("AnalyticsEngine drops over-limit and invalid batch points when configured"
     Effect.gen(function* () {
       const analytics = yield* RequestAnalytics;
 
-      yield* analytics.writeBatch(dataPoints, { onInvalid: "drop" });
+      yield* analytics.writeDataPoints(dataPoints, { onInvalid: "drop" });
     }).pipe(Effect.provide(analyticsLayer(dataset))),
   );
 

--- a/packages/effect-cf/tests/Email.test.ts
+++ b/packages/effect-cf/tests/Email.test.ts
@@ -6,11 +6,11 @@ import { Binding, Email, WorkerEnvironment } from "../src/index";
 class TestEmail extends Email.Tag<TestEmail>()("test/TestEmail") {}
 
 interface SendCall {
-  readonly message: Email.EmailSendInput;
+  readonly message: Email.EmailMessageBuilder;
 }
 
 interface FakeEmailOptions {
-  readonly send?: (message: Email.EmailSendInput) => Promise<Email.EmailSendResult>;
+  readonly send?: (message: Email.EmailMessageBuilder) => Promise<Email.EmailSendResult>;
 }
 
 const makeFakeEmail = (options: FakeEmailOptions = {}) =>
@@ -57,34 +57,6 @@ const emailLayer = (email: SendEmail) =>
           text: "Welcome to Example",
           headers: { "X-Template": "welcome" },
         });
-      }),
-    );
-  });
-}
-
-{
-  const calls: Array<SendCall> = [];
-  const email = makeFakeEmail({
-    send: async (message) => {
-      calls.push({ message });
-
-      return { messageId: "email-message-1" };
-    },
-  });
-
-  layer(emailLayer(email))("Send Email native messages", (it) => {
-    it.effect("wraps native EmailMessage sends", () =>
-      Effect.gen(function* () {
-        const email = yield* TestEmail;
-        const message = {
-          from: "team@example.com",
-          to: "user@example.com",
-        } satisfies Email.EmailMessage;
-
-        const result = yield* email.send(message);
-
-        assert.strictEqual(result.messageId, "email-message-1");
-        assert.deepStrictEqual(calls[0]?.message, message);
       }),
     );
   });

--- a/packages/effect-cf/tests/Environment.test.ts
+++ b/packages/effect-cf/tests/Environment.test.ts
@@ -40,7 +40,7 @@ test("WorkerConfig.providerFromEnv preserves empty strings when requested", asyn
   expect(result).toBe("");
 });
 
-test("WorkerConfig.layer reads scalar config from WorkerEnvironment", async () => {
+test("WorkerConfig.providerLayer reads scalar config from WorkerEnvironment", async () => {
   const env = {
     DATABASE_URL: "postgres://example.test/app",
     SECRET_VALUE: "secret",
@@ -59,7 +59,7 @@ test("WorkerConfig.layer reads scalar config from WorkerEnvironment", async () =
         databaseUrl: Redacted.value(config.databaseUrl),
       };
     }).pipe(
-      Effect.provide(WorkerConfig.layer),
+      Effect.provide(WorkerConfig.providerLayer),
       Effect.provide(Layer.succeed(WorkerEnvironment, env)),
       Effect.orDie,
     ),

--- a/packages/effect-cf/tests/binding-ergonomics.test-d.ts
+++ b/packages/effect-cf/tests/binding-ergonomics.test-d.ts
@@ -252,11 +252,6 @@ const emailProgram = Effect.gen(function* () {
     ],
   });
 
-  yield* email.send({
-    from: "team@example.com",
-    to: "user@example.com",
-  } satisfies Email.EmailMessage);
-
   // @ts-expect-error builder messages require a subject.
   yield* email.send({
     from: "team@example.com",
@@ -324,7 +319,7 @@ export class RequestAnalytics extends AnalyticsEngine.Tag<RequestAnalytics>()("R
 
 export const RequestAnalyticsLayer = RequestAnalytics.layer({
   binding: "REQUEST_ANALYTICS",
-  write: { onInvalid: "drop", batchSize: 100 },
+  write: { onInvalid: "drop" },
 });
 
 export class RequestAnalyticsQuery extends AnalyticsEngine.QueryTag<RequestAnalyticsQuery>()(
@@ -367,7 +362,7 @@ const analyticsEngineProgram = Effect.gen(function* () {
   ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineWriteError>>();
 
   expectTypeOf(
-    analytics.write({ indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] }),
+    analytics.writeDataPoint({ indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] }),
   ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineWriteError>>();
 
   expectTypeOf(
@@ -376,12 +371,12 @@ const analyticsEngineProgram = Effect.gen(function* () {
         { indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] },
         { indexes: ["example.com"], blobs: ["/home"], doubles: [1] },
       ],
-      { onInvalid: "error", batchSize: 2 },
+      { onInvalid: "error" },
     ),
   ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineWriteError>>();
 
   expectTypeOf(
-    analytics.writeBatch([{ indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] }]),
+    analytics.writeDataPoints([{ indexes: ["example.com"], blobs: ["/pricing"], doubles: [1] }]),
   ).toEqualTypeOf<Effect.Effect<void, AnalyticsEngine.AnalyticsEngineWriteError>>();
 
   expectTypeOf(analytics.rawUnsafe).toEqualTypeOf<


### PR DESCRIPTION
## Summary

- Remove legacy aliases and compatibility adapters; use the canonical Analytics, WorkerConfig, Durable Object Alarm, and structured Email APIs.
- Align package-facing install docs and peer ranges with Effect `^4.0.0-beta.105`, and add a minor changeset.

## Validation

- `vp run check` — passed
- `vp test` — passed (240 tests, 1 skipped)