### PR TITLE
feat: add effect-webtransport package and truthful Workers WebTransport boundary

### DIFF
--- a/.changeset/effect-cf-webtransport-boundary.md
+++ b/.changeset/effect-cf-webtransport-boundary.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add the `WebTransport` module: a truthful WebTransport/HTTP-3 boundary for Workers. `inboundTransport` decodes the HTTP protocol metadata Cloudflare's edge attaches to requests (`httpProtocol`, `clientQuicRtt`, `clientTcpRtt`) with `isHttp3` on top; `capabilities` feature-detects what the runtime provides; and `inboundSessionsUnsupported` is an explicit typed boundary for the inbound WebTransport session API that workerd does not have (cloudflare/workerd#6451).

--- a/.changeset/effect-webtransport-initial.md
+++ b/.changeset/effect-webtransport-initial.md
@@ -1,0 +1,5 @@
+---
+"effect-webtransport": minor
+---
+
+Initial release: an Effect-native WebTransport library. Acquire sessions as scoped resources through a feature-detected, test-substitutable `WebTransportConstructor` service; open reliable bidirectional and unidirectional streams and use backpressured, bounded datagrams with typed `WebTransportError` reasons; adapt one reliable bidirectional stream to `effect/unstable/socket` `Socket` (and therefore `RpcClient.layerProtocolSocket`); and pin a transport with the `Fallback` module's ordered candidate selection (WebTransport handshake first, WebSocket fallback).

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,9 +38,10 @@ jobs:
       - name: Verify locked Dev Kit setup
         run: bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked
 
-      - name: "Build effect-cf"
+      - name: "Build packages"
         run: |
           vp run effect-cf#build
+          vp run effect-webtransport#build
 
       - name: Check formatting
         run: vp fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
           needs_changeset=false
           has_changeset=false
           while IFS= read -r file; do
-            if [[ "$file" == packages/effect-cf/src/* || "$file" == packages/effect-cf/package.json ]]; then
+            if [[ "$file" == packages/effect-cf/src/* || "$file" == packages/effect-cf/package.json ||
+                  "$file" == packages/effect-webtransport/src/* || "$file" == packages/effect-webtransport/package.json ]]; then
               needs_changeset=true
             fi
             if [[ "$file" == .changeset/*.md && "$file" != ".changeset/README.md" ]]; then
@@ -58,7 +59,7 @@ jobs:
           done <<<"$changed_files"
 
           if [[ "$needs_changeset" == true && "$has_changeset" != true ]]; then
-            echo "PRs that change packages/effect-cf/src or its package.json must include a changeset under .changeset/."
+            echo "PRs that change a publishable package's src or package.json must include a changeset under .changeset/."
             echo "Internal-only PRs need no changeset. Never add an empty changeset: a pending changeset on main silently blocks the next release publish."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
       # environment resolves a different TypeScript than Vite+ does, which
       # emits different declarations and needs an undeclared dependency.
       - run: vp run effect-cf#build
+      - run: vp run effect-webtransport#build
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest
       - name: Create GitHub App token

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,10 @@ Do not use `bun run`, `npm run`, `pnpm run`, or `yarn run` in this repository. D
 
 # Package Layout
 
-- `packages/effect-cf` is the publishable package.
+- `packages/effect-cf` and `packages/effect-webtransport` are the publishable packages.
+- `packages/effect-cf` holds Cloudflare-specific primitives; `packages/effect-webtransport` is a platform-generic Effect WebTransport library with no Cloudflare dependency.
 - `examples/` contains consumer and example applications.
-- Reusable package code belongs under `packages/effect-cf/src` and must be exported from `packages/effect-cf/src/index.ts`.
+- Reusable package code belongs under a package's `src/` and must be exported from that package's `src/index.ts`.
 - Worker projects use `@cloudflare/workers-types` directly for Cloudflare runtime types.
 - Effect source code can be referenced at `.repos/effect` for patterns and API style when changing Effect-heavy code. Do not edit it; Dev Kit owns and version-matches that checkout.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, Cache, KV, Email, Analytics Engine, and Durable Object storage.
 
+This monorepo also publishes [`effect-webtransport`](packages/effect-webtransport), a platform-generic Effect WebTransport library (sessions, streams, datagrams, `Socket`/RPC adapters, and WebSocket fallback selection). `effect-cf`'s `WebTransport` module documents the Cloudflare boundary: Workers cannot accept inbound WebTransport sessions today, so the module exposes typed capabilities and decoded HTTP/3 request metadata instead.
+
 ## Install
 
 `effect-cf` targets Effect `^4.0.0-beta.105`.

--- a/bun.lock
+++ b/bun.lock
@@ -212,6 +212,7 @@
         "@effect-cf/todo-rpc-ws-domain": "workspace:*",
         "@vitejs/plugin-react": "^6.0.1",
         "effect": "catalog:",
+        "effect-webtransport": "workspace:*",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
       },
@@ -289,7 +290,7 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.24.0",
+      "version": "0.25.1",
       "devDependencies": {
         "@cloudflare/containers": "catalog:",
         "@cloudflare/vitest-pool-workers": "catalog:",
@@ -316,6 +317,19 @@
         "@cloudflare/workers-types",
         "@effect/sql-pg",
       ],
+    },
+    "packages/effect-webtransport": {
+      "name": "effect-webtransport",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@effect/vitest": "catalog:",
+        "effect": "catalog:",
+        "vite-plus": "catalog:",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "^4.0.0-beta.107 <4.0.0-rc.0",
+      },
     },
     "tools/effect-cf-repo": {
       "name": "@effect-cf/repo",
@@ -963,6 +977,8 @@
     "effect": ["effect@4.0.0-beta.107", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "uuid": "^14.0.1" } }, "sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ=="],
 
     "effect-cf": ["effect-cf@workspace:packages/effect-cf"],
+
+    "effect-webtransport": ["effect-webtransport@workspace:packages/effect-webtransport"],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 

--- a/dev-kit.jsonc
+++ b/dev-kit.jsonc
@@ -19,12 +19,12 @@
       "quality": {
         "workflow": {
           "enabled": true,
-          // Examples and the worker test fixtures resolve `effect-cf` through
-          // its published `dist` entrypoints.
+          // Examples and the worker test fixtures resolve the publishable
+          // packages through their published `dist` entrypoints.
           "beforeChecks": [
             {
-              "name": "Build effect-cf",
-              "run": ["vp run effect-cf#build"],
+              "name": "Build packages",
+              "run": ["vp run effect-cf#build", "vp run effect-webtransport#build"],
             },
           ],
         },

--- a/dev-kit.lock.json
+++ b/dev-kit.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "toolVersion": "0.14.0",
-  "manifestDigest": "sha256:59daada55c27a503f1cb45ca64547c793a69152ec8726847d760ee56588b641b",
+  "manifestDigest": "sha256:d632eef835e02b46deeb7866de3b2c711abc95f10c0214f1137d63a4c1521339",
   "setup": {
     "effectSource": {
       "packageName": "effect",
@@ -235,7 +235,7 @@
       "sourcePath": "templates/vite-plus/github-actions-check.yml",
       "mode": "copy",
       "kind": "file",
-      "digest": "sha256:27d06667f945e3457d4c028feea48fe828d43e31b4f042acfed2ed1448b3d1c5"
+      "digest": "sha256:84e1775fdcc0c7405abd0a6b59e72ffb08115f214805f6ab29863a838c5ced5e"
     },
     {
       "resourceId": "setup:agent-instructions",

--- a/examples/todo-rpc-ws/README.md
+++ b/examples/todo-rpc-ws/README.md
@@ -1,3 +1,5 @@
 # todo-rpc-ws
 
 Effect RPC over WebSocket hosted in a Durable Object. Run `vp run todo-rpc-ws-api-worker#dev` and `vp run todo-rpc-ws-web#dev`; build with `vp run build:todo-rpc-ws`. The DO uses `DurableObjectRpcWebSocket.layer({ tag: "todo-rpc" })`, accepts upgrades, and forwards `webSocketMessage`, `webSocketClose`, and `webSocketError` to the transport service.
+
+The web client selects its transport with `effect-webtransport`'s `Fallback` module: a WebTransport candidate runs its real handshake first and — because Cloudflare's edge does not accept inbound WebTransport sessions (workerd has no QUIC stack; cloudflare/workerd#6451) — fails over to the WebSocket candidate before any RPC traffic is sent. The chosen transport is pinned for the client runtime's lifetime, so no in-flight request is replayed across transports.

--- a/examples/todo-rpc-ws/web/package.json
+++ b/examples/todo-rpc-ws/web/package.json
@@ -14,6 +14,7 @@
     "@effect-cf/todo-rpc-ws-domain": "workspace:*",
     "@vitejs/plugin-react": "^6.0.1",
     "effect": "catalog:",
+    "effect-webtransport": "workspace:*",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/examples/todo-rpc-ws/web/src/clients.ts
+++ b/examples/todo-rpc-ws/web/src/clients.ts
@@ -4,6 +4,9 @@ import { Socket } from "effect/unstable/socket";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import type { RpcClientError } from "effect/unstable/rpc/RpcClientError";
 import type { Rpcs } from "effect/unstable/rpc/RpcGroup";
+import { Fallback } from "effect-webtransport";
+
+const webTransportUrl = Effect.sync(() => new URL("/api/wt", window.location.href).toString());
 
 const webSocketUrl = Effect.sync(() => {
   const url = new URL("/api/ws", window.location.href);
@@ -13,14 +16,37 @@ const webSocketUrl = Effect.sync(() => {
   return url.toString();
 });
 
+// Effectful transport selection, tried strictly in order before any RPC
+// traffic is sent, then pinned for the lifetime of the client runtime:
+//
+// 1. WebTransport — the candidate performs the real session handshake as its
+//    probe. Cloudflare's edge does not accept inbound WebTransport sessions
+//    today (workerd has no QUIC stack; cloudflare/workerd#6451), so against
+//    this deployment the handshake fails and selection moves on. The
+//    candidate also fails cleanly on browsers without WebTransport.
+// 2. WebSocket — the transport Cloudflare actually supports end-to-end
+//    (Durable Object hibernatable WebSockets on the server side).
+//
+// Because selection happens before use and the transport is pinned, no
+// in-flight request is ever replayed across transports.
+//
+// Serialization note: `layerJson` below matches the WebSocket server and is
+// safe there because WebSocket frames delimit messages. A deployment where
+// the WebTransport candidate can actually win must switch both ends to a
+// self-delimiting serialization (`RpcSerialization.layerNdjson`), because
+// WebTransport streams are unframed byte streams.
+const transportLayer = Fallback.layerSocket([
+  Fallback.webTransport(webTransportUrl, { openTimeout: 3000 }),
+  Fallback.webSocket(webSocketUrl),
+]).pipe(Layer.provide(Socket.layerWebSocketConstructorGlobal));
+
 export class TodoRpcClient extends Context.Service<
   TodoRpcClient,
   RpcClient.RpcClient<Rpcs<typeof TodoRpcGroup>, RpcClientError>
 >()("todo-rpc-ws-web/TodoRpcClient") {
   static readonly layer = Layer.effect(this, RpcClient.make(TodoRpcGroup)).pipe(
     Layer.provide(RpcClient.layerProtocolSocket()),
-    Layer.provide(Socket.layerWebSocket(webSocketUrl)),
-    Layer.provide(Socket.layerWebSocketConstructorGlobal),
+    Layer.provide(transportLayer),
     Layer.provide(RpcSerialization.layerJson),
   );
 }

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -42,6 +42,7 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `Queue` - typed Queue producer/consumer tags plus client and error types
 - `Workflow` - typed Workflow entrypoints, steps, starter clients, and instance types
 - `Rpc` - Cloudflare RPC type helpers and scoped disposal utilities
+- `WebTransport` - truthful WebTransport/HTTP-3 boundary: typed runtime capabilities and decoded inbound protocol metadata
 - `WorkerConfig` - Effect `Config` helpers backed by Cloudflare `env`
 - `effect-cf/vitest` - Effect-native runners and scoped test helpers for Cloudflare's Vitest Workers pool
 
@@ -697,6 +698,36 @@ if (Worker.isWebSocketUpgrade(request)) {
 ```
 
 Use `DurableObjectRpcWebSocket.layer(...)` for Effect RPC-over-WebSocket transports. It owns protocol parsing and RPC client bookkeeping; use `DurableWebSocket` for general application sockets, rooms, presence, and broadcast flows.
+
+## WebTransport and HTTP/3
+
+Cloudflare Workers cannot accept inbound WebTransport sessions today: workerd contains no QUIC/HTTP-3 stack, there is no `WebSocketPair`-style session API, and the maintainers state the feature "is not currently on our priority list" ([cloudflare/workerd#6451](https://github.com/cloudflare/workerd/issues/6451)). Inbound HTTP/3 is a zone-level setting — the edge terminates QUIC and the Worker still receives an ordinary `fetch` Request. Durable Object hibernatable WebSockets remain the only bidirectional push channel into Worker code.
+
+The `WebTransport` module gives that boundary a typed shape rather than pretending otherwise:
+
+```ts
+import { Effect, Option } from "effect";
+import { WebTransport } from "effect-cf";
+
+const fetch = Effect.fn("fetch")(function* (request: Request) {
+  // Decoded metadata about the browser→edge hop (HTTP/3 does not reach you).
+  const transport = WebTransport.inboundTransport(request);
+  const viaHttp3 = Option.match(transport, {
+    onNone: () => false,
+    onSome: WebTransport.isHttp3,
+  });
+
+  // Feature-detected runtime capabilities: { inboundSessions: false, ... }.
+  const capabilities = yield* WebTransport.capabilities;
+
+  // Explicit typed boundary where a future inbound session API would slot in.
+  // yield* WebTransport.inboundSessionsUnsupported;
+
+  return Response.json({ viaHttp3, capabilities });
+});
+```
+
+For clients that prefer WebTransport where it exists and fall back to Cloudflare-supported WebSockets, see the companion [`effect-webtransport`](../effect-webtransport) package's `Fallback` module — `examples/todo-rpc-ws` wires it up end to end.
 
 ## License
 

--- a/packages/effect-cf/src/WebTransport.ts
+++ b/packages/effect-cf/src/WebTransport.ts
@@ -1,0 +1,123 @@
+/**
+ * Truthful WebTransport / HTTP/3 boundary for Cloudflare Workers.
+ *
+ * What Cloudflare supports today (verified against primary sources, August
+ * 2026):
+ *
+ * - Inbound HTTP/3 is a zone-level setting. Cloudflare's edge terminates the
+ *   QUIC connection and invokes the Worker with an ordinary `fetch` Request;
+ *   the inbound protocol is surfaced only as metadata on `request.cf`
+ *   ({@link inboundTransport}).
+ * - There is no runtime API for inbound WebTransport sessions — nothing
+ *   analogous to `WebSocketPair`. workerd contains no QUIC/HTTP-3 stack, and
+ *   the maintainers state WebTransport support "is not currently on our
+ *   priority list" (cloudflare/workerd#6451, discussion #6454).
+ * - There is no outbound WebTransport/QUIC/UDP client capability either;
+ *   `cloudflare:sockets` `connect()` is TCP-only, and
+ *   `@cloudflare/workers-types` contains no WebTransport types.
+ * - Durable Objects' hibernatable WebSockets (`acceptWebSocket`,
+ *   `webSocketMessage`, `webSocketClose`) remain the only bidirectional push
+ *   channel into a Worker or Durable Object.
+ *
+ * Consequently a browser's WebTransport session can never reach Worker code:
+ * clients should attempt WebTransport only against origins that actually
+ * speak it, and fall back to WebSockets for Cloudflare-hosted endpoints (see
+ * the `effect-webtransport` package's `Fallback` module). This module gives
+ * that reality a typed shape: {@link capabilities} feature-detects what the
+ * current runtime provides, {@link inboundSessionsUnsupported} is the
+ * explicit typed boundary for the missing inbound API, and
+ * {@link inboundTransport} decodes the HTTP/3-relevant request metadata that
+ * the edge does provide.
+ */
+import type { Request as CloudflareRequest } from "@cloudflare/workers-types";
+import { Data, Effect, Option, Result, Schema as S } from "effect";
+
+/**
+ * Metadata Cloudflare's edge reports about the inbound client connection.
+ *
+ * `httpProtocol` and `clientTcpRtt` are declared in
+ * `@cloudflare/workers-types`; `clientQuicRtt` is documented by Cloudflare
+ * ("only present when the client connected over QUIC (HTTP/3)") but not yet
+ * present in the published types, so it is decoded from the open
+ * `Record<string, unknown>` side of `request.cf`.
+ */
+export class InboundTransport extends S.Class<InboundTransport>("InboundTransport")({
+  /** The HTTP protocol the client used, e.g. `"HTTP/2"` or `"HTTP/3"`. */
+  httpProtocol: S.String,
+  /** Client round-trip time; only present for QUIC (HTTP/3) connections. */
+  clientQuicRtt: S.optional(S.Number),
+  /** Client round-trip time; only present for TCP (HTTP/1.x, HTTP/2) connections. */
+  clientTcpRtt: S.optional(S.Number),
+}) {}
+
+const decodeInboundTransport = S.decodeUnknownResult(InboundTransport);
+
+/**
+ * Decodes the inbound transport metadata from `request.cf`.
+ *
+ * Returns `None` when the metadata is absent (for example in local `wrangler
+ * dev` or when a Worker invokes another Worker directly) or does not match
+ * the expected shape.
+ */
+export const inboundTransport = (
+  request: Pick<CloudflareRequest, "cf">,
+): Option.Option<InboundTransport> => Result.getSuccess(decodeInboundTransport(request.cf));
+
+/**
+ * Returns `true` when the client reached Cloudflare's edge over QUIC
+ * (HTTP/3). Prefers the documented QUIC signal (`clientQuicRtt` is only
+ * present for QUIC connections) and falls back to the `httpProtocol` string.
+ *
+ * Note this describes the browser→edge hop only: the edge always terminates
+ * QUIC, and the Worker still handles an ordinary `fetch` Request.
+ */
+export const isHttp3 = (transport: InboundTransport): boolean =>
+  transport.clientQuicRtt !== undefined || transport.httpProtocol === "HTTP/3";
+
+/** WebTransport-related capabilities of the current Workers runtime. */
+export interface Capabilities {
+  /**
+   * Whether Worker code can accept inbound WebTransport sessions. Typed as
+   * literally `false`: no such runtime API exists (cloudflare/workerd#6451),
+   * so this can only change through a breaking, deliberate update when
+   * Cloudflare ships one.
+   */
+  readonly inboundSessions: false;
+  /**
+   * Whether the runtime exposes a client `WebTransport` constructor global.
+   * Feature-detected at runtime; `false` in workerd today, which has no
+   * QUIC stack.
+   */
+  readonly outboundSessions: boolean;
+}
+
+/** Feature-detects the WebTransport capabilities of the current runtime. */
+export const capabilities: Effect.Effect<Capabilities> = Effect.sync(() => ({
+  inboundSessions: false,
+  outboundSessions: typeof (globalThis as Record<string, unknown>)["WebTransport"] === "function",
+}));
+
+/** WebTransport capability missing from the current Workers runtime. */
+export type WebTransportCapability = "inbound-sessions" | "outbound-sessions";
+
+/** Raised when a WebTransport capability is unavailable in this runtime. */
+export class WebTransportUnsupportedError extends Data.TaggedError("WebTransportUnsupportedError")<{
+  readonly capability: WebTransportCapability;
+}> {
+  override get message(): string {
+    return this.capability === "inbound-sessions"
+      ? "Cloudflare Workers cannot accept inbound WebTransport sessions: the edge terminates QUIC and no runtime session API exists (cloudflare/workerd#6451). Use Durable Object WebSockets for bidirectional push."
+      : "This Workers runtime provides no WebTransport client: workerd has no QUIC stack and cloudflare:sockets is TCP-only.";
+  }
+}
+
+/**
+ * The explicit typed boundary for inbound WebTransport sessions.
+ *
+ * Always fails with {@link WebTransportUnsupportedError} today. Route the
+ * code path that would accept a session through this effect so the
+ * limitation is visible in the type system and greppable when Cloudflare
+ * ships a real API.
+ */
+export const inboundSessionsUnsupported: Effect.Effect<never, WebTransportUnsupportedError> =
+  Effect.fail(new WebTransportUnsupportedError({ capability: "inbound-sessions" }));

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -28,6 +28,7 @@ export * as Rpc from "./Rpc";
 export * as RpcDefinition from "./RpcDefinition";
 export * as ServiceBinding from "./ServiceBinding";
 export * as Vectorize from "./Vectorize";
+export * as WebTransport from "./WebTransport";
 export * as Worker from "./Worker";
 export * as WorkerDefinition from "./WorkerDefinition";
 export * as WorkersAi from "./WorkersAi";

--- a/packages/effect-cf/tests/WebTransport.test.ts
+++ b/packages/effect-cf/tests/WebTransport.test.ts
@@ -1,0 +1,74 @@
+import { assert, describe, it, test } from "@effect/vitest";
+import { Effect, Option } from "effect";
+
+import { WebTransport } from "../src/index";
+
+const request = (cf: unknown) =>
+  ({ cf }) as Pick<Parameters<typeof WebTransport.inboundTransport>[0], "cf">;
+
+describe("inboundTransport", () => {
+  test("decodes HTTP/3 metadata and ignores unrelated cf fields", () => {
+    const transport = WebTransport.inboundTransport(
+      request({
+        httpProtocol: "HTTP/3",
+        clientQuicRtt: 12,
+        colo: "AMS",
+        asn: 1234,
+      }),
+    );
+
+    assert.isTrue(Option.isSome(transport));
+    assert.strictEqual(Option.getOrThrow(transport).httpProtocol, "HTTP/3");
+    assert.strictEqual(Option.getOrThrow(transport).clientQuicRtt, 12);
+    assert.isTrue(WebTransport.isHttp3(Option.getOrThrow(transport)));
+  });
+
+  test("identifies QUIC by the documented clientQuicRtt signal alone", () => {
+    const transport = Option.getOrThrow(
+      WebTransport.inboundTransport(request({ httpProtocol: "HTTP/3+QUIC/1", clientQuicRtt: 3 })),
+    );
+
+    assert.isTrue(WebTransport.isHttp3(transport));
+  });
+
+  test("decodes TCP metadata as not HTTP/3", () => {
+    const transport = Option.getOrThrow(
+      WebTransport.inboundTransport(request({ httpProtocol: "HTTP/2", clientTcpRtt: 30 })),
+    );
+
+    assert.strictEqual(transport.clientTcpRtt, 30);
+    assert.isFalse(WebTransport.isHttp3(transport));
+  });
+
+  test("returns None when cf metadata is absent or malformed", () => {
+    assert.isTrue(Option.isNone(WebTransport.inboundTransport(request(undefined))));
+    assert.isTrue(Option.isNone(WebTransport.inboundTransport(request({ httpProtocol: 42 }))));
+    assert.isTrue(Option.isNone(WebTransport.inboundTransport(request("not an object"))));
+  });
+});
+
+describe("capabilities", () => {
+  it.effect("reports the truthful capability set", () =>
+    Effect.gen(function* () {
+      const capabilities = yield* WebTransport.capabilities;
+
+      assert.strictEqual(capabilities.inboundSessions, false);
+      assert.strictEqual(
+        capabilities.outboundSessions,
+        typeof (globalThis as Record<string, unknown>)["WebTransport"] === "function",
+      );
+    }),
+  );
+});
+
+describe("inboundSessionsUnsupported", () => {
+  it.effect("is an explicit typed boundary", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(WebTransport.inboundSessionsUnsupported);
+
+      assert.strictEqual(error._tag, "WebTransportUnsupportedError");
+      assert.strictEqual(error.capability, "inbound-sessions");
+      assert.include(error.message, "cloudflare/workerd#6451");
+    }),
+  );
+});

