### PR TITLE
fix: flush telemetry after Durable Object alarms

### DIFF
--- a/.changeset/quiet-alarms-flush.md
+++ b/.changeset/quiet-alarms-flush.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": patch
+---
+
+Flush configured OTLP telemetry after Durable Object alarm handlers, including failed alarms, so buffered telemetry is exported consistently with fetch and native RPC handlers.

--- a/packages/effect-cf/src/CloudflareOtlp.ts
+++ b/packages/effect-cf/src/CloudflareOtlp.ts
@@ -3,8 +3,9 @@
  *
  * Every layer exposes {@link OtlpExporter.Flusher}, which drains buffered
  * telemetry on demand. Cloudflare isolates can freeze before the periodic
- * export interval fires. Effect-backed Worker fetch handlers and Worker or
- * Durable Object native RPC handlers schedule this flusher automatically.
+ * export interval fires. Effect-backed Worker fetch handlers, Worker or
+ * Durable Object native RPC handlers, and Durable Object alarm handlers
+ * schedule this flusher automatically.
  * Flush or scheduling failures do not replace the handler outcome and emit
  * only bounded framework diagnostics without attaching the foreign cause.
  * Other entrypoint lifecycles can flush explicitly or hand the flush to their

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -121,6 +121,12 @@ export interface DurableObjectOptions<
    * the Durable Object's single managed runtime boundary.
    */
   readonly alarms?: Effect.Effect<unknown, unknown, HandlerContext<RRuntime | REvent>>;
+  /**
+   * Optional raw alarm handler.
+   *
+   * After every invocation, the configured OTLP flusher is scheduled through
+   * `DurableObjectState.waitUntil`, including when the handler fails.
+   */
   readonly alarm?: (
     alarmInfo?: globalThis.AlarmInvocationInfo,
   ) => Effect.Effect<void, unknown, HandlerContext<RRuntime | REvent>>;
@@ -204,22 +210,16 @@ export const make = <
     alarm(alarmInfo?: globalThis.AlarmInvocationInfo): Promise<void> | void {
       const logicalAlarms = options.alarms?.pipe(Effect.asVoid);
       const rawAlarm = options.alarm?.(alarmInfo);
+      const alarmEffect =
+        logicalAlarms !== undefined && rawAlarm !== undefined
+          ? Effect.gen(function* () {
+              yield* logicalAlarms;
+              yield* rawAlarm;
+            })
+          : (logicalAlarms ?? rawAlarm);
 
-      if (logicalAlarms !== undefined && rawAlarm !== undefined) {
-        return this[RunSymbol](
-          Effect.gen(function* () {
-            yield* logicalAlarms;
-            yield* rawAlarm;
-          }),
-        );
-      }
-
-      if (logicalAlarms !== undefined) {
-        return this[RunSymbol](logicalAlarms);
-      }
-
-      if (rawAlarm !== undefined) {
-        return this[RunSymbol](rawAlarm);
+      if (alarmEffect !== undefined) {
+        return this[RunSymbol](alarmEffect.pipe(Effect.onExit(() => scheduleTelemetryFlush)));
       }
     }
 

--- a/packages/effect-cf/tests/CloudflareOtlp.test.ts
+++ b/packages/effect-cf/tests/CloudflareOtlp.test.ts
@@ -5,7 +5,7 @@ import { HttpServer, HttpServerRequest, HttpServerResponse } from "effect/unstab
 import { OtlpExporter } from "effect/unstable/observability";
 import process from "node:process";
 
-import { CloudflareOtlp, Worker, WorkerDefinition } from "../src/index";
+import { CloudflareOtlp, DurableObject, Worker, WorkerDefinition } from "../src/index";
 
 const TelemetryWorker = WorkerDefinition.make("CloudflareOtlpTelemetryWorker", {
   run: WorkerDefinition.method({ success: S.String }),
@@ -28,6 +28,20 @@ const makeWaitUntilExecutionContext = () => {
   } as unknown as globalThis.ExecutionContext;
 
   return { executionContext, waitUntilPromises };
+};
+
+const makeWaitUntilDurableObjectState = () => {
+  const waitUntilPromises: Array<Promise<unknown>> = [];
+  const state = {
+    id: { toString: () => "durable-object:telemetry-test" },
+    storage: {},
+    waitUntil: (promise: Promise<unknown>) => {
+      waitUntilPromises.push(promise);
+    },
+    blockConcurrencyWhile: async <A>(callback: () => Promise<A>) => callback(),
+  } as unknown as globalThis.DurableObjectState;
+
+  return { state, waitUntilPromises };
 };
 
 const processEnv = process.env;
@@ -281,6 +295,46 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
       expect(request.body).toContain("effect-cf-rpc-test");
       expect(request.body).toContain("test.rpc");
       expect(request.body).toContain("native-rpc");
+    }),
+  );
+
+  it.effect("exports Durable Object alarm spans through waitUntil", () =>
+    Effect.gen(function* () {
+      const collector = yield* OtlpCollector;
+      const DurableObjectClass = DurableObject.make(Layer.empty, {
+        eventLayer: CloudflareOtlp.layerDurableObject({
+          signals: ["traces"],
+          serialization: "json",
+          resource: { serviceName: "effect-cf-alarm-test" },
+          className: "TelemetryAlarm",
+        }),
+        alarm: () =>
+          Effect.void.pipe(
+            Effect.withSpan("test.alarm", { attributes: { transport: "durable-object-alarm" } }),
+          ),
+      });
+      const { state, waitUntilPromises } = makeWaitUntilDurableObjectState();
+      const durableObject = new DurableObjectClass(
+        state,
+        makeEnv({
+          OTEL_TRACES_EXPORTER: "otlp",
+          OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: `${collector.endpoint}/v1/traces`,
+          OTEL_BSP_SCHEDULE_DELAY: "600000",
+        }),
+      );
+
+      yield* Effect.promise(() => Promise.resolve(durableObject.alarm?.()));
+
+      expect(waitUntilPromises).toHaveLength(1);
+
+      yield* Effect.promise(() => Promise.all(waitUntilPromises));
+
+      const request = yield* collector.nextRequest;
+
+      expect(request.path).toBe("/v1/traces");
+      expect(request.body).toContain("effect-cf-alarm-test");
+      expect(request.body).toContain("test.alarm");
+      expect(request.body).toContain("durable-object-alarm");
     }),
   );
 
