### PR TITLE
fix: flush telemetry after native RPC handlers

### DIFF
--- a/.changeset/calm-workers-flush.md
+++ b/.changeset/calm-workers-flush.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": patch
+---
+
+Flush configured OTLP telemetry after native Worker and Durable Object RPC handlers complete. Flush and scheduling failures keep the handler outcome unchanged and emit only bounded framework diagnostics.

--- a/packages/effect-cf/src/CloudflareOtlp.ts
+++ b/packages/effect-cf/src/CloudflareOtlp.ts
@@ -3,8 +3,12 @@
  *
  * Every layer exposes {@link OtlpExporter.Flusher}, which drains buffered
  * telemetry on demand. Cloudflare isolates can freeze before the periodic
- * export interval fires, so flush explicitly before returning a response, or
- * hand the flush to `ctx.waitUntil`:
+ * export interval fires. Effect-backed Worker fetch handlers and Worker or
+ * Durable Object native RPC handlers schedule this flusher automatically.
+ * Flush or scheduling failures do not replace the handler outcome and emit
+ * only bounded framework diagnostics without attaching the foreign cause.
+ * Other entrypoint lifecycles can flush explicitly or hand the flush to their
+ * `waitUntil` mechanism:
  *
  * ```ts
  * const flusher = yield* OtlpExporter.Flusher;

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -7,6 +7,7 @@ import { DurableObjectState, fromDurableObjectState } from "./DurableObjectState
 import { fromWebSocket, type DurableWebSocket } from "./DurableObjectWebSocket";
 import * as Entrypoint from "./internal/Entrypoint";
 import * as Runtime from "./internal/Runtime";
+import * as Telemetry from "./internal/Telemetry";
 
 const reservedMethodNames = new Set<string>([
   "constructor",
@@ -28,6 +29,11 @@ type RunOptions = {
 };
 
 const RunSymbol = Symbol.for("effect-cf/DurableObject/run");
+
+const scheduleTelemetryFlush: Effect.Effect<void, never, DurableObjectState> =
+  Telemetry.scheduleTelemetryFlush((flush) =>
+    Effect.flatMap(DurableObjectState, (state) => state.waitUntil(flush)),
+  );
 
 /**
  * Effect type for Durable Object lifecycle and RPC handlers.
@@ -98,7 +104,12 @@ export interface DurableObjectOptions<
    * Object storage if work must happen only once per id.
    */
   readonly initialize?: Effect.Effect<void, unknown, HandlerContext<RRuntime>>;
-  /** Optional RPC methods exposed as Durable Object instance methods. */
+  /**
+   * Optional RPC methods exposed as Durable Object instance methods.
+   *
+   * After every invocation, the configured OTLP flusher is scheduled through
+   * `DurableObjectState.waitUntil`, including when the handler fails.
+   */
   readonly rpc?: Rpc;
   /** Optional fetch handler for HTTP/WebSocket requests. */
   readonly fetch?: Effect.Effect<Response, unknown, FetchContext<RRuntime | REvent>>;
@@ -244,6 +255,7 @@ export const make = <
     options.rpc,
     reservedMethodNames,
     (self, effect) => self[RunSymbol](effect),
+    () => scheduleTelemetryFlush,
   );
 
   return Entrypoint.assumeEntrypointClass<DurableObjectClass<Rpc, ROut | REvent>>(

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -1,21 +1,13 @@
 import { WorkerEntrypoint as CloudflareWorkerEntrypoint } from "cloudflare:workers";
-import {
-  type Cause,
-  Context,
-  Effect,
-  Layer,
-  type ManagedRuntime,
-  Option,
-  type Scope,
-} from "effect";
+import { type Cause, Context, Effect, Layer, type ManagedRuntime, type Scope } from "effect";
 import { HttpEffect, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
-import { OtlpExporter } from "effect/unstable/observability";
 
 import { WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { fromMessage, fromMessageBatch, type QueueHandler } from "./Queue";
 import type * as RpcDefinition from "./RpcDefinition";
 import * as Entrypoint from "./internal/Entrypoint";
 import * as Runtime from "./internal/Runtime";
+import * as Telemetry from "./internal/Telemetry";
 import { fromExecutionContext } from "./internal/WorkerContext";
 
 /**
@@ -208,7 +200,12 @@ export interface WorkerOptions<
   >;
   /** Queue consumer handler invoked per message batch. */
   readonly queue?: QueueHandler<RRuntime | REvent>;
-  /** Optional RPC methods exposed as class instance methods. */
+  /**
+   * Optional RPC methods exposed as class instance methods.
+   *
+   * After every invocation, the configured OTLP flusher is scheduled through
+   * `WorkerContext.waitUntil`, including when the handler fails.
+   */
   readonly rpc?: Rpc;
 }
 
@@ -292,14 +289,10 @@ const isWorkerOptions = <ROut, REvent, EventLayerError, Rpc extends WorkerRpc<RO
  * (including streaming bodies still being consumed). It is a no-op when the
  * context does not contain an `OtlpExporter.Flusher`.
  */
-const scheduleTelemetryFlush: Effect.Effect<void, never, WorkerContext> = Effect.flatMap(
-  Effect.serviceOption(OtlpExporter.Flusher),
-  Option.match({
-    onNone: () => Effect.void,
-    onSome: (flusher) =>
-      Effect.flatMap(WorkerContext, (workerContext) => workerContext.waitUntil(flusher.flush)),
-  }),
-);
+const scheduleTelemetryFlush: Effect.Effect<void, never, WorkerContext> =
+  Telemetry.scheduleTelemetryFlush((flush) =>
+    Effect.flatMap(WorkerContext, (workerContext) => workerContext.waitUntil(flush)),
+  );
 
 /**
  * Creates a Cloudflare worker class backed by a single managed Effect runtime.
@@ -424,6 +417,7 @@ export function make<
     options.rpc,
     reservedMethodNames,
     (self, effect) => self[RunSymbol](effect),
+    () => scheduleTelemetryFlush,
   );
 
   return Entrypoint.assumeEntrypointClass<WorkerClass<Rpc, ROut | REvent>>(EffectWorker);

--- a/packages/effect-cf/src/internal/Entrypoint.ts
+++ b/packages/effect-cf/src/internal/Entrypoint.ts
@@ -19,6 +19,7 @@ export const defineEntrypointRpcMethods = <Self>(
   rpc: EntrypointRpc | undefined,
   reservedMethodNames: ReadonlySet<string>,
   run: (self: Self, effect: Effect.Effect<any, any, any>) => Promise<unknown>,
+  onExit?: (self: Self) => Effect.Effect<void, never, any>,
 ): void => {
   const methods = rpc ?? {};
 
@@ -28,11 +29,13 @@ export const defineEntrypointRpcMethods = <Self>(
     Object.defineProperty(prototype, key, {
       enumerable: true,
       value(this: Self, ...args: AnyArgs) {
+        const handler = Effect.suspend(() => method(...args)).pipe(
+          Effect.mapError(RpcDefinition.encodeWireError),
+        );
+
         return run(
           this,
-          Effect.suspend(() => method(...args)).pipe(
-            Effect.mapError(RpcDefinition.encodeWireError),
-          ),
+          onExit === undefined ? handler : handler.pipe(Effect.onExit(() => onExit(this))),
         );
       },
     });

--- a/packages/effect-cf/src/internal/Telemetry.ts
+++ b/packages/effect-cf/src/internal/Telemetry.ts
@@ -1,0 +1,27 @@
+import { Effect, Option } from "effect";
+import { OtlpExporter } from "effect/unstable/observability";
+
+const logFlushFailure = Effect.logError("Telemetry flush failed").pipe(Effect.ignoreCause);
+
+const logFlushSchedulingFailure = Effect.logError("Telemetry flush scheduling failed").pipe(
+  Effect.ignoreCause,
+);
+
+/**
+ * Schedules a configured OTLP flusher through the current Cloudflare event.
+ */
+export const scheduleTelemetryFlush = <R>(
+  waitUntil: (flush: Effect.Effect<void>) => Effect.Effect<void, never, R>,
+): Effect.Effect<void, never, R> =>
+  Effect.gen(function* () {
+    const flusher = yield* Effect.serviceOption(OtlpExporter.Flusher);
+
+    if (Option.isNone(flusher)) {
+      return;
+    }
+
+    // Exporters and platform schedulers are foreign boundaries. Preserve a
+    // useful diagnostic without retaining their arbitrary failure causes in
+    // logs, where payloads, headers, or credentials could otherwise escape.
+    yield* waitUntil(flusher.value.flush.pipe(Effect.catchCause(() => logFlushFailure)));
+  }).pipe(Effect.catchCause(() => logFlushSchedulingFailure));

--- a/packages/effect-cf/tests/CloudflareOtlp.test.ts
+++ b/packages/effect-cf/tests/CloudflareOtlp.test.ts
@@ -1,17 +1,34 @@
 import { NodeHttpServer } from "@effect/platform-node";
 import { expect, it, layer } from "@effect/vitest";
-import { ConfigProvider, Context, Effect, Layer, Queue } from "effect";
+import { ConfigProvider, Context, Effect, Layer, Queue, Schema as S } from "effect";
 import { HttpServer, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { OtlpExporter } from "effect/unstable/observability";
 import process from "node:process";
 
-import { CloudflareOtlp, Worker } from "../src/index";
+import { CloudflareOtlp, Worker, WorkerDefinition } from "../src/index";
+
+const TelemetryWorker = WorkerDefinition.make("CloudflareOtlpTelemetryWorker", {
+  run: WorkerDefinition.method({ success: S.String }),
+});
 
 const makeExecutionContext = (): globalThis.ExecutionContext => ({
   props: undefined,
   waitUntil: () => undefined,
   passThroughOnException: () => undefined,
 });
+
+const makeWaitUntilExecutionContext = () => {
+  const waitUntilPromises: Array<Promise<unknown>> = [];
+  const executionContext = {
+    props: undefined,
+    waitUntil: (promise: Promise<unknown>) => {
+      waitUntilPromises.push(promise);
+    },
+    passThroughOnException: () => undefined,
+  } as unknown as globalThis.ExecutionContext;
+
+  return { executionContext, waitUntilPromises };
+};
 
 const processEnv = process.env;
 
@@ -221,6 +238,49 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
       expect(getStringAttribute(resourceAttributes, "cloudflare.worker.name")).toBe("api-worker");
       expect(spans.map((span) => getString(span, "name"))).toContain("test.fetch");
       expect(getStringAttribute(spanAttributes, "route")).toBe("/");
+    }),
+  );
+
+  it.effect("exports WorkerDefinition RPC spans through waitUntil", () =>
+    Effect.gen(function* () {
+      const collector = yield* OtlpCollector;
+      const WorkerClass = TelemetryWorker.make(Layer.empty, {
+        eventLayer: CloudflareOtlp.layerWorker({
+          signals: ["traces"],
+          serialization: "json",
+          resource: { serviceName: "effect-cf-rpc-test" },
+          workerName: "rpc-worker",
+        }),
+        rpc: {
+          run: () =>
+            Effect.succeed("result").pipe(
+              Effect.withSpan("test.rpc", { attributes: { transport: "native-rpc" } }),
+            ),
+        },
+      });
+      const { executionContext, waitUntilPromises } = makeWaitUntilExecutionContext();
+      const worker = new WorkerClass(
+        executionContext,
+        makeEnv({
+          OTEL_TRACES_EXPORTER: "otlp",
+          OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: `${collector.endpoint}/v1/traces`,
+          OTEL_BSP_SCHEDULE_DELAY: "600000",
+        }),
+      );
+
+      const result = yield* Effect.promise(() => worker.run());
+
+      expect(result).toBe("result");
+      expect(waitUntilPromises).toHaveLength(1);
+
+      yield* Effect.promise(() => Promise.all(waitUntilPromises));
+
+      const request = yield* collector.nextRequest;
+
+      expect(request.path).toBe("/v1/traces");
+      expect(request.body).toContain("effect-cf-rpc-test");
+      expect(request.body).toContain("test.rpc");
+      expect(request.body).toContain("native-rpc");
     }),
   );
 
@@ -519,5 +579,37 @@ mapleSmokeTest("CloudflareOtlp exports Worker spans to Maple local OTLP", () =>
     );
 
     expect(response.status).toBe(200);
+  }),
+);
+
+mapleSmokeTest("CloudflareOtlp exports WorkerDefinition RPC spans to Maple local OTLP", () =>
+  Effect.gen(function* () {
+    const WorkerClass = TelemetryWorker.make(Layer.empty, {
+      eventLayer: CloudflareOtlp.layerWorker({
+        signals: ["traces"],
+        resource: { serviceName: "effect-cf-maple-rpc-smoke" },
+      }),
+      rpc: {
+        run: () => Effect.succeed("result").pipe(Effect.withSpan("maple.rpc")),
+      },
+    });
+    const { executionContext, waitUntilPromises } = makeWaitUntilExecutionContext();
+    const worker = new WorkerClass(
+      executionContext,
+      makeEnv({
+        OTEL_TRACES_EXPORTER: "otlp",
+        OTEL_EXPORTER_OTLP_ENDPOINT:
+          processEnv?.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://127.0.0.1:4318",
+        OTEL_SERVICE_NAME: "effect-cf-maple-rpc-smoke",
+        OTEL_BSP_SCHEDULE_DELAY: "600000",
+      }),
+    );
+
+    const result = yield* Effect.promise(() => worker.run());
+
+    expect(result).toBe("result");
+    expect(waitUntilPromises).toHaveLength(1);
+
+    yield* Effect.promise(() => Promise.all(waitUntilPromises));
   }),
 );

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -1,9 +1,27 @@
-import { Clock, Config, ConfigProvider, Context, Data, Effect, Layer, Stream } from "effect";
+import {
+  Cause,
+  Clock,
+  Config,
+  ConfigProvider,
+  Context,
+  Data,
+  Effect,
+  Layer,
+  Logger,
+  Schema as S,
+  Stream,
+} from "effect";
 import { HttpEffect, HttpServerResponse } from "effect/unstable/http";
 import { OtlpExporter } from "effect/unstable/observability";
 import { expect, test } from "vite-plus/test";
 
-import { DurableObject, Worker, WorkerConfig } from "../src/index";
+import {
+  DurableObject,
+  DurableObjectDefinition,
+  Worker,
+  WorkerConfig,
+  WorkerDefinition,
+} from "../src/index";
 
 class RenderValue extends Context.Service<RenderValue, string>()(
   "effect-cf/test/WorkerBoundary/RenderValue",
@@ -14,6 +32,15 @@ class EventValue extends Context.Service<EventValue, string>()(
 ) {}
 
 class BoomError extends Data.TaggedError("BoomError") {}
+
+const TelemetryWorker = WorkerDefinition.make("TelemetryWorker", {
+  succeed: WorkerDefinition.method({ success: S.String }),
+  fail: WorkerDefinition.method({ success: S.String }),
+});
+
+const TelemetryDurableObject = DurableObjectDefinition.make("TelemetryDurableObject", {
+  succeed: DurableObjectDefinition.method({ success: S.String }),
+});
 
 const makeExecutionContext = () =>
   ({
@@ -36,13 +63,52 @@ const makeWaitUntilContext = () => {
   return { executionContext, waitUntilPromises };
 };
 
-const makeDurableObjectState = () =>
+const makeDurableObjectState = (waitUntil: (promise: Promise<unknown>) => void = () => undefined) =>
   ({
     id: { toString: () => "durable-object:test" },
     storage: {},
-    waitUntil: () => undefined,
+    waitUntil,
     blockConcurrencyWhile: async <T>(callback: () => Promise<T>) => callback(),
   }) as unknown as globalThis.DurableObjectState;
+
+const makeFlusherProbeLayer = (flushes: Array<string>) =>
+  Layer.effectDiscard(
+    Effect.gen(function* () {
+      const flusher = yield* OtlpExporter.Flusher;
+
+      yield* flusher.register(
+        Effect.sync(() => {
+          flushes.push("flush");
+        }),
+      );
+    }),
+  ).pipe(Layer.provideMerge(OtlpExporter.layerFlusher));
+
+interface CapturedLog {
+  readonly cause: Cause.Cause<unknown>;
+  readonly level: string;
+  readonly message: unknown;
+}
+
+const makeCapturedLoggerLayer = (logs: Array<CapturedLog>) =>
+  Logger.layer([
+    Logger.make(({ cause, logLevel, message }) => {
+      logs.push({ cause, level: logLevel, message });
+    }),
+  ]);
+
+const expectBoundedTelemetryLog = (
+  logs: Array<CapturedLog>,
+  message: string,
+  foreignFailure: Error,
+) => {
+  expect(logs).toHaveLength(1);
+  expect(logs[0]?.level).toBe("Error");
+  expect(logs[0]?.message).toEqual([message]);
+  expect(logs[0]?.message).not.toContain(foreignFailure);
+  expect(String(logs[0]?.message)).not.toContain(foreignFailure.message);
+  expect(logs[0]?.cause.reasons).toEqual([]);
+};
 
 test("Worker.makeFetchHandler returns an ExportedHandler-compatible fetch object", async () => {
   const handler = Worker.makeFetchHandler(Layer.empty, {
@@ -118,6 +184,147 @@ test("Worker.fetch flushes runtime OTLP telemetry through waitUntil", async () =
   const response = await worker.fetch(new Request("https://worker.test/"));
 
   expect(response.status).toBe(200);
+  expect(waitUntilPromises).toHaveLength(1);
+
+  await Promise.all(waitUntilPromises);
+
+  expect(flushes).toEqual(["flush"]);
+});
+
+test("WorkerDefinition RPC schedules event-scoped OTLP telemetry after success", async () => {
+  const flushes: Array<string> = [];
+  const Live = TelemetryWorker.make(Layer.empty, {
+    eventLayer: makeFlusherProbeLayer(flushes),
+    rpc: {
+      succeed: () => Effect.succeed("result"),
+      fail: () => Effect.succeed("unused"),
+    },
+  });
+  const { executionContext, waitUntilPromises } = makeWaitUntilContext();
+  const worker = new Live(executionContext, {} as Cloudflare.Env);
+
+  await expect(worker.succeed()).resolves.toBe("result");
+  expect(waitUntilPromises).toHaveLength(1);
+
+  await Promise.all(waitUntilPromises);
+
+  expect(flushes).toEqual(["flush"]);
+});
+
+test("WorkerDefinition RPC preserves handler failure and still schedules telemetry", async () => {
+  const flushes: Array<string> = [];
+  const handlerFailure = new BoomError();
+  const Live = TelemetryWorker.make(Layer.empty, {
+    eventLayer: makeFlusherProbeLayer(flushes),
+    rpc: {
+      succeed: () => Effect.succeed("unused"),
+      fail: () => Effect.fail(handlerFailure),
+    },
+  });
+  const { executionContext, waitUntilPromises } = makeWaitUntilContext();
+  const worker = new Live(executionContext, {} as Cloudflare.Env);
+
+  await expect(worker.fail()).rejects.toBe(handlerFailure);
+  expect(waitUntilPromises).toHaveLength(1);
+
+  await Promise.all(waitUntilPromises);
+
+  expect(flushes).toEqual(["flush"]);
+});
+
+test("WorkerDefinition RPC does not schedule background work without a flusher", async () => {
+  const Live = TelemetryWorker.make(Layer.empty, {
+    rpc: {
+      succeed: () => Effect.succeed("result"),
+      fail: () => Effect.succeed("unused"),
+    },
+  });
+  const { executionContext, waitUntilPromises } = makeWaitUntilContext();
+  const worker = new Live(executionContext, {} as Cloudflare.Env);
+
+  await expect(worker.succeed()).resolves.toBe("result");
+  expect(waitUntilPromises).toHaveLength(0);
+});
+
+test("WorkerDefinition RPC logs a bounded diagnostic for telemetry flush failure", async () => {
+  const secret = "Bearer sensitive-exporter-credential";
+  const flushFailure = Object.assign(new Error(`foreign exporter failure: ${secret}`), {
+    headers: { authorization: secret },
+    payload: { secret },
+  });
+  const logs: Array<CapturedLog> = [];
+  let flushAttempts = 0;
+  const failingFlusher = Layer.succeed(OtlpExporter.Flusher, {
+    flush: Effect.sync(() => {
+      flushAttempts++;
+      throw flushFailure;
+    }),
+    register: () => Effect.void,
+  });
+  const Live = TelemetryWorker.make(Layer.mergeAll(failingFlusher, makeCapturedLoggerLayer(logs)), {
+    rpc: {
+      succeed: () => Effect.succeed("result"),
+      fail: () => Effect.succeed("unused"),
+    },
+  });
+  const { executionContext, waitUntilPromises } = makeWaitUntilContext();
+  const worker = new Live(executionContext, {} as Cloudflare.Env);
+
+  await expect(worker.succeed()).resolves.toBe("result");
+  expect(waitUntilPromises).toHaveLength(1);
+  await expect(Promise.all(waitUntilPromises)).resolves.toEqual([undefined]);
+  expect(flushAttempts).toBe(1);
+  expectBoundedTelemetryLog(logs, "Telemetry flush failed", flushFailure);
+});
+
+test("WorkerDefinition RPC logs a bounded diagnostic for telemetry scheduling failure", async () => {
+  const handlerFailure = new BoomError();
+  const secret = "Bearer sensitive-platform-credential";
+  const schedulingFailure = Object.assign(new Error(`foreign waitUntil failure: ${secret}`), {
+    headers: { authorization: secret },
+    payload: { secret },
+  });
+  const logs: Array<CapturedLog> = [];
+  let schedulingAttempts = 0;
+  const Live = TelemetryWorker.make(
+    Layer.mergeAll(OtlpExporter.layerFlusher, makeCapturedLoggerLayer(logs)),
+    {
+      rpc: {
+        succeed: () => Effect.succeed("unused"),
+        fail: () => Effect.fail(handlerFailure),
+      },
+    },
+  );
+  const executionContext = {
+    props: undefined,
+    waitUntil: () => {
+      schedulingAttempts++;
+      throw schedulingFailure;
+    },
+    passThroughOnException: () => undefined,
+  } as unknown as globalThis.ExecutionContext;
+  const worker = new Live(executionContext, {} as Cloudflare.Env);
+
+  await expect(worker.fail()).rejects.toBe(handlerFailure);
+  expect(schedulingAttempts).toBe(1);
+  expectBoundedTelemetryLog(logs, "Telemetry flush scheduling failed", schedulingFailure);
+});
+
+test("DurableObjectDefinition RPC uses DurableObjectState.waitUntil for telemetry", async () => {
+  const flushes: Array<string> = [];
+  const waitUntilPromises: Array<Promise<unknown>> = [];
+  const Live = TelemetryDurableObject.make(Layer.empty, {
+    eventLayer: makeFlusherProbeLayer(flushes),
+    rpc: {
+      succeed: () => Effect.succeed("result"),
+    },
+  });
+  const durableObject = new Live(
+    makeDurableObjectState((promise) => waitUntilPromises.push(promise)),
+    {} as Cloudflare.Env,
+  );
+
+  await expect(durableObject.succeed()).resolves.toBe("result");
   expect(waitUntilPromises).toHaveLength(1);
 
   await Promise.all(waitUntilPromises);


### PR DESCRIPTION
## Summary

- Automatically schedule the configured OTLP flusher after every native Worker RPC invocation, on success or failure, without changing the RPC result.
- Apply the same shared exit hook to Durable Object RPC, the only mechanically equivalent native RPC entrypoint surface.
- Keep telemetry best-effort while logging only bounded, framework-owned flush/scheduling diagnostics; arbitrary exporter and platform causes are never attached automatically.
- Document the lifecycle and failure policy, add a patch changeset, and cover the behavior with boundary, real OTLP collector, Workers runtime, and opt-in Maple tests.

## Cause and lifecycle

`WorkerDefinition` delegates native RPC methods to `Worker.make`, but only the fetch path scheduled `OtlpExporter.Flusher`. Calls through `ctx.exports` therefore bypassed the flush boundary and could leave event telemetry buffered; the downstream emergency workaround added `Effect.ensuring(flushTelemetry)` to each RPC handler in [kommunikasie#353](https://github.com/reve-ai/kommunikasie/pull/353).

Cloudflare exposes [`this.ctx` on `WorkerEntrypoint` and supports `ctx.waitUntil()` from RPC methods](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/rpc/#lifecycle-methods-ctx). An RPC call has its own [execution context, which `waitUntil` extends past the method return](https://developers.cloudflare.com/workers/runtime-apis/rpc/lifecycle/#end-of-event-handler--execution-context).

The [shared native RPC installer](https://github.com/danieljvdm/effect-cf/blob/a8c9ac5ecd28ae236f4ce50a83aba412e09bd618/packages/effect-cf/src/internal/Entrypoint.ts#L16-L43) now runs a parameterless `Effect.onExit` hook for success, typed failure, and defect. It does not receive or retain the handler result/cause. [Worker RPC](https://github.com/danieljvdm/effect-cf/blob/a8c9ac5ecd28ae236f4ce50a83aba412e09bd618/packages/effect-cf/src/Worker.ts#L414-L421) uses the current `WorkerContext.waitUntil`; [Durable Object RPC](https://github.com/danieljvdm/effect-cf/blob/a8c9ac5ecd28ae236f4ce50a83aba412e09bd618/packages/effect-cf/src/DurableObject.ts#L252-L259) uses `DurableObjectState.waitUntil`.

The RPC promise waits only for synchronous registration, not export. The background flush starts under the captured Effect context and is handed to Cloudflare before the event scope closes; `waitUntil` keeps the event alive for that promise. This is lifecycle extension, not durable delivery: Cloudflare documents that caller disconnection can still cancel the RPC execution context.

## Failure and privacy policy

The original scheduling wrapper used `Effect.ignoreCause({ log: ... })`, which attaches the full scheduling `Cause`, while the default `waitUntil` observer pretty-printed a failed flush `Cause`. Either could recursively expose failed telemetry payloads, headers, credentials, or host-added values.

The [central telemetry scheduler](https://github.com/danieljvdm/effect-cf/blob/a8c9ac5ecd28ae236f4ce50a83aba412e09bd618/packages/effect-cf/src/internal/Telemetry.ts#L4-L27) now catches exporter failure before it reaches the generic `waitUntil` observer and catches platform registration failure at the helper boundary. It emits exactly `Telemetry flush failed` or `Telemetry flush scheduling failed` with an empty log `Cause`; the logging effects are themselves cause-ignored so logger defects cannot replace the handler result. A missing flusher remains a no-op.

This helper is also used by the existing Worker fetch path, so all automatic flush paths share the same bounded failure policy. Generated Worker and Durable Object methods are the only mechanically equivalent native RPC surfaces. Queue, scheduled, Workflow `run`, Durable Object fetch/alarm, and WebSocket callbacks are platform event APIs rather than generated native RPC methods, so this PR does not broaden their lifecycle behavior; they can flush explicitly through their event `waitUntil` mechanism.

## Compatibility

- RPC return values, rejection objects/causes, schemas, and public method signatures are unchanged.
- Applications without `OtlpExporter.Flusher` register no background work.
- Applications with a flusher gain one lifecycle-managed flush per native Worker or Durable Object RPC invocation and can remove per-method flush wrappers.
- Flush/export/scheduling failures remain observed and non-replacing, but their automatic log output is intentionally redacted to fixed framework diagnostics.
- The change is generic to Effect OTLP telemetry; it adds no Sentry or effect-agent concepts.

## Validation

- [`WorkerBoundary.test.ts`](https://github.com/danieljvdm/effect-cf/blob/a8c9ac5ecd28ae236f4ce50a83aba412e09bd618/packages/effect-cf/tests/WorkerBoundary.test.ts#L194-L337) proves success, exact handler failure preservation, no-flusher behavior, flush failure, scheduling failure, sensitive foreign `Error`/message non-reachability from captured log message/cause, and Durable Object parity.
- [`CloudflareOtlp.test.ts`](https://github.com/danieljvdm/effect-cf/blob/a8c9ac5ecd28ae236f4ce50a83aba412e09bd618/packages/effect-cf/tests/CloudflareOtlp.test.ts#L244-L285) drives a real local OTLP HTTP collector with a long batch delay, proves the native RPC returns first, awaits the captured `waitUntil` promise, and then asserts the exported service/span/attribute payload.
- `vp test packages/effect-cf/tests/WorkerBoundary.test.ts packages/effect-cf/tests/CloudflareOtlp.test.ts` — passed, 33 tests; 2 opt-in Maple tests skipped.
- `MAPLE_OTLP_SMOKE=1 OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:14318 vp test packages/effect-cf/tests/CloudflareOtlp.test.ts` — passed, 12 tests. The committed [RPC Maple smoke](https://github.com/danieljvdm/effect-cf/blob/a8c9ac5ecd28ae236f4ce50a83aba412e09bd618/packages/effect-cf/tests/CloudflareOtlp.test.ts#L585-L614) awaits the registered flush.
- A temporary production-shaped Workers fixture exercised native `ctx.exports` and `vp test packages/effect-cf/tests/workers-runtime.worker.test.ts` passed all 3 tests; Maple then returned `maple.ctx_exports.rpc` for service `effect-cf-maple-ctx-exports-smoke`, status `Ok`, with `cloudflare.resource_type=worker`. The fixture/config edits were reverted and are not part of this PR.
- After the later 12-test opt-in run passed, the detached local Maple process exited and left its temporary store dirty. A follow-up `maple traces` query failed with `Unable to connect. Is the computer able to access the url?`, and a read-only restart attempt reported that the store was not cleanly closed. The store was not reset, restored, or deleted; this happened after the successful smoke and is treated as unrelated local collector teardown.
- `vp check` — passed with 0 errors and 5 pre-existing warnings.
- `vp run check` — passed after the final diff: package build, formatting, lint, all 34 test files (`247 passed`, `2 opt-in skipped`), and workspace typechecks.