--- a/packages/effect-cf/tests/WebTransport.worker.test.ts
+++ b/packages/effect-cf/tests/WebTransport.worker.test.ts
@@ -1,0 +1,31 @@
+import { assert, expect, it, test } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { WebTransport } from "../src/index";
+
+// These assertions run inside workerd itself: they document — as executable
+// evidence — that the runtime exposes no WebTransport API today. If Cloudflare
+// ever ships one, these tests fail and the capability boundary must be
+// revisited deliberately.
+
+test("workerd exposes no WebTransport constructor global", () => {
+  expect("WebTransport" in globalThis).toBe(false);
+});
+
+it.effect("capabilities are truthfully unsupported inside workerd", () =>
+  Effect.gen(function* () {
+    const capabilities = yield* WebTransport.capabilities;
+
+    assert.strictEqual(capabilities.inboundSessions, false);
+    assert.strictEqual(capabilities.outboundSessions, false);
+  }),
+);
+
+it.effect("the inbound-session boundary fails typed inside workerd", () =>
+  Effect.gen(function* () {
+    const error = yield* Effect.flip(WebTransport.inboundSessionsUnsupported);
+
+    assert.strictEqual(error._tag, "WebTransportUnsupportedError");
+    assert.strictEqual(error.capability, "inbound-sessions");
+  }),
+);

--- a/packages/effect-webtransport/.gitignore
+++ b/packages/effect-webtransport/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+*.log
+.DS_Store