@@ -608,6 +662,36 @@ mapleSmokeTest("CloudflareOtlp exports WorkerDefinition RPC spans to Maple local
     const result = yield* Effect.promise(() => worker.run());
 
     expect(result).toBe("result");
+    expect(waitUntilPromises).toHaveLength(1);
+
+    yield* Effect.promise(() => Promise.all(waitUntilPromises));
+  }),
+);
+
+mapleSmokeTest("CloudflareOtlp exports Durable Object alarm spans to Maple local OTLP", () =>
+  Effect.gen(function* () {
+    const DurableObjectClass = DurableObject.make(Layer.empty, {
+      eventLayer: CloudflareOtlp.layerDurableObject({
+        signals: ["traces"],
+        resource: { serviceName: "effect-cf-maple-alarm-smoke" },
+        className: "MapleTelemetryAlarm",
+      }),
+      alarm: () => Effect.void.pipe(Effect.withSpan("maple.alarm")),
+    });
+    const { state, waitUntilPromises } = makeWaitUntilDurableObjectState();
+    const durableObject = new DurableObjectClass(
+      state,
+      makeEnv({
+        OTEL_TRACES_EXPORTER: "otlp",
+        OTEL_EXPORTER_OTLP_ENDPOINT:
+          processEnv?.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://127.0.0.1:4318",
+        OTEL_SERVICE_NAME: "effect-cf-maple-alarm-smoke",
+        OTEL_BSP_SCHEDULE_DELAY: "600000",
+      }),
+    );
+
+    yield* Effect.promise(() => Promise.resolve(durableObject.alarm?.()));
+
     expect(waitUntilPromises).toHaveLength(1);
 
     yield* Effect.promise(() => Promise.all(waitUntilPromises));


### PR DESCRIPTION
## Summary

- Flush configured OTLP telemetry after Durable Object alarm handlers finish, including failed alarms.
- Add deterministic collector coverage and an opt-in Maple smoke test for alarm spans.

## Validation

- `vp run check` — passed (248 tests passed, 3 opt-in Maple tests skipped; 5 existing lint warnings remain in untouched files)
- `MAPLE_OTLP_SMOKE=1 vp test run packages/effect-cf/tests/CloudflareOtlp.test.ts -t "exports Durable Object alarm spans to Maple local OTLP"` — passed against an isolated local Maple instance
- `maple traces --local --since 5m --service effect-cf-maple-alarm-smoke --span-name maple.alarm --limit 5` — returned the `maple.alarm` span with status `Ok` and the expected Durable Object resource attributes