--- a/packages/effect-webtransport/LICENSE
+++ b/packages/effect-webtransport/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dan van der Merwe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/effect-webtransport/README.md
+++ b/packages/effect-webtransport/README.md
@@ -1,0 +1,110 @@
+# effect-webtransport
+
+Effect-native [WebTransport](https://developer.mozilla.org/docs/Web/API/WebTransport) sessions, streams, and datagrams, with adapters into `effect/unstable/socket` and Effect RPC.
+
+WebTransport is the application-level API for HTTP/3 transport: one QUIC connection carries multiplexed reliable bidirectional/unidirectional streams plus unreliable datagrams. This package wraps a platform `WebTransport` implementation (browser global, Deno, or a test fake) behind Effect services with Scope-safe acquisition, typed errors, and bounded, backpressured I/O.
+
+## Install
+
+```sh
+bun add effect-webtransport effect@^4.0.0-beta.107
+```
+
+`effect` is a peer dependency. WebTransport is Baseline in browsers since March 2026 (Chrome 97+, Edge 98+, Firefox 114+, Safari 26.4+); Node.js and Bun have no native implementation, which is why the constructor is a feature-detected, substitutable service.
+
+## Exports
+
+- `WebTransport` – scoped session acquisition (`connect`, `layer`), the feature-detected `WebTransportConstructor` service, reliable bidi/uni stream opening, incoming stream `Stream`s, backpressured datagrams, typed `WebTransportError` reasons, and `readStream`/`writer` helpers.
+- `WebTransportSocket` – adapts one reliable bidirectional stream to `effect/unstable/socket` `Socket`, so Effect socket consumers (including `RpcClient.layerProtocolSocket`) run over WebTransport unchanged.
+- `Fallback` – effectful transport candidate selection: try WebTransport (real handshake as the probe), fall back to WebSocket, pin the winner for the session.
+
+## Sessions
+
+```ts
+import { Effect } from "effect";
+import { WebTransport } from "effect-webtransport";
+
+const program = Effect.gen(function* () {
+  const session = yield* WebTransport.connect("https://example.com/wt", {
+    openTimeout: 5000,
+    datagrams: { incomingHighWaterMark: 16, outgoingHighWaterMark: 16 },
+  });
+
+  // Reliable bidirectional stream, closed with its scope.
+  const stream = yield* session.openBidirectionalStream();
+  const write = yield* WebTransport.writer(stream.writable);
+  yield* write(new TextEncoder().encode("hello"));
+
+  // Unreliable datagrams with platform-bounded buffering.
+  yield* session.datagrams.send(new Uint8Array([1, 2, 3]));
+  const datagram = yield* session.datagrams.take;
+
+  return datagram;
+}).pipe(Effect.scoped, Effect.provide(WebTransport.layerConstructorGlobal));
+```
+
+Closing the scope closes the session (and every stream it carries) and waits for closure to settle — including on interruption. All failures are typed: `WebTransportError` wraps `ConnectError`, `SessionClosedError`, `StreamOpenError`, `ReadError`, `WriteError`, `DatagramTooLargeError`, and `UnsupportedError` (feature detection for the constructor, unidirectional streams, and datagrams).
+
+In tests, substitute the constructor instead of the network:
+
+```ts
+import { Layer } from "effect";
+import { WebTransport } from "effect-webtransport";
+
+const TestConstructor = Layer.succeed(WebTransport.WebTransportConstructor)(
+  (url) => myFakeNativeWebTransport,
+);
+```
+
+## Effect RPC over WebTransport
+
+`WebTransportSocket` turns one reliable bidirectional stream into an Effect `Socket`, so the existing `RpcClient` socket protocol works as-is. Each `Socket.run` opens a fresh stream on the same session; a finished run closes its stream with a FIN.
+
+```ts
+import { Layer } from "effect";
+import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
+import { WebTransport, WebTransportSocket } from "effect-webtransport";
+
+const protocol = RpcClient.layerProtocolSocket().pipe(
+  Layer.provide(WebTransportSocket.layerSocket()),
+  Layer.provide(WebTransport.layer("https://example.com/rpc")),
+  Layer.provide(WebTransport.layerConstructorGlobal),
+  // WebTransport streams are unframed byte streams: use a self-delimiting
+  // serialization (ndjson/msgpack), not plain layerJson.
+  Layer.provide(RpcSerialization.layerNdjson),
+);
+```
+
+Two honest limitations of this lowest-common-denominator mode:
+
+- It uses exactly one reliable bidirectional stream: QUIC stream multiplexing and unreliable datagrams are not exercised, and head-of-line blocking within the stream applies.
+- Unlike WebSocket, WebTransport streams carry no message framing, hence the ndjson/msgpack requirement above.
+
+## Transport fallback
+
+`Fallback` selects a transport effectfully, in order, before any application traffic — then pins it. A WebTransport candidate performs the real session handshake as its probe (and fails cleanly on platforms without WebTransport); a WebSocket candidate acquires lazily and belongs last. No in-flight request is ever replayed across transports: once pinned, a dying transport fails the consumer instead of silently failing over.
+
+```ts
+import { Layer } from "effect";
+import { Socket } from "effect/unstable/socket";
+import { Fallback } from "effect-webtransport";
+
+const transport = Fallback.layerSocket([
+  Fallback.webTransport("https://example.com/wt", { openTimeout: 3000 }),
+  Fallback.webSocket("wss://example.com/ws"),
+]).pipe(Layer.provide(Socket.layerWebSocketConstructorGlobal));
+```
+
+## Cloudflare Workers reality
+
+This package is platform-generic and works wherever a client `WebTransport` implementation exists. Cloudflare's platform, as of August 2026 (primary sources):
+
+- Workers and Durable Objects **cannot accept inbound WebTransport sessions**. workerd contains no QUIC/HTTP-3 stack and its maintainers state WebTransport support "is not currently on our priority list" ([cloudflare/workerd#6451](https://github.com/cloudflare/workerd/issues/6451), [discussion #6454](https://github.com/cloudflare/workerd/discussions/6454)).
+- Inbound HTTP/3 is a zone setting: the edge terminates QUIC and the Worker receives an ordinary `fetch` Request with protocol metadata (`request.cf.httpProtocol`, `clientQuicRtt`). Edge HTTP/3 does **not** give Worker code access to QUIC streams or datagrams.
+- There is no outbound WebTransport/QUIC/UDP client in Workers either (`cloudflare:sockets` is TCP-only), and `@cloudflare/workers-types` contains no WebTransport types.
+
+So against Cloudflare-hosted endpoints, the `Fallback` module's WebSocket candidate is the one that wins, backed on the server by Durable Object hibernatable WebSockets. The `effect-cf` package's `WebTransport` module exposes this boundary as typed capabilities and decoded HTTP/3 request metadata. A future inbound Workers WebTransport API can slot in through `WebTransport.fromNative`, which wraps any object satisfying the structural `NativeWebTransport` shape — no WebSocket assumptions are baked into this package.
+
+## License
+
+MIT

--- a/packages/effect-webtransport/package.json
+++ b/packages/effect-webtransport/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "effect-webtransport",
+  "version": "0.0.0",
+  "description": "Effect-native WebTransport sessions, streams, datagrams, and Socket/RPC adapters.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljvdm/effect-cf.git",
+    "directory": "packages/effect-webtransport"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "dist",
+    "src"
+  ],
+  "type": "module",
+  "sideEffects": [],
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vp pack",
+    "dev": "vp pack --watch",
+    "test": "vp test",
+    "check": "vp check",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@effect/vitest": "catalog:",
+    "effect": "catalog:",
+    "vite-plus": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "^4.0.0-beta.107 <4.0.0-rc.0"
+  }
+}

--- a/packages/effect-webtransport/src/Fallback.ts
+++ b/packages/effect-webtransport/src/Fallback.ts
@@ -1,0 +1,161 @@
+/**
+ * Effectful transport candidate selection with session pinning.
+ *
+ * Candidates are tried strictly in order; the first whose acquisition
+ * succeeds is pinned for the lifetime of the surrounding scope. Selection
+ * happens before any application traffic, so no in-flight request is ever
+ * replayed across transports: once pinned, a dying transport fails the
+ * consumer instead of silently failing over. Re-run selection at the
+ * application level if a new transport decision is desired.
+ *
+ * A WebTransport candidate performs the real session handshake as its probe.
+ * A WebSocket candidate acquires lazily (the socket connects per run), so it
+ * is best placed last as the assumed-available fallback.
+ */
+import {
+  type Array as Arr,
+  type Duration,
+  Effect,
+  Exit,
+  Layer,
+  Option,
+  Schema,
+  Scope,
+} from "effect";
+import { Socket } from "effect/unstable/socket";
+
+import * as WebTransport from "./WebTransport";
+import * as WebTransportSocket from "./WebTransportSocket";
+
+/** A named transport candidate producing a `Socket` when it is viable. */
+export interface Candidate<E = unknown, R = never> {
+  readonly name: string;
+  readonly socket: Effect.Effect<Socket.Socket, E, R>;
+}
+
+/** The transport pinned by {@link select}. */
+export interface SelectedTransport {
+  readonly name: string;
+  readonly socket: Socket.Socket;
+}
+
+/** Every transport candidate failed. Carries each candidate's failure. */
+export class TransportSelectionError extends Schema.TaggedError<TransportSelectionError>()(
+  "TransportSelectionError",
+  {
+    failures: Schema.Array(Schema.Struct({ name: Schema.String, cause: Schema.Defect() })),
+  },
+) {
+  override get message(): string {
+    return `no transport candidate succeeded (tried: ${this.failures.map((failure) => failure.name).join(", ")})`;
+  }
+}
+
+/**
+ * WebTransport candidate: connects a session to `url` (the QUIC/HTTP-3
+ * handshake is the probe) and, when pinned, serves one fresh reliable
+ * bidirectional stream per `Socket.run`.
+ *
+ * Uses a `WebTransportConstructor` from the environment when one is provided,
+ * and otherwise feature-detects `globalThis.WebTransport` — a platform
+ * without WebTransport makes this candidate fail (and selection move on)
+ * instead of failing the surrounding layer.
+ */
+export const webTransport = (
+  url: string | Effect.Effect<string>,
+  options?: WebTransport.ConnectOptions &
+    WebTransportSocket.MakeSocketOptions & { readonly name?: string | undefined },
+): Candidate<WebTransport.WebTransportError, Scope.Scope> => ({
+  name: options?.name ?? "webtransport",
+  socket: Effect.gen(function* () {
+    const makeNative = yield* Effect.serviceOption(WebTransport.WebTransportConstructor).pipe(
+      Effect.flatMap(
+        Option.match({
+          onNone: () => WebTransport.constructorGlobal,
+          onSome: Effect.succeed,
+        }),
+      ),
+    );
+    const session = yield* WebTransport.connect(url, options).pipe(
+      Effect.provideService(WebTransport.WebTransportConstructor, makeNative),
+    );
+
+    return yield* WebTransportSocket.fromBidirectionalStream(
+      session.openBidirectionalStream(options?.sendStream),
+      options,
+    );
+  }),
+});
+
+/**
+ * WebSocket candidate. Acquisition itself cannot fail — the WebSocket
+ * connects lazily on each `Socket.run` — so place it after candidates whose
+ * viability is probed eagerly.
+ */
+export const webSocket = (
+  url: string | Effect.Effect<string>,
+  options?: {
+    readonly name?: string | undefined;
+    readonly closeCodeIsError?: ((code: number) => boolean) | undefined;
+    readonly openTimeout?: Duration.Input | undefined;
+    readonly protocols?: string | Array<string> | undefined;
+  },
+): Candidate<never, Socket.WebSocketConstructor> => ({
+  name: options?.name ?? "websocket",
+  socket: Socket.makeWebSocket(url, options),
+});
+
+/** Context required by a union of candidates. */
+export type CandidateContext<C extends Candidate<any, any>> =
+  C extends Candidate<any, infer R> ? R : never;
+
+/**
+ * Tries candidates in order and pins the first that succeeds. Resources of a
+ * failed candidate are released before the next candidate is tried; the
+ * winning candidate's resources live in the surrounding scope.
+ */
+export const select = <const Candidates extends Arr.NonEmptyReadonlyArray<Candidate<any, any>>>(
+  candidates: Candidates,
+): Effect.Effect<
+  SelectedTransport,
+  TransportSelectionError,
+  Exclude<CandidateContext<Candidates[number]>, Scope.Scope> | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const outerScope = yield* Effect.scope;
+    const failures: Array<{ name: string; cause: unknown }> = [];
+
+    for (const candidate of candidates) {
+      const candidateScope = yield* Scope.fork(outerScope);
+      const selected = yield* candidate.socket.pipe(
+        Scope.provide(candidateScope),
+        Effect.map((socket): SelectedTransport => ({ name: candidate.name, socket })),
+        Effect.catch((error) => {
+          failures.push({ name: candidate.name, cause: error });
+
+          return Effect.succeed(undefined);
+        }),
+      );
+
+      if (selected !== undefined) {
+        return selected;
+      }
+      yield* Scope.close(candidateScope, Exit.void);
+    }
+
+    return yield* new TransportSelectionError({ failures });
+  });
+
+/**
+ * Layer that provides a `Socket` from the first viable candidate, pinned for
+ * the lifetime of the layer.
+ */
+export const layerSocket = <
+  const Candidates extends Arr.NonEmptyReadonlyArray<Candidate<any, any>>,
+>(
+  candidates: Candidates,
+): Layer.Layer<
+  Socket.Socket,
+  TransportSelectionError,
+  Exclude<CandidateContext<Candidates[number]>, Scope.Scope>
+> => Layer.effect(Socket.Socket)(Effect.map(select(candidates), (selected) => selected.socket));

--- a/packages/effect-webtransport/src/WebTransport.ts
+++ b/packages/effect-webtransport/src/WebTransport.ts
@@ -1,0 +1,721 @@
+/**
+ * Effect-native access to the WebTransport API.
+ *
+ * WebTransport is the application-level API for HTTP/3 transport: a session
+ * multiplexes reliable bidirectional/unidirectional streams and unreliable
+ * datagrams over one QUIC connection.
+ *
+ * This module wraps a platform `WebTransport` implementation (browser global,
+ * Deno, or a test fake) behind a feature-detected, test-substitutable
+ * {@link WebTransportConstructor} service, and exposes sessions as scoped
+ * Effect resources with typed errors.
+ */
+import {
+  Context,
+  type Duration,
+  Effect,
+  Layer,
+  Predicate,
+  Result,
+  Schema,
+  type Scope,
+  Stream,
+} from "effect";
+
+// -----------------------------------------------------------------------------
+// Platform (structural) types
+//
+// These mirror the WebTransport WebIDL surface without requiring the DOM type
+// library, so the package can be consumed from browser, Deno, Node, and Workers
+// type environments alike, and so tests can substitute plain-object fakes.
+// A `lib.dom.d.ts` `WebTransport` instance is structurally assignable to
+// `NativeWebTransport`.
+// -----------------------------------------------------------------------------
+
+/** Close information passed to `WebTransport.close` and reported by `closed`. */
+export interface NativeCloseInfo {
+  readonly closeCode?: number | undefined;
+  readonly reason?: string | undefined;
+}
+
+/** Certificate hash entry accepted by the `serverCertificateHashes` option. */
+export interface NativeCertificateHash {
+  readonly algorithm: string;
+  readonly value: ArrayBuffer | ArrayBufferView;
+}
+
+/** Options accepted by the platform `WebTransport` constructor. */
+export interface NativeConnectOptions {
+  readonly allowPooling?: boolean | undefined;
+  readonly congestionControl?: "default" | "low-latency" | "throughput" | undefined;
+  readonly protocols?: ReadonlyArray<string> | undefined;
+  readonly requireUnreliable?: boolean | undefined;
+  readonly serverCertificateHashes?: ReadonlyArray<NativeCertificateHash> | undefined;
+}
+
+/** Options accepted when opening an outgoing stream. */
+export interface NativeSendStreamOptions {
+  readonly sendOrder?: number | undefined;
+}
+
+/** A reliable bidirectional WebTransport stream: a readable/writable byte pair. */
+export interface NativeBidirectionalStream {
+  readonly readable: ReadableStream<Uint8Array>;
+  readonly writable: WritableStream<Uint8Array>;
+}
+
+/** The duplex datagram surface of a WebTransport session. */
+export interface NativeDatagramDuplexStream {
+  readonly readable: ReadableStream<Uint8Array>;
+  readonly writable: WritableStream<Uint8Array>;
+  readonly maxDatagramSize: number;
+  incomingHighWaterMark?: number;
+  outgoingHighWaterMark?: number;
+  incomingMaxAge?: number | null;
+  outgoingMaxAge?: number | null;
+}
+
+/**
+ * Structural type of a platform `WebTransport` instance.
+ *
+ * `createUnidirectionalStream`, `incomingUnidirectionalStreams`, and
+ * `datagrams` are optional so partial implementations are represented
+ * truthfully; the wrappers fail with a typed `UnsupportedError` when a member
+ * is absent.
+ */
+export interface NativeWebTransport {
+  readonly ready: Promise<void>;
+  readonly closed: Promise<unknown>;
+  readonly close: (info?: NativeCloseInfo) => void;
+  readonly createBidirectionalStream: (
+    options?: NativeSendStreamOptions,
+  ) => Promise<NativeBidirectionalStream>;
+  readonly createUnidirectionalStream?:
+    | ((options?: NativeSendStreamOptions) => Promise<WritableStream<Uint8Array>>)
+    | undefined;
+  readonly incomingBidirectionalStreams: ReadableStream<NativeBidirectionalStream>;
+  readonly incomingUnidirectionalStreams?: ReadableStream<ReadableStream<Uint8Array>> | undefined;
+  readonly datagrams?: NativeDatagramDuplexStream | undefined;
+}
+
+// -----------------------------------------------------------------------------
+// Errors
+// -----------------------------------------------------------------------------
+
+/** Type-level identifier used to mark `WebTransportError` values. */
+export type WebTransportErrorTypeId = "~effect-webtransport/WebTransport/WebTransportError";
+
+/** Runtime type identifier attached to `WebTransportError` values. */
+export const WebTransportErrorTypeId: WebTransportErrorTypeId =
+  "~effect-webtransport/WebTransport/WebTransportError";
+
+/** Returns `true` when a value is a `WebTransportError`. */
+export const isWebTransportError = (u: unknown): u is WebTransportError =>
+  Predicate.hasProperty(u, WebTransportErrorTypeId);
+
+/** Failure while establishing a WebTransport session. */
+export class ConnectError extends Schema.Error<ConnectError>(
+  "effect-webtransport/WebTransport/ConnectError",
+)({
+  _tag: Schema.tag("ConnectError"),
+  kind: Schema.Literals(["OpenFailed", "Timeout"]),
+  cause: Schema.Defect(),
+}) {
+  override get message(): string {
+    return this.kind === "Timeout"
+      ? `timeout waiting for WebTransport session "ready"`
+      : "An error occurred while opening the WebTransport session";
+  }
+}
+
+/** The WebTransport session terminated, either cleanly by the peer or abruptly. */
+export class SessionClosedError extends Schema.Error<SessionClosedError>(
+  "effect-webtransport/WebTransport/SessionClosedError",
+)({
+  _tag: Schema.tag("SessionClosedError"),
+  closeCode: Schema.optional(Schema.Number),
+  closeReason: Schema.optional(Schema.String),
+  cause: Schema.Defect(),
+}) {
+  override get message(): string {
+    return this.closeReason
+      ? `WebTransport session closed (${this.closeCode ?? "no code"}): ${this.closeReason}`
+      : "WebTransport session closed";
+  }
+}
+
+/** Failure while opening an outgoing WebTransport stream. */
+export class StreamOpenError extends Schema.Error<StreamOpenError>(
+  "effect-webtransport/WebTransport/StreamOpenError",
+)({
+  _tag: Schema.tag("StreamOpenError"),
+  direction: Schema.Literals(["bidirectional", "unidirectional"]),
+  cause: Schema.Defect(),
+}) {
+  override get message(): string {
+    return `An error occurred while opening a ${this.direction} WebTransport stream`;
+  }
+}
+
+/** Failure while reading from a WebTransport stream or the datagram surface. */
+export class ReadError extends Schema.Error<ReadError>(
+  "effect-webtransport/WebTransport/ReadError",
+)({
+  _tag: Schema.tag("ReadError"),
+  source: Schema.Literals(["stream", "datagram", "incomingStreams"]),
+  cause: Schema.Defect(),
+}) {
+  override get message(): string {
+    return `An error occurred while reading from the WebTransport ${this.source} source`;
+  }
+}
+
+/** Failure while writing to a WebTransport stream or the datagram surface. */
+export class WriteError extends Schema.Error<WriteError>(
+  "effect-webtransport/WebTransport/WriteError",
+)({
+  _tag: Schema.tag("WriteError"),
+  source: Schema.Literals(["stream", "datagram"]),
+  cause: Schema.Defect(),
+}) {
+  override get message(): string {
+    return `An error occurred while writing to the WebTransport ${this.source} target`;
+  }
+}
+
+/** The datagram payload exceeds the session's `maxDatagramSize`. */
+export class DatagramTooLargeError extends Schema.Error<DatagramTooLargeError>(
+  "effect-webtransport/WebTransport/DatagramTooLargeError",
+)({
+  _tag: Schema.tag("DatagramTooLargeError"),
+  size: Schema.Int,
+  maxDatagramSize: Schema.Int,
+}) {
+  override get message(): string {
+    return `datagram of ${this.size} bytes exceeds maxDatagramSize of ${this.maxDatagramSize}`;
+  }
+}
+
+/** The current platform does not provide the requested WebTransport feature. */
+export class UnsupportedError extends Schema.Error<UnsupportedError>(
+  "effect-webtransport/WebTransport/UnsupportedError",
+)({
+  _tag: Schema.tag("UnsupportedError"),
+  feature: Schema.Literals(["WebTransport", "UnidirectionalStreams", "Datagrams"]),
+}) {
+  override get message(): string {
+    return `The current platform does not support ${this.feature === "WebTransport" ? "the WebTransport API" : `WebTransport ${this.feature}`}`;
+  }
+}
+
+/** Schema for all WebTransport-specific error reasons. */
+export const WebTransportErrorReason = Schema.Union([
+  ConnectError,
+  SessionClosedError,
+  StreamOpenError,
+  ReadError,
+  WriteError,
+  DatagramTooLargeError,
+  UnsupportedError,
+]);
+
+/** Union of WebTransport-specific error reasons. */
+export type WebTransportErrorReason =
+  | ConnectError
+  | SessionClosedError
+  | StreamOpenError
+  | ReadError
+  | WriteError
+  | DatagramTooLargeError
+  | UnsupportedError;
+
+/**
+ * Tagged error that wraps WebTransport failures while preserving the
+ * underlying reason, mirroring `effect/unstable/socket` `SocketError`.
+ */
+export class WebTransportError extends Schema.TaggedError<WebTransportError>(
+  WebTransportErrorTypeId,
+)("WebTransportError", {
+  reason: WebTransportErrorReason,
+}) {
+  // @effect-diagnostics-next-line overriddenSchemaConstructor:off
+  constructor(props: { readonly reason: WebTransportErrorReason }) {
+    if ("cause" in props.reason) {
+      super({ ...props, cause: props.reason.cause } as any);
+    } else {
+      super(props);
+    }
+  }
+
+  /** Marks this value as a WebTransport error wrapper for runtime guards. */
+  readonly [WebTransportErrorTypeId]: WebTransportErrorTypeId = WebTransportErrorTypeId;
+
+  /** Returns `true` when the value is a `WebTransportError`. */
+  static is(u: unknown): u is WebTransportError {
+    return isWebTransportError(u);
+  }
+
+  override readonly message = this.reason.message;
+}
+
+const wtError = (reason: WebTransportErrorReason): WebTransportError =>
+  new WebTransportError({ reason });
+
+// -----------------------------------------------------------------------------
+// Close info
+// -----------------------------------------------------------------------------
+
+/** Validated close information reported when a session ends cleanly. */
+export class CloseInfo extends Schema.Class<CloseInfo>(
+  "effect-webtransport/WebTransport/CloseInfo",
+)({
+  closeCode: Schema.optional(Schema.Number),
+  reason: Schema.optional(Schema.String),
+}) {}
+
+const decodeCloseInfo = Schema.decodeUnknownResult(CloseInfo);
+
+// -----------------------------------------------------------------------------
+// Constructor service and feature detection
+// -----------------------------------------------------------------------------
+
+/**
+ * Context service for constructing platform `WebTransport` instances from a
+ * URL and options. Substitute this service in tests or non-browser platforms.
+ */
+export class WebTransportConstructor extends Context.Service<
+  WebTransportConstructor,
+  (url: string, options?: NativeConnectOptions) => NativeWebTransport
+>()("effect-webtransport/WebTransport/WebTransportConstructor") {}
+
+/** Returns `true` when `globalThis` exposes a `WebTransport` constructor. */
+export const isSupportedUnsafe = (): boolean =>
+  typeof (globalThis as Record<string, unknown>)["WebTransport"] === "function";
+
+/** Effectful variant of {@link isSupportedUnsafe}. */
+export const isSupported: Effect.Effect<boolean> = Effect.sync(isSupportedUnsafe);
+
+/**
+ * Feature-detected constructor from `globalThis.WebTransport`, failing with a
+ * typed `UnsupportedError` when the platform does not implement the
+ * WebTransport API.
+ */
+export const constructorGlobal: Effect.Effect<
+  (url: string, options?: NativeConnectOptions) => NativeWebTransport,
+  WebTransportError
+> = Effect.suspend(() => {
+  const ctor = (globalThis as Record<string, unknown>)["WebTransport"];
+
+  if (typeof ctor !== "function") {
+    return Effect.fail(wtError(new UnsupportedError({ feature: "WebTransport" })));
+  }
+  const make = ctor as new (url: string, options?: NativeConnectOptions) => NativeWebTransport;
+
+  return Effect.succeed(
+    (url: string, options?: NativeConnectOptions): NativeWebTransport => new make(url, options),
+  );
+});
+
+/**
+ * Layer that provides `WebTransportConstructor` from `globalThis.WebTransport`,
+ * failing with a typed `UnsupportedError` when the platform does not implement
+ * the WebTransport API.
+ */
+export const layerConstructorGlobal: Layer.Layer<WebTransportConstructor, WebTransportError> =
+  Layer.effect(WebTransportConstructor)(constructorGlobal);
+
+// -----------------------------------------------------------------------------
+// Session model
+// -----------------------------------------------------------------------------
+
+/** Runtime type identifier attached to `WebTransport` session values. */
+export const TypeId = "~effect-webtransport/WebTransport";
+
+/** Datagram surface of a session: unreliable, bounded, backpressured. */
+export interface Datagrams {
+  /** Maximum payload size currently accepted by {@link Datagrams.send}. */
+  readonly maxDatagramSize: Effect.Effect<number, WebTransportError>;
+  /**
+   * Sends one datagram. Waits for the outgoing queue (bounded by
+   * `outgoingHighWaterMark`) to have capacity before writing, and fails with
+   * `DatagramTooLargeError` when the payload exceeds `maxDatagramSize`.
+   */
+  readonly send: (data: Uint8Array) => Effect.Effect<void, WebTransportError>;
+  /**
+   * Receives one datagram, failing with `SessionClosedError` once the incoming
+   * datagram source has ended. The incoming buffer is bounded by
+   * `incomingHighWaterMark`; the platform drops datagrams beyond it.
+   */
+  readonly take: Effect.Effect<Uint8Array, WebTransportError>;
+  /**
+   * Incoming datagrams as a pull-based stream that ends when the session
+   * closes. The underlying readable supports a single consumer at a time:
+   * while the stream is being consumed, `take` fails with a `ReadError`.
+   */
+  readonly stream: Stream.Stream<Uint8Array, WebTransportError>;
+}
+
+/**
+ * An established WebTransport session as an Effect resource.
+ *
+ * Sessions are acquired with {@link connect} inside a `Scope`; closing the
+ * scope closes the session (and thereby every stream it carries).
+ */
+export interface WebTransport {
+  readonly [TypeId]: typeof TypeId;
+  /** The underlying platform instance, for escape hatches and diagnostics. */
+  readonly native: NativeWebTransport;
+  /**
+   * Opens an outgoing reliable bidirectional stream. Releasing the scope
+   * closes the writable half (FIN) and cancels the readable half.
+   */
+  readonly openBidirectionalStream: (
+    options?: NativeSendStreamOptions,
+  ) => Effect.Effect<NativeBidirectionalStream, WebTransportError, Scope.Scope>;
+  /**
+   * Opens an outgoing reliable unidirectional (send) stream where the
+   * platform supports it. Releasing the scope closes the stream.
+   */
+  readonly openUnidirectionalStream: (
+    options?: NativeSendStreamOptions,
+  ) => Effect.Effect<WritableStream<Uint8Array>, WebTransportError, Scope.Scope>;
+  /** Bidirectional streams initiated by the peer. Single consumer. */
+  readonly incomingBidirectionalStreams: Stream.Stream<
+    NativeBidirectionalStream,
+    WebTransportError
+  >;
+  /**
+   * Unidirectional (receive) streams initiated by the peer, where the
+   * platform supports them. Single consumer.
+   */
+  readonly incomingUnidirectionalStreams: Stream.Stream<
+    ReadableStream<Uint8Array>,
+    WebTransportError
+  >;
+  /** The unreliable datagram surface of the session. */
+  readonly datagrams: Datagrams;
+  /** Closes the session and waits for closure to settle. Idempotent. */
+  readonly close: (info?: NativeCloseInfo) => Effect.Effect<void>;
+  /**
+   * Waits for the session to end. Succeeds with validated {@link CloseInfo}
+   * on clean closure and fails with `SessionClosedError` on abrupt
+   * termination.
+   */
+  readonly closed: Effect.Effect<CloseInfo, WebTransportError>;
+}
+
+/** Service tag for the current WebTransport session. */
+export const WebTransport: Context.Service<WebTransport, WebTransport> =
+  Context.Service<WebTransport>("effect-webtransport/WebTransport");
+
+const constVoid = () => undefined;
+
+const closeBidirectionalStreamSafely = (stream: NativeBidirectionalStream) =>
+  Effect.promise(async () => {
+    try {
+      await stream.writable.close();
+    } catch {
+      // already closed, errored, or locked by a consumer that owns closure
+    }
+    try {
+      await stream.readable.cancel();
+    } catch {
+      // already closed, errored, or locked by a consumer that owns closure
+    }
+  });
+
+const makeDatagrams = (native: NativeWebTransport): Datagrams => {
+  const requireDatagrams = Effect.suspend(() =>
+    native.datagrams === undefined
+      ? Effect.fail(wtError(new UnsupportedError({ feature: "Datagrams" })))
+      : Effect.succeed(native.datagrams),
+  );
+  let cachedWriter: WritableStreamDefaultWriter<Uint8Array> | undefined;
+  const send = (data: Uint8Array): Effect.Effect<void, WebTransportError> =>
+    Effect.flatMap(requireDatagrams, (datagrams) => {
+      if (data.byteLength > datagrams.maxDatagramSize) {
+        return Effect.fail(
+          wtError(
+            new DatagramTooLargeError({
+              size: data.byteLength,
+              maxDatagramSize: datagrams.maxDatagramSize,
+            }),
+          ),
+        );
+      }
+
+      return Effect.tryPromise({
+        try: async () => {
+          cachedWriter ??= datagrams.writable.getWriter();
+          const writer = cachedWriter;
+
+          await writer.ready;
+          await writer.write(data);
+        },
+        catch: (cause) => wtError(new WriteError({ source: "datagram", cause })),
+      });
+    });
+  const take: Effect.Effect<Uint8Array, WebTransportError> = Effect.flatMap(
+    requireDatagrams,
+    (datagrams) =>
+      Effect.suspend(() => {
+        let reader: ReadableStreamDefaultReader<Uint8Array>;
+
+        try {
+          reader = datagrams.readable.getReader();
+        } catch (cause) {
+          return Effect.fail(wtError(new ReadError({ source: "datagram", cause })));
+        }
+
+        return Effect.tryPromise({
+          try: () => reader.read(),
+          catch: (cause) => wtError(new ReadError({ source: "datagram", cause })),
+        }).pipe(
+          Effect.flatMap((result) =>
+            result.done
+              ? Effect.fail(wtError(new SessionClosedError({ cause: "datagram source ended" })))
+              : Effect.succeed(result.value),
+          ),
+          Effect.ensuring(
+            Effect.sync(() => {
+              try {
+                reader.releaseLock();
+              } catch {
+                // lock already released
+              }
+            }),
+          ),
+        );
+      }),
+  );
+  const stream = Stream.unwrap(
+    Effect.map(requireDatagrams, (datagrams) =>
+      Stream.fromReadableStream({
+        evaluate: () => datagrams.readable,
+        onError: (cause) => wtError(new ReadError({ source: "datagram", cause })),
+        releaseLockOnEnd: true,
+      }),
+    ),
+  );
+  const maxDatagramSize = Effect.map(requireDatagrams, (datagrams) => datagrams.maxDatagramSize);
+
+  return { maxDatagramSize, send, take, stream };
+};
+
+/**
+ * Wraps an established platform instance as a `WebTransport` session.
+ *
+ * The wrapper does not own the session lifecycle; prefer {@link connect} for
+ * scoped acquisition. This is the substitution point for tests and for future
+ * server-side session objects handed to an application by a runtime.
+ */
+export const fromNative = (native: NativeWebTransport): WebTransport => ({
+  [TypeId]: TypeId,
+  native,
+  openBidirectionalStream: (options?: NativeSendStreamOptions) =>
+    Effect.acquireRelease(
+      Effect.tryPromise({
+        try: () => native.createBidirectionalStream(options),
+        catch: (cause) => wtError(new StreamOpenError({ direction: "bidirectional", cause })),
+      }),
+      closeBidirectionalStreamSafely,
+    ),
+  openUnidirectionalStream: (options?: NativeSendStreamOptions) =>
+    Effect.suspend(() => {
+      const create = native.createUnidirectionalStream;
+
+      if (typeof create !== "function") {
+        return Effect.fail(wtError(new UnsupportedError({ feature: "UnidirectionalStreams" })));
+      }
+
+      return Effect.acquireRelease(
+        Effect.tryPromise({
+          try: () => create.call(native, options),
+          catch: (cause) => wtError(new StreamOpenError({ direction: "unidirectional", cause })),
+        }),
+        (writable) => Effect.promise(() => writable.close().then(constVoid, constVoid)),
+      );
+    }),
+  incomingBidirectionalStreams: Stream.fromReadableStream({
+    evaluate: () => native.incomingBidirectionalStreams,
+    onError: (cause) => wtError(new ReadError({ source: "incomingStreams", cause })),
+  }),
+  incomingUnidirectionalStreams: Stream.unwrap(
+    Effect.suspend(() =>
+      native.incomingUnidirectionalStreams === undefined
+        ? Effect.fail(wtError(new UnsupportedError({ feature: "UnidirectionalStreams" })))
+        : Effect.succeed(
+            Stream.fromReadableStream({
+              evaluate: () => native.incomingUnidirectionalStreams!,
+              onError: (cause) => wtError(new ReadError({ source: "incomingStreams", cause })),
+            }),
+          ),
+    ),
+  ),
+  datagrams: makeDatagrams(native),
+  close: (info?: NativeCloseInfo) =>
+    Effect.promise(async () => {
+      try {
+        native.close(info);
+      } catch {
+        // session already closed or failed
+      }
+      await native.closed.then(constVoid, constVoid);
+    }),
+  closed: Effect.tryPromise({
+    try: () => native.closed,
+    catch: (cause) => wtError(new SessionClosedError({ cause })),
+  }).pipe(
+    Effect.flatMap((info) => {
+      const result = decodeCloseInfo(info);
+
+      return Result.isSuccess(result)
+        ? Effect.succeed(result.success)
+        : Effect.fail(wtError(new SessionClosedError({ cause: result.failure })));
+    }),
+  ),
+});
+
+// -----------------------------------------------------------------------------
+// Session acquisition
+// -----------------------------------------------------------------------------
+
+/** Bounded-buffer configuration applied to the datagram surface on connect. */
+export interface DatagramBufferOptions {
+  readonly incomingHighWaterMark?: number | undefined;
+  readonly outgoingHighWaterMark?: number | undefined;
+  readonly incomingMaxAge?: number | null | undefined;
+  readonly outgoingMaxAge?: number | null | undefined;
+}
+
+/** Options accepted by {@link connect} and {@link layer}. */
+export interface ConnectOptions extends NativeConnectOptions {
+  /** Time to wait for the session handshake. Defaults to 10 seconds. */
+  readonly openTimeout?: Duration.Input | undefined;
+  /** Close information sent when the owning scope closes the session. */
+  readonly closeInfo?: NativeCloseInfo | undefined;
+  /** Bounded-buffer configuration for the datagram surface. */
+  readonly datagrams?: DatagramBufferOptions | undefined;
+}
+
+/**
+ * Acquires a WebTransport session as a scoped resource: constructs the
+ * platform instance via {@link WebTransportConstructor}, waits for the
+ * handshake with a timeout, and closes the session (awaiting settlement of
+ * `closed`) when the scope ends — including on interruption.
+ */
+export const connect = Effect.fn("WebTransport.connect")(function* (
+  url: string | Effect.Effect<string>,
+  options?: ConnectOptions,
+): Effect.fn.Return<WebTransport, WebTransportError, WebTransportConstructor | Scope.Scope> {
+  const makeNative = yield* WebTransportConstructor;
+  const resolvedUrl = typeof url === "string" ? url : yield* url;
+  const native = yield* Effect.acquireRelease(
+    Effect.try({
+      try: () => makeNative(resolvedUrl, options),
+      catch: (cause) => wtError(new ConnectError({ kind: "OpenFailed", cause })),
+    }),
+    (native) =>
+      Effect.promise(async () => {
+        try {
+          native.close(options?.closeInfo);
+        } catch {
+          // session already closed or failed
+        }
+        await native.closed.then(constVoid, constVoid);
+      }),
+  );
+
+  yield* Effect.tryPromise({
+    try: () => native.ready,
+    catch: (cause) => wtError(new ConnectError({ kind: "OpenFailed", cause })),
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: options?.openTimeout ?? 10000,
+      orElse: () =>
+        Effect.fail(
+          wtError(
+            new ConnectError({
+              kind: "Timeout",
+              cause: new Error(`timeout waiting for WebTransport session "ready"`),
+            }),
+          ),
+        ),
+    }),
+  );
+  const datagramOptions = options?.datagrams;
+
+  if (datagramOptions !== undefined && native.datagrams !== undefined) {
+    const datagrams = native.datagrams;
+
+    if (datagramOptions.incomingHighWaterMark !== undefined) {
+      datagrams.incomingHighWaterMark = datagramOptions.incomingHighWaterMark;
+    }
+    if (datagramOptions.outgoingHighWaterMark !== undefined) {
+      datagrams.outgoingHighWaterMark = datagramOptions.outgoingHighWaterMark;
+    }
+    if (datagramOptions.incomingMaxAge !== undefined) {
+      datagrams.incomingMaxAge = datagramOptions.incomingMaxAge;
+    }
+    if (datagramOptions.outgoingMaxAge !== undefined) {
+      datagrams.outgoingMaxAge = datagramOptions.outgoingMaxAge;
+    }
+  }
+
+  return fromNative(native);
+});
+
+/**
+ * Layer that provides a `WebTransport` session for the layer's lifetime,
+ * connecting on build and closing the session when the layer is released.
+ */
+export const layer = (
+  url: string | Effect.Effect<string>,
+  options?: ConnectOptions,
+): Layer.Layer<WebTransport, WebTransportError, WebTransportConstructor> =>
+  Layer.effect(WebTransport)(connect(url, options));
+
+// -----------------------------------------------------------------------------
+// Stream helpers
+// -----------------------------------------------------------------------------
+
+/** Reads a WebTransport receive stream as a byte `Stream`, ending on FIN. */
+export const readStream = (
+  readable: ReadableStream<Uint8Array>,
+): Stream.Stream<Uint8Array, WebTransportError> =>
+  Stream.fromReadableStream({
+    evaluate: () => readable,
+    onError: (cause) => wtError(new ReadError({ source: "stream", cause })),
+  });
+
+/**
+ * Acquires a scoped, backpressured writer for a WebTransport send stream.
+ * Each write waits for queue capacity (`writer.ready`) before enqueueing.
+ * Releasing the scope closes the stream (FIN).
+ */
+export const writer = (
+  writable: WritableStream<Uint8Array>,
+): Effect.Effect<
+  (chunk: Uint8Array) => Effect.Effect<void, WebTransportError>,
+  WebTransportError,
+  Scope.Scope
+> =>
+  Effect.acquireRelease(
+    Effect.try({
+      try: () => writable.getWriter(),
+      catch: (cause) => wtError(new WriteError({ source: "stream", cause })),
+    }),
+    (writer) => Effect.promise(() => writer.close().then(constVoid, constVoid)),
+  ).pipe(
+    Effect.map(
+      (writer) =>
+        (chunk: Uint8Array): Effect.Effect<void, WebTransportError> =>
+          Effect.tryPromise({
+            try: async () => {
+              await writer.ready;
+              await writer.write(chunk);
+            },
+            catch: (cause) => wtError(new WriteError({ source: "stream", cause })),
+          }),
+    ),
+  );

--- a/packages/effect-webtransport/src/WebTransportSocket.ts
+++ b/packages/effect-webtransport/src/WebTransportSocket.ts
@@ -1,0 +1,213 @@
+/**
+ * Adapts a single reliable bidirectional WebTransport stream to
+ * `effect/unstable/socket` `Socket`, so existing Effect socket consumers —
+ * including `RpcClient.layerProtocolSocket` — can run over WebTransport in a
+ * lowest-common-denominator mode.
+ *
+ * Two honest limitations of this mode:
+ *
+ * - It uses exactly one reliable bidirectional stream. QUIC stream
+ *   multiplexing and unreliable datagrams are not exercised; head-of-line
+ *   blocking within the single stream applies.
+ * - WebTransport streams are byte streams without message framing (unlike
+ *   WebSocket). Pair the socket with a self-delimiting serialization such as
+ *   `RpcSerialization.layerNdjson` or `layerMsgPack` — plain `layerJson`
+ *   relies on chunk boundaries that real transports do not preserve.
+ *
+ * The implementation mirrors `Socket.fromTransformStream`, hardened for
+ * WebTransport semantics: stream errors surface as typed `SocketReadError` /
+ * `SocketWriteError` values (never finalizer defects), writes respect the
+ * writable stream's backpressure, and each finished run closes its stream
+ * with a FIN.
+ */
+import { Context, Deferred, Effect, FiberSet, Latch, Layer, Scope } from "effect";
+import { Socket } from "effect/unstable/socket";
+
+import * as WebTransport from "./WebTransport";
+
+/** Options for adapting a bidirectional stream to a `Socket`. */
+export interface FromBidirectionalStreamOptions {
+  /**
+   * Classifies which close codes fail the socket run. WebTransport streams
+   * have no close codes of their own; a graceful FIN surfaces as code `1000`,
+   * which is treated as a clean end by default.
+   */
+  readonly closeCodeIsError?: ((code: number) => boolean) | undefined;
+}
+
+/** Options accepted by {@link makeSocket} and {@link layerSocket}. */
+export interface MakeSocketOptions extends FromBidirectionalStreamOptions {
+  /** Options applied when opening each outgoing bidirectional stream. */
+  readonly sendStream?: WebTransport.NativeSendStreamOptions | undefined;
+}
+
+/** Default close-code classifier: only a graceful end (code 1000) is clean. */
+export const defaultCloseCodeIsError = (code: number): boolean => code !== 1000;
+
+const toSocketOpenError = (error: WebTransport.WebTransportError): Socket.SocketError =>
+  new Socket.SocketError({
+    reason: new Socket.SocketOpenError({ kind: "Unknown", cause: error }),
+  });
+
+const encoder = new TextEncoder();
+
+const swallow = () => undefined;
+
+/**
+ * Builds a `Socket` from a scoped acquisition of one reliable bidirectional
+ * WebTransport stream. The acquisition runs once per `Socket.run`, so a
+ * retried run opens a fresh stream on the same session; when a run ends, its
+ * stream is closed (FIN) and its read side cancelled.
+ */
+export const fromBidirectionalStream = <R>(
+  acquire: Effect.Effect<WebTransport.NativeBidirectionalStream, WebTransport.WebTransportError, R>,
+  options?: FromBidirectionalStreamOptions,
+): Effect.Effect<Socket.Socket, never, Exclude<R, Scope.Scope>> =>
+  Effect.withFiber((fiber) => {
+    const latch = Latch.makeUnsafe(false);
+    let current:
+      | {
+          readonly writer: WritableStreamDefaultWriter<Uint8Array>;
+          readonly fiberSet: FiberSet.FiberSet<any, any>;
+        }
+      | undefined;
+    const acquireServices = fiber.context as Context.Context<R>;
+    const closeCodeIsError = options?.closeCodeIsError ?? defaultCloseCodeIsError;
+
+    const runRaw = <_, E, R2>(
+      handler: (_: string | Uint8Array) => Effect.Effect<_, E, R2> | void,
+      opts?: {
+        readonly onOpen?: Effect.Effect<void> | undefined;
+      },
+    ) =>
+      Effect.scopedWith(
+        Effect.fnUntraced(function* (scope) {
+          const stream = yield* Scope.provide(Effect.mapError(acquire, toSocketOpenError), scope);
+          const reader = stream.readable.getReader();
+
+          yield* Scope.addFinalizer(
+            scope,
+            Effect.promise(() => reader.cancel().then(swallow, swallow)),
+          );
+          const writer = stream.writable.getWriter();
+
+          yield* Scope.addFinalizer(
+            scope,
+            Effect.promise(() => writer.close().then(swallow, swallow)),
+          );
+          const fiberSet = yield* FiberSet.make<any, E | Socket.SocketError>().pipe(
+            Scope.provide(scope),
+          );
+          const runFork = yield* FiberSet.runtime(fiberSet)<R2>();
+
+          yield* Effect.tryPromise({
+            try: async () => {
+              while (true) {
+                const { done, value } = await reader.read();
+
+                if (done) {
+                  throw new Socket.SocketError({
+                    reason: new Socket.SocketCloseError({ code: 1000 }),
+                  });
+                }
+                const result = handler(value);
+
+                if (Effect.isEffect(result)) {
+                  runFork(result);
+                }
+              }
+            },
+            catch: (cause) =>
+              Socket.isSocketError(cause)
+                ? cause
+                : new Socket.SocketError({ reason: new Socket.SocketReadError({ cause }) }),
+          }).pipe(FiberSet.run(fiberSet));
+
+          current = { writer, fiberSet };
+          yield* latch.open;
+          if (opts?.onOpen) yield* opts.onOpen;
+
+          return yield* Effect.catchFilter(
+            FiberSet.join(fiberSet),
+            Socket.SocketCloseError.filterClean((code) => !closeCodeIsError(code)),
+            () => Effect.void,
+          );
+        }),
+      ).pipe(
+        Effect.updateContext((input: Context.Context<R2>) => Context.merge(acquireServices, input)),
+        Effect.ensuring(
+          Effect.sync(() => {
+            latch.closeUnsafe();
+            current = undefined;
+          }),
+        ),
+      );
+
+    const write = (chunk: Uint8Array | string | Socket.CloseEvent) =>
+      latch.whenOpen(
+        Effect.suspend(() => {
+          const { fiberSet, writer } = current!;
+
+          if (Socket.isCloseEvent(chunk)) {
+            return Deferred.fail(
+              fiberSet.deferred,
+              new Socket.SocketError({
+                reason: new Socket.SocketCloseError({
+                  code: chunk.code,
+                  closeReason: chunk.reason,
+                }),
+              }),
+            );
+          }
+
+          return Effect.tryPromise({
+            try: async () => {
+              const data = typeof chunk === "string" ? encoder.encode(chunk) : chunk;
+
+              await writer.ready;
+              await writer.write(data);
+            },
+            catch: (cause) =>
+              new Socket.SocketError({ reason: new Socket.SocketWriteError({ cause }) }),
+          });
+        }),
+      );
+
+    return Effect.succeed(
+      Socket.make({
+        runRaw,
+        writer: Effect.succeed(write),
+      }),
+    );
+  });
+
+/**
+ * Builds a `Socket` backed by the current `WebTransport` session, opening a
+ * fresh reliable bidirectional stream for each `Socket.run`.
+ */
+export const makeSocket = (
+  options?: MakeSocketOptions,
+): Effect.Effect<Socket.Socket, never, WebTransport.WebTransport> =>
+  Effect.flatMap(WebTransport.WebTransport, (session) =>
+    fromBidirectionalStream(session.openBidirectionalStream(options?.sendStream), options),
+  );
+
+/** Layer that provides a `Socket` backed by the current `WebTransport` session. */
+export const layerSocket = (
+  options?: MakeSocketOptions,
+): Layer.Layer<Socket.Socket, never, WebTransport.WebTransport> =>
+  Layer.effect(Socket.Socket)(makeSocket(options));
+
+/**
+ * Layer that connects a WebTransport session to `url` and provides a `Socket`
+ * over one reliable bidirectional stream per run. The session lives as long
+ * as the layer.
+ */
+export const layerSocketWebTransport = (
+  url: string | Effect.Effect<string>,
+  options?: MakeSocketOptions & WebTransport.ConnectOptions,
+): Layer.Layer<
+  Socket.Socket,
+  WebTransport.WebTransportError,
+  WebTransport.WebTransportConstructor
+> => layerSocket(options).pipe(Layer.provide(WebTransport.layer(url, options)));

--- a/packages/effect-webtransport/src/index.ts
+++ b/packages/effect-webtransport/src/index.ts
@@ -1,0 +1,3 @@
+export * as Fallback from "./Fallback";
+export * as WebTransport from "./WebTransport";
+export * as WebTransportSocket from "./WebTransportSocket";

--- a/packages/effect-webtransport/tests/Fallback.test.ts
+++ b/packages/effect-webtransport/tests/Fallback.test.ts
@@ -1,0 +1,122 @@
+import { assert, describe, it } from "@effect/vitest";
+import { Data, Effect } from "effect";
+import { Socket } from "effect/unstable/socket";
+
+import * as Fallback from "../src/Fallback";
+import * as WebTransport from "../src/WebTransport";
+import { makeFakeBidi, makeFakeWebTransport, type FakeWebTransportHandle } from "./fakes";
+
+class NopeError extends Data.TaggedError("NopeError")<{}> {}
+
+const provideConstructor = (handle: FakeWebTransportHandle) =>
+  Effect.provideService(
+    WebTransport.WebTransportConstructor,
+    WebTransport.WebTransportConstructor.of(() => handle.native),
+  );
+
+const workingCandidate = (
+  name: string,
+  onAcquire?: () => void,
+): Fallback.Candidate<never, never> => ({
+  name,
+  socket: Effect.suspend(() => {
+    onAcquire?.();
+
+    return Socket.fromTransformStream(Effect.succeed(makeFakeBidi().native));
+  }),
+});
+
+describe("Fallback", () => {
+  it.effect("pins the first successful candidate", () =>
+    Effect.gen(function* () {
+      const acquisitions: Array<string> = [];
+      const selected = yield* Effect.scoped(
+        Fallback.select([
+          workingCandidate("first", () => acquisitions.push("first")),
+          workingCandidate("second", () => acquisitions.push("second")),
+        ]),
+      );
+
+      assert.strictEqual(selected.name, "first");
+      assert.isTrue(Socket.isSocket(selected.socket));
+      assert.deepStrictEqual(acquisitions, ["first"]);
+    }),
+  );
+
+  it.effect("falls back when the WebTransport handshake fails and releases its resources", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ ready: { reject: new Error("handshake refused") } });
+      const selected = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const selected = yield* Fallback.select([
+            Fallback.webTransport("https://example.com/wt"),
+            workingCandidate("fallback"),
+          ]);
+
+          // The failed WebTransport candidate's session is torn down before
+          // the next candidate is tried.
+          assert.strictEqual(fake.closeCalls.length, 1);
+
+          return selected;
+        }).pipe(provideConstructor(fake)),
+      );
+
+      assert.strictEqual(selected.name, "fallback");
+    }),
+  );
+
+  it.effect("fails typed when every candidate fails", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ ready: { reject: new Error("handshake refused") } });
+      const failing: Fallback.Candidate<NopeError, never> = {
+        name: "always-fails",
+        socket: Effect.fail(new NopeError()),
+      };
+      const error = yield* Effect.scoped(
+        Fallback.select([Fallback.webTransport("https://example.com/wt"), failing]).pipe(
+          provideConstructor(fake),
+        ),
+      ).pipe(Effect.flip);
+
+      assert.strictEqual(error._tag, "TransportSelectionError");
+      assert.deepStrictEqual(
+        error.failures.map((failure) => failure.name),
+        ["webtransport", "always-fails"],
+      );
+      assert.isTrue(WebTransport.WebTransportError.is(error.failures[0]!.cause));
+    }),
+  );
+
+  it.effect("falls back when the platform lacks WebTransport entirely", () =>
+    Effect.gen(function* () {
+      // No WebTransportConstructor provided and no global available in Node:
+      // the candidate must fail typed and selection must move on.
+      const selected = yield* Effect.scoped(
+        Fallback.select([
+          Fallback.webTransport("https://example.com/wt"),
+          workingCandidate("fallback"),
+        ]),
+      );
+
+      assert.strictEqual(selected.name, "fallback");
+    }),
+  );
+
+  it.effect("webSocket candidates acquire lazily and carry their name", () =>
+    Effect.gen(function* () {
+      const candidate = Fallback.webSocket("wss://example.com", { name: "ws-fallback" });
+
+      assert.strictEqual(candidate.name, "ws-fallback");
+      const selected = yield* Effect.scoped(Fallback.select([candidate])).pipe(
+        Effect.provideService(
+          Socket.WebSocketConstructor,
+          Socket.WebSocketConstructor.of(() => {
+            throw new Error("must not connect during selection");
+          }),
+        ),
+      );
+
+      assert.strictEqual(selected.name, "ws-fallback");
+    }),
+  );
+});

--- a/packages/effect-webtransport/tests/Rpc.test.ts
+++ b/packages/effect-webtransport/tests/Rpc.test.ts
@@ -1,0 +1,95 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer, Schema } from "effect";
+import { Rpc, RpcClient, RpcGroup, RpcSerialization, RpcServer } from "effect/unstable/rpc";
+import { Socket, SocketServer } from "effect/unstable/socket";
+
+import * as WebTransport from "../src/WebTransport";
+import * as WebTransportSocket from "../src/WebTransportSocket";
+
+class Ping extends Rpc.make("Ping", {
+  payload: { nonce: Schema.String },
+  success: Schema.Struct({ nonce: Schema.String }),
+}) {}
+class TestRpcs extends RpcGroup.make(Ping) {}
+
+const TestHandlers = TestRpcs.toLayer(
+  Effect.succeed(
+    TestRpcs.of({
+      Ping: ({ nonce }) => Effect.succeed({ nonce }),
+    }),
+  ),
+);
+
+interface ServerStream {
+  readonly readable: ReadableStream<Uint8Array>;
+  readonly writable: WritableStream<Uint8Array>;
+}
+
+/**
+ * An in-memory "wire": the client's WebTransport session hands out one end of
+ * a byte-stream pair per opened bidirectional stream, and a fake
+ * `SocketServer` serves the other end to a real Effect `RpcServer`.
+ */
+const makeWire = () => {
+  let resolveServerStream!: (stream: ServerStream) => void;
+  const serverStream = new Promise<ServerStream>((resolve) => {
+    resolveServerStream = resolve;
+  });
+  const native: WebTransport.NativeWebTransport = {
+    ready: Promise.resolve(),
+    closed: new Promise<never>(() => {}),
+    close: () => {},
+    createBidirectionalStream: () => {
+      const clientToServer = new TransformStream<Uint8Array, Uint8Array>();
+      const serverToClient = new TransformStream<Uint8Array, Uint8Array>();
+
+      resolveServerStream({
+        readable: clientToServer.readable,
+        writable: serverToClient.writable,
+      });
+
+      return Promise.resolve({
+        readable: serverToClient.readable,
+        writable: clientToServer.writable,
+      });
+    },
+    incomingBidirectionalStreams: new ReadableStream<WebTransport.NativeBidirectionalStream>(),
+  };
+  const socketServer = SocketServer.SocketServer.of({
+    address: { _tag: "TcpAddress", hostname: "in-memory", port: 0 },
+    run: (handler) =>
+      Effect.gen(function* () {
+        const stream = yield* Effect.promise(() => serverStream);
+        const socket = yield* Socket.fromTransformStream(Effect.succeed(stream));
+
+        return yield* handler(socket).pipe(Effect.andThen(Effect.never), Effect.orDie);
+      }),
+  });
+
+  return { native, socketServer };
+};
+
+it.effect("Effect RPC round-trips over a WebTransport bidirectional stream", () =>
+  Effect.gen(function* () {
+    const wire = makeWire();
+
+    const serverLive = RpcServer.layer(TestRpcs).pipe(
+      Layer.provide(TestHandlers),
+      Layer.provide(RpcServer.layerProtocolSocketServer),
+      Layer.provide(Layer.succeed(SocketServer.SocketServer)(wire.socketServer)),
+      Layer.provide(RpcSerialization.layerNdjson),
+    );
+    const clientLive = RpcClient.layerProtocolSocket().pipe(
+      Layer.provide(WebTransportSocket.layerSocket()),
+      Layer.provide(Layer.succeed(WebTransport.WebTransport)(WebTransport.fromNative(wire.native))),
+      Layer.provide(RpcSerialization.layerNdjson),
+    );
+
+    yield* Effect.gen(function* () {
+      const client = yield* RpcClient.make(TestRpcs);
+      const result = yield* client.Ping({ nonce: "abc" });
+
+      assert.deepStrictEqual(result, { nonce: "abc" });
+    }).pipe(Effect.scoped, Effect.provide(Layer.mergeAll(clientLive, serverLive)));
+  }),
+);

--- a/packages/effect-webtransport/tests/WebTransport.test.ts
+++ b/packages/effect-webtransport/tests/WebTransport.test.ts
@@ -1,0 +1,448 @@
+import { assert, describe, it } from "@effect/vitest";
+import { Effect, Exit, Fiber, Scope, Stream } from "effect";
+import { TestClock } from "effect/testing";
+
+import * as WebTransport from "../src/WebTransport";
+import { makeFakeBidi, makeFakeWebTransport, type FakeWebTransportHandle } from "./fakes";
+
+const bytes = (...values: Array<number>) => Uint8Array.from(values);
+
+const provideConstructor = (handle: FakeWebTransportHandle, urls?: Array<string>) =>
+  Effect.provideService(
+    WebTransport.WebTransportConstructor,
+    WebTransport.WebTransportConstructor.of((url) => {
+      urls?.push(url);
+
+      return handle.native;
+    }),
+  );
+
+const tick = Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+
+const waitFor = (condition: () => boolean) =>
+  Effect.gen(function* () {
+    for (let i = 0; i < 100 && !condition(); i++) {
+      yield* tick;
+    }
+    assert.isTrue(condition(), "condition not reached");
+  });
+
+const expectReason = (
+  error: unknown,
+  tag: WebTransport.WebTransportErrorReason["_tag"],
+): WebTransport.WebTransportErrorReason => {
+  assert.isTrue(WebTransport.WebTransportError.is(error), `not a WebTransportError: ${error}`);
+  const reason = (error as WebTransport.WebTransportError).reason;
+
+  assert.strictEqual(reason._tag, tag);
+
+  return reason;
+};
+
+describe("connect", () => {
+  it.effect("acquires a session and closes it when the scope closes", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const urls: Array<string> = [];
+      const scope = yield* Scope.make();
+      const session = yield* WebTransport.connect("https://example.com/wt", {
+        closeInfo: { closeCode: 7, reason: "done" },
+      }).pipe(Scope.provide(scope), provideConstructor(fake, urls));
+
+      assert.deepStrictEqual(urls, ["https://example.com/wt"]);
+      assert.strictEqual(session.native, fake.native);
+      assert.deepStrictEqual(fake.closeCalls, []);
+      yield* Scope.close(scope, Exit.void);
+      assert.deepStrictEqual(fake.closeCalls, [{ closeCode: 7, reason: "done" }]);
+    }),
+  );
+
+  it.effect("maps a throwing constructor to ConnectError", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.scoped(WebTransport.connect("https://example.com")).pipe(
+        Effect.provideService(
+          WebTransport.WebTransportConstructor,
+          WebTransport.WebTransportConstructor.of(() => {
+            throw new Error("bad url");
+          }),
+        ),
+        Effect.flip,
+      );
+      const reason = expectReason(error, "ConnectError");
+
+      assert.strictEqual((reason as WebTransport.ConnectError).kind, "OpenFailed");
+    }),
+  );
+
+  it.effect("maps a rejected handshake to ConnectError and still closes", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ ready: { reject: new Error("handshake failed") } });
+      const error = yield* Effect.scoped(WebTransport.connect("https://example.com")).pipe(
+        provideConstructor(fake),
+        Effect.flip,
+      );
+      const reason = expectReason(error, "ConnectError");
+
+      assert.strictEqual((reason as WebTransport.ConnectError).kind, "OpenFailed");
+      assert.strictEqual(fake.closeCalls.length, 1);
+    }),
+  );
+
+  it.effect("times out waiting for the handshake", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ ready: "pending" });
+      const fiber = yield* Effect.scoped(
+        WebTransport.connect("https://example.com", { openTimeout: 1000 }),
+      ).pipe(provideConstructor(fake), Effect.flip, Effect.forkChild);
+
+      yield* TestClock.adjust(1001);
+      const error = yield* Fiber.join(fiber);
+      const reason = expectReason(error, "ConnectError");
+
+      assert.strictEqual((reason as WebTransport.ConnectError).kind, "Timeout");
+      assert.strictEqual(fake.closeCalls.length, 1);
+    }),
+  );
+
+  it.effect("applies datagram buffer options", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          yield* WebTransport.connect("https://example.com", {
+            datagrams: {
+              incomingHighWaterMark: 5,
+              outgoingHighWaterMark: 7,
+              incomingMaxAge: 100,
+              outgoingMaxAge: null,
+            },
+          });
+          const datagrams = fake.datagrams!.native;
+
+          assert.strictEqual(datagrams.incomingHighWaterMark, 5);
+          assert.strictEqual(datagrams.outgoingHighWaterMark, 7);
+          assert.strictEqual(datagrams.incomingMaxAge, 100);
+          assert.strictEqual(datagrams.outgoingMaxAge, null);
+        }),
+      ).pipe(provideConstructor(fake));
+    }),
+  );
+});
+
+describe("feature detection", () => {
+  it.effect("isSupported is false without a global constructor", () =>
+    Effect.gen(function* () {
+      assert.isFalse(yield* WebTransport.isSupported);
+    }),
+  );
+
+  it.effect("layerConstructorGlobal fails typed without a global constructor", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.scoped(WebTransport.connect("https://example.com")).pipe(
+        Effect.provide(WebTransport.layerConstructorGlobal),
+        Effect.flip,
+      );
+      const reason = expectReason(error, "UnsupportedError");
+
+      assert.strictEqual((reason as WebTransport.UnsupportedError).feature, "WebTransport");
+    }),
+  );
+
+  it.effect("layerConstructorGlobal uses the platform constructor when present", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const urls: Array<string> = [];
+
+      class StubWebTransport {
+        constructor(url: string) {
+          urls.push(url);
+
+          // eslint-disable-next-line no-constructor-return
+          return fake.native as unknown as StubWebTransport;
+        }
+      }
+      (globalThis as Record<string, unknown>)["WebTransport"] = StubWebTransport;
+      yield* Effect.gen(function* () {
+        assert.isTrue(yield* WebTransport.isSupported);
+        yield* Effect.scoped(WebTransport.connect("https://example.com/session")).pipe(
+          Effect.provide(WebTransport.layerConstructorGlobal),
+        );
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            delete (globalThis as Record<string, unknown>)["WebTransport"];
+          }),
+        ),
+      );
+      assert.deepStrictEqual(urls, ["https://example.com/session"]);
+      assert.strictEqual(fake.closeCalls.length, 1);
+    }),
+  );
+});
+
+describe("streams", () => {
+  it.effect("openBidirectionalStream opens and closes with its scope", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const stream = yield* session.openBidirectionalStream({ sendOrder: 3 });
+
+          assert.strictEqual(stream, fake.bidis[0]!.native);
+          assert.deepStrictEqual(fake.bidiCalls, [{ sendOrder: 3 }]);
+        }),
+      );
+      assert.isTrue(fake.bidis[0]!.writableClosed());
+      assert.isTrue(fake.bidis[0]!.readableCancelled());
+    }),
+  );
+
+  it.effect("openBidirectionalStream maps open failures to StreamOpenError", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ failBidiOpen: new Error("too many streams") });
+      const session = WebTransport.fromNative(fake.native);
+      const error = yield* Effect.scoped(session.openBidirectionalStream()).pipe(Effect.flip);
+      const reason = expectReason(error, "StreamOpenError");
+
+      assert.strictEqual((reason as WebTransport.StreamOpenError).direction, "bidirectional");
+    }),
+  );
+
+  it.effect("openUnidirectionalStream fails typed when the platform lacks it", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ omitUnidirectional: true });
+      const session = WebTransport.fromNative(fake.native);
+      const error = yield* Effect.scoped(session.openUnidirectionalStream()).pipe(Effect.flip);
+      const reason = expectReason(error, "UnsupportedError");
+
+      assert.strictEqual(
+        (reason as WebTransport.UnsupportedError).feature,
+        "UnidirectionalStreams",
+      );
+    }),
+  );
+
+  it.effect("openUnidirectionalStream closes the stream with its scope", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const writable = yield* session.openUnidirectionalStream();
+          const write = yield* WebTransport.writer(writable);
+
+          yield* write(bytes(1, 2, 3));
+        }),
+      );
+      assert.deepStrictEqual(fake.uniStreams[0]!.written, [bytes(1, 2, 3)]);
+      assert.isTrue(fake.uniStreams[0]!.closedCalled());
+    }),
+  );
+
+  it.effect("incomingBidirectionalStreams surfaces peer-initiated streams", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+      const first = makeFakeBidi();
+      const second = makeFakeBidi();
+
+      fake.pushIncomingBidi(first.native);
+      fake.pushIncomingBidi(second.native);
+      fake.endIncomingBidi();
+      const collected = yield* Stream.runCollect(session.incomingBidirectionalStreams);
+
+      assert.deepStrictEqual(collected, [first.native, second.native]);
+    }),
+  );
+
+  it.effect("incomingUnidirectionalStreams fails typed when the platform lacks them", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ omitUnidirectional: true });
+      const session = WebTransport.fromNative(fake.native);
+      const error = yield* Stream.runCollect(session.incomingUnidirectionalStreams).pipe(
+        Effect.flip,
+      );
+      const reason = expectReason(error, "UnsupportedError");
+
+      assert.strictEqual(
+        (reason as WebTransport.UnsupportedError).feature,
+        "UnidirectionalStreams",
+      );
+    }),
+  );
+
+  it.effect("readStream reads bytes until FIN", () =>
+    Effect.gen(function* () {
+      const bidi = makeFakeBidi();
+
+      bidi.push(bytes(1));
+      bidi.push(bytes(2, 3));
+      bidi.end();
+      const collected = yield* Stream.runCollect(WebTransport.readStream(bidi.native.readable));
+
+      assert.deepStrictEqual(collected, [bytes(1), bytes(2, 3)]);
+    }),
+  );
+
+  it.effect("readStream maps stream failures to ReadError", () =>
+    Effect.gen(function* () {
+      const bidi = makeFakeBidi();
+
+      bidi.fail(new Error("reset"));
+      const error = yield* Stream.runCollect(WebTransport.readStream(bidi.native.readable)).pipe(
+        Effect.flip,
+      );
+
+      expectReason(error, "ReadError");
+    }),
+  );
+});
+
+describe("datagrams", () => {
+  it.effect("send writes datagrams and take receives them", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      yield* session.datagrams.send(bytes(1, 2));
+      assert.deepStrictEqual(fake.datagrams!.sent, [bytes(1, 2)]);
+      fake.datagrams!.push(bytes(9));
+      assert.deepStrictEqual(yield* session.datagrams.take, bytes(9));
+    }),
+  );
+
+  it.effect("send fails typed when the payload exceeds maxDatagramSize", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ datagrams: { maxDatagramSize: 2 } });
+      const session = WebTransport.fromNative(fake.native);
+
+      assert.strictEqual(yield* session.datagrams.maxDatagramSize, 2);
+      const error = yield* session.datagrams.send(bytes(1, 2, 3)).pipe(Effect.flip);
+      const reason = expectReason(error, "DatagramTooLargeError");
+
+      assert.strictEqual((reason as WebTransport.DatagramTooLargeError).size, 3);
+      assert.strictEqual((reason as WebTransport.DatagramTooLargeError).maxDatagramSize, 2);
+      assert.deepStrictEqual(fake.datagrams!.sent, []);
+    }),
+  );
+
+  it.effect("send waits for the outgoing sink (backpressure)", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ datagrams: { gated: true } });
+      const session = WebTransport.fromNative(fake.native);
+      const fiber = yield* Effect.forkChild(
+        Effect.andThen(session.datagrams.send(bytes(1)), session.datagrams.send(bytes(2))),
+      );
+
+      yield* waitFor(() => fake.datagrams!.pendingWrites() === 1);
+      assert.deepStrictEqual(fake.datagrams!.sent, []);
+      fake.datagrams!.releaseOne();
+      yield* waitFor(() => fake.datagrams!.pendingWrites() === 1);
+      assert.deepStrictEqual(fake.datagrams!.sent, [bytes(1)]);
+      fake.datagrams!.releaseOne();
+      yield* Fiber.join(fiber);
+      assert.deepStrictEqual(fake.datagrams!.sent, [bytes(1), bytes(2)]);
+    }),
+  );
+
+  it.effect("take fails typed once the datagram source ends", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      fake.datagrams!.end();
+      const error = yield* session.datagrams.take.pipe(Effect.flip);
+
+      expectReason(error, "SessionClosedError");
+    }),
+  );
+
+  it.effect("stream yields datagrams and ends when the source ends", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      fake.datagrams!.push(bytes(1));
+      fake.datagrams!.push(bytes(2));
+      fake.datagrams!.end();
+      const collected = yield* Stream.runCollect(session.datagrams.stream);
+
+      assert.deepStrictEqual(collected, [bytes(1), bytes(2)]);
+    }),
+  );
+
+  it.effect("every datagram operation fails typed when the platform lacks datagrams", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ omitDatagrams: true });
+      const session = WebTransport.fromNative(fake.native);
+
+      for (const operation of [
+        session.datagrams.send(bytes(1)),
+        session.datagrams.take,
+        session.datagrams.maxDatagramSize,
+        Stream.runCollect(session.datagrams.stream),
+      ] as const) {
+        const reason = expectReason(yield* Effect.flip(operation), "UnsupportedError");
+
+        assert.strictEqual((reason as WebTransport.UnsupportedError).feature, "Datagrams");
+      }
+    }),
+  );
+});
+
+describe("session closure", () => {
+  it.effect("closed decodes clean close info", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      fake.resolveClosed({ closeCode: 42, reason: "bye" });
+      const info = yield* session.closed;
+
+      assert.strictEqual(info.closeCode, 42);
+      assert.strictEqual(info.reason, "bye");
+    }),
+  );
+
+  it.effect("closed fails typed on abrupt termination", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      fake.rejectClosed(new Error("connection lost"));
+      const error = yield* session.closed.pipe(Effect.flip);
+
+      expectReason(error, "SessionClosedError");
+    }),
+  );
+
+  it.effect("closed fails typed on malformed close info", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      fake.resolveClosed("garbage");
+      const error = yield* session.closed.pipe(Effect.flip);
+
+      expectReason(error, "SessionClosedError");
+    }),
+  );
+
+  it.effect("close is idempotent and awaits settlement", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      yield* session.close({ closeCode: 1, reason: "first" });
+      yield* session.close({ closeCode: 2, reason: "second" });
+      assert.strictEqual(fake.closeCalls.length, 2);
+      const info = yield* session.closed;
+
+      assert.strictEqual(info.closeCode, 1);
+    }),
+  );
+});

--- a/packages/effect-webtransport/tests/WebTransportSocket.test.ts
+++ b/packages/effect-webtransport/tests/WebTransportSocket.test.ts
@@ -1,0 +1,136 @@
+import { assert, describe, it } from "@effect/vitest";
+import { Effect, Fiber } from "effect";
+import { Socket } from "effect/unstable/socket";
+
+import * as WebTransport from "../src/WebTransport";
+import * as WebTransportSocket from "../src/WebTransportSocket";
+import { makeFakeWebTransport, type FakeWebTransportHandle } from "./fakes";
+
+const bytes = (...values: Array<number>) => Uint8Array.from(values);
+
+const provideSession = (handle: FakeWebTransportHandle) =>
+  Effect.provideService(
+    WebTransport.WebTransport,
+    WebTransport.WebTransport.of(WebTransport.fromNative(handle.native)),
+  );
+
+const tick = Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+
+const waitFor = (condition: () => boolean) =>
+  Effect.gen(function* () {
+    for (let i = 0; i < 100 && !condition(); i++) {
+      yield* tick;
+    }
+    assert.isTrue(condition(), "condition not reached");
+  });
+
+describe("WebTransportSocket", () => {
+  it.effect("round-trips bytes through a bidirectional stream", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ echo: true });
+      const socket = yield* WebTransportSocket.makeSocket().pipe(provideSession(fake));
+      const received: Array<Uint8Array> = [];
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const write = yield* socket.writer;
+          const fiber = yield* Effect.forkChild(
+            socket.run((data) => {
+              received.push(data);
+            }),
+          );
+
+          yield* write(bytes(1, 2, 3));
+          yield* waitFor(() => received.length === 1);
+          yield* write(new Socket.CloseEvent(1000));
+          yield* Fiber.join(fiber);
+        }),
+      );
+      assert.deepStrictEqual(received, [bytes(1, 2, 3)]);
+      assert.deepStrictEqual(fake.bidis[0]!.written, [bytes(1, 2, 3)]);
+    }),
+  );
+
+  it.effect("opens a fresh stream for every run and cleans up after each", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const socket = yield* WebTransportSocket.makeSocket().pipe(provideSession(fake));
+      const runOnce = (expectedStreams: number) =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const fiber = yield* Effect.forkChild(socket.run(() => {}));
+
+            yield* waitFor(() => fake.bidis.length === expectedStreams);
+            fake.bidis.at(-1)!.end();
+            yield* Fiber.join(fiber);
+          }),
+        );
+
+      yield* runOnce(1);
+      yield* runOnce(2);
+      assert.strictEqual(fake.bidis.length, 2);
+      // Each finished run closed its own stream: FIN on the writable half and
+      // cancellation of the readable half.
+      assert.isTrue(fake.bidis[0]!.writableClosed());
+      assert.isTrue(fake.bidis[1]!.writableClosed());
+    }),
+  );
+
+  it.effect("a peer FIN ends the run cleanly by default", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const socket = yield* WebTransportSocket.makeSocket().pipe(provideSession(fake));
+      const fiber = yield* Effect.forkChild(socket.run(() => {}));
+
+      yield* waitFor(() => fake.bidis.length === 1);
+      fake.bidis[0]!.end();
+      yield* Fiber.join(fiber);
+    }),
+  );
+
+  it.effect("a peer FIN fails the run when classified as an error", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const socket = yield* WebTransportSocket.makeSocket({
+        closeCodeIsError: () => true,
+      }).pipe(provideSession(fake));
+      const fiber = yield* Effect.forkChild(Effect.flip(socket.run(() => {})));
+
+      yield* waitFor(() => fake.bidis.length === 1);
+      fake.bidis[0]!.end();
+      const error = yield* Fiber.join(fiber);
+
+      assert.isTrue(Socket.SocketError.is(error));
+      assert.strictEqual((error as Socket.SocketError).reason._tag, "SocketCloseError");
+    }),
+  );
+
+  it.effect("maps stream-open failures to SocketOpenError with the typed cause", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ failBidiOpen: new Error("no streams left") });
+      const socket = yield* WebTransportSocket.makeSocket().pipe(provideSession(fake));
+      const error = yield* Effect.flip(socket.run(() => {}));
+
+      assert.isTrue(Socket.SocketError.is(error));
+      const reason = (error as Socket.SocketError).reason;
+
+      assert.strictEqual(reason._tag, "SocketOpenError");
+      assert.isTrue(WebTransport.WebTransportError.is((reason as Socket.SocketOpenError).cause));
+    }),
+  );
+
+  it.effect("stream read failures fail the run as SocketReadError", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const socket = yield* WebTransportSocket.makeSocket().pipe(provideSession(fake));
+      const fiber = yield* Effect.forkChild(Effect.flip(socket.run(() => {})));
+
+      yield* waitFor(() => fake.bidis.length === 1);
+      fake.bidis[0]!.fail(new Error("stream reset"));
+      const error = yield* Fiber.join(fiber);
+
+      assert.isTrue(Socket.SocketError.is(error));
+      assert.strictEqual((error as Socket.SocketError).reason._tag, "SocketReadError");
+    }),
+  );
+});

--- a/packages/effect-webtransport/tests/fakes.ts
+++ b/packages/effect-webtransport/tests/fakes.ts
@@ -1,0 +1,268 @@
+import type * as WebTransport from "../src/WebTransport";
+
+export interface FakeBidi {
+  readonly native: WebTransport.NativeBidirectionalStream;
+  readonly written: Array<Uint8Array>;
+  readonly push: (chunk: Uint8Array) => void;
+  readonly end: () => void;
+  readonly fail: (error: unknown) => void;
+  readonly writableClosed: () => boolean;
+  readonly readableCancelled: () => boolean;
+}
+
+export const makeFakeBidi = (options?: { readonly echo?: boolean }): FakeBidi => {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  let cancelled = false;
+  let closed = false;
+  let ended = false;
+  const end = () => {
+    if (!ended) {
+      ended = true;
+      controller.close();
+    }
+  };
+  const readable = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+  const written: Array<Uint8Array> = [];
+  const writable = new WritableStream<Uint8Array>({
+    write(chunk) {
+      written.push(chunk);
+      if (options?.echo && !ended) {
+        controller.enqueue(chunk);
+      }
+    },
+    close() {
+      closed = true;
+      if (options?.echo) {
+        end();
+      }
+    },
+  });
+
+  return {
+    native: { readable, writable },
+    written,
+    push: (chunk) => controller.enqueue(chunk),
+    end,
+    fail: (error) => controller.error(error),
+    writableClosed: () => closed,
+    readableCancelled: () => cancelled,
+  };
+};
+
+export interface FakeDatagrams {
+  readonly native: WebTransport.NativeDatagramDuplexStream;
+  readonly sent: Array<Uint8Array>;
+  readonly push: (chunk: Uint8Array) => void;
+  readonly end: () => void;
+  /** Resolves the oldest in-flight gated sink write. */
+  readonly releaseOne: () => void;
+  readonly pendingWrites: () => number;
+}
+
+export const makeFakeDatagrams = (options?: {
+  readonly maxDatagramSize?: number;
+  readonly gated?: boolean;
+}): FakeDatagrams => {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  let ended = false;
+  const readable = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const sent: Array<Uint8Array> = [];
+  const gates: Array<() => void> = [];
+  const writable = new WritableStream<Uint8Array>({
+    async write(chunk) {
+      if (options?.gated) {
+        await new Promise<void>((resolve) => gates.push(resolve));
+      }
+      sent.push(chunk);
+    },
+  });
+
+  return {
+    native: {
+      readable,
+      writable,
+      maxDatagramSize: options?.maxDatagramSize ?? 1200,
+    },
+    sent,
+    push: (chunk) => controller.enqueue(chunk),
+    end: () => {
+      if (!ended) {
+        ended = true;
+        controller.close();
+      }
+    },
+    releaseOne: () => gates.shift()?.(),
+    pendingWrites: () => gates.length,
+  };
+};
+
+export interface FakeUniStream {
+  readonly native: WritableStream<Uint8Array>;
+  readonly written: Array<Uint8Array>;
+  readonly closedCalled: () => boolean;
+}
+
+const makeFakeUniStream = (): FakeUniStream => {
+  let closed = false;
+  const written: Array<Uint8Array> = [];
+  const native = new WritableStream<Uint8Array>({
+    write(chunk) {
+      written.push(chunk);
+    },
+    close() {
+      closed = true;
+    },
+  });
+
+  return { native, written, closedCalled: () => closed };
+};
+
+export interface FakeWebTransportOptions {
+  readonly ready?: "resolved" | "pending" | { readonly reject: unknown };
+  readonly echo?: boolean;
+  readonly omitUnidirectional?: boolean;
+  readonly omitDatagrams?: boolean;
+  readonly datagrams?: {
+    readonly maxDatagramSize?: number;
+    readonly gated?: boolean;
+  };
+  readonly failBidiOpen?: unknown;
+}
+
+export interface FakeWebTransportHandle {
+  readonly native: WebTransport.NativeWebTransport;
+  readonly resolveReady: () => void;
+  readonly resolveClosed: (info: unknown) => void;
+  readonly rejectClosed: (error: unknown) => void;
+  readonly closeCalls: Array<WebTransport.NativeCloseInfo | undefined>;
+  readonly bidiCalls: Array<WebTransport.NativeSendStreamOptions | undefined>;
+  readonly bidis: Array<FakeBidi>;
+  readonly uniStreams: Array<FakeUniStream>;
+  readonly pushIncomingBidi: (native: WebTransport.NativeBidirectionalStream) => void;
+  readonly endIncomingBidi: () => void;
+  readonly pushIncomingUni: (native: ReadableStream<Uint8Array>) => void;
+  readonly endIncomingUni: () => void;
+  readonly datagrams: FakeDatagrams | undefined;
+}
+
+export const makeFakeWebTransport = (options?: FakeWebTransportOptions): FakeWebTransportHandle => {
+  let resolveReady!: () => void;
+  let rejectReady!: (error: unknown) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+
+  ready.catch(() => {});
+  const readyMode = options?.ready ?? "resolved";
+
+  if (readyMode === "resolved") {
+    resolveReady();
+  } else if (typeof readyMode === "object") {
+    rejectReady(readyMode.reject);
+  }
+
+  let resolveClosed!: (info: unknown) => void;
+  let rejectClosed!: (error: unknown) => void;
+  let closedSettled = false;
+  const closed = new Promise<unknown>((resolve, reject) => {
+    resolveClosed = resolve;
+    rejectClosed = reject;
+  });
+
+  closed.catch(() => {});
+
+  const closeCalls: Array<WebTransport.NativeCloseInfo | undefined> = [];
+  const bidiCalls: Array<WebTransport.NativeSendStreamOptions | undefined> = [];
+  const bidis: Array<FakeBidi> = [];
+  const uniStreams: Array<FakeUniStream> = [];
+
+  let incomingBidiController!: ReadableStreamDefaultController<WebTransport.NativeBidirectionalStream>;
+  const incomingBidirectionalStreams = new ReadableStream<WebTransport.NativeBidirectionalStream>({
+    start(c) {
+      incomingBidiController = c;
+    },
+  });
+  let incomingUniController!: ReadableStreamDefaultController<ReadableStream<Uint8Array>>;
+  const incomingUnidirectionalStreams = new ReadableStream<ReadableStream<Uint8Array>>({
+    start(c) {
+      incomingUniController = c;
+    },
+  });
+
+  const datagrams = options?.omitDatagrams ? undefined : makeFakeDatagrams(options?.datagrams);
+
+  const native: WebTransport.NativeWebTransport = {
+    ready,
+    closed,
+    close: (info) => {
+      closeCalls.push(info);
+      if (!closedSettled) {
+        closedSettled = true;
+        resolveClosed({ closeCode: info?.closeCode ?? 0, reason: info?.reason ?? "" });
+      }
+    },
+    createBidirectionalStream: (streamOptions) => {
+      bidiCalls.push(streamOptions);
+      if (options?.failBidiOpen !== undefined) {
+        return Promise.reject(options.failBidiOpen);
+      }
+      const bidi = makeFakeBidi({ echo: options?.echo });
+
+      bidis.push(bidi);
+
+      return Promise.resolve(bidi.native);
+    },
+    createUnidirectionalStream: options?.omitUnidirectional
+      ? undefined
+      : () => {
+          const stream = makeFakeUniStream();
+
+          uniStreams.push(stream);
+
+          return Promise.resolve(stream.native);
+        },
+    incomingBidirectionalStreams,
+    incomingUnidirectionalStreams: options?.omitUnidirectional
+      ? undefined
+      : incomingUnidirectionalStreams,
+    datagrams: datagrams?.native,
+  };
+
+  return {
+    native,
+    resolveReady,
+    resolveClosed: (info) => {
+      if (!closedSettled) {
+        closedSettled = true;
+        resolveClosed(info);
+      }
+    },
+    rejectClosed: (error) => {
+      if (!closedSettled) {
+        closedSettled = true;
+        rejectClosed(error);
+      }
+    },
+    closeCalls,
+    bidiCalls,
+    bidis,
+    uniStreams,
+    pushIncomingBidi: (bidi) => incomingBidiController.enqueue(bidi),
+    endIncomingBidi: () => incomingBidiController.close(),
+    pushIncomingUni: (readable) => incomingUniController.enqueue(readable),
+    endIncomingUni: () => incomingUniController.close(),
+    datagrams,
+  };
+};

--- a/packages/effect-webtransport/tsconfig.json
+++ b/packages/effect-webtransport/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": [],
+    "strict": true,
+    "noUnusedLocals": true,
+    "declaration": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/effect-webtransport/vite.config.ts
+++ b/packages/effect-webtransport/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "vite-plus";
+
+const testExcludes = ["**/node_modules/**", "**/dist/**", "**/.git/**"];
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: "node",
+          exclude: testExcludes,
+          include: ["**/*.test.ts"],
+        },
+      },
+    ],
+  },
+  pack: {
+    entry: ["src/index.ts"],
+    dts: {
+      tsgo: true,
+    },
+  },
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+  },
+  fmt: {},
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ const testExcludes = [
 // Effect-patched TypeScript-Go compiler.
 const typecheckPackages = [
   "packages/effect-cf",
+  "packages/effect-webtransport",
   "examples/chat/durable-objects/chat-room",
   "examples/chat/packages/contracts",
   "examples/chat/web",
@@ -100,9 +101,16 @@ export default defineConfig({
     cache: true,
     tasks: {
       ...recommended.run.tasks,
-      // Examples consume `effect-cf` through its published `dist` entrypoints.
-      check: { command: recommended.run.tasks.check, dependsOn: ["effect-cf#build"] },
-      typecheck: { ...recommended.run.tasks.typecheck, dependsOn: ["effect-cf#build"] },
+      // Examples consume the publishable packages through their published
+      // `dist` entrypoints.
+      check: {
+        command: recommended.run.tasks.check,
+        dependsOn: ["effect-cf#build", "effect-webtransport#build"],
+      },
+      typecheck: {
+        ...recommended.run.tasks.typecheck,
+        dependsOn: ["effect-cf#build", "effect-webtransport#build"],
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- Adds `effect-webtransport`, a new publishable, platform-generic Effect v4 WebTransport library: scoped session acquisition via a feature-detected, test-substitutable `WebTransportConstructor` service; reliable bidirectional/unidirectional streams; backpressured, platform-bounded datagrams; typed `WebTransportError` reasons; an adapter from one reliable bidirectional stream to `effect/unstable/socket` `Socket` (works unchanged with `RpcClient.layerProtocolSocket`); and a `Fallback` module that pins the first viable transport (WebTransport handshake as the probe, WebSocket last, no cross-transport replay).
- Adds an `effect-cf` `WebTransport` module as the strongest integration the runtime honestly supports: workerd has no QUIC stack and no inbound WebTransport session API ([cloudflare/workerd#6451](https://github.com/cloudflare/workerd/issues/6451)), so the module exposes typed runtime capabilities (`inboundSessions: false` at the type level), an explicit typed `inboundSessionsUnsupported` boundary, and Schema-decoded HTTP/3 request metadata (`httpProtocol`, `clientQuicRtt`, `clientTcpRtt`). Workerd-pool tests assert the API's absence as executable evidence, so a future runtime change fails CI and forces a deliberate revisit.
- Wires the `todo-rpc-ws` web example to select its transport through `Fallback` (WebTransport → WebSocket, chosen before any RPC traffic and pinned), and widens release/CI/dev-kit wiring for a second publishable package. Changesets included for both packages.

Implementation note for review: the Socket adapter mirrors `Socket.fromTransformStream` but hardened — upstream's finalizer calls `reader.cancel()`, which rejects on an errored `ReadableStream`, turning a stream reset into a defect instead of a typed `SocketReadError`. Likely worth upstreaming to Effect.

## Validation

- `vp run check` — passed on the rebased branch (format check, lint, tests, typecheck across the workspace)
- `vp test` — 40 files, 287 passed / 1 pre-existing skip; new coverage: lifecycle cleanup, typed failure mapping, datagram backpressure and bounds, feature detection, fresh-stream-per-run semantics, fallback pinning with failed-candidate resource release, a real `RpcServer` ↔ `RpcClient` ndjson round-trip over WebTransport-shaped stream pairs, and the workerd evidence suite
- `vp run todo-rpc-ws-web#build` — passed with the fallback wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)