### PR TITLE
fix(webtransport): harden stream lifecycle cleanup

### DIFF
--- a/.changeset/webtransport-stream-lifecycle.md
+++ b/.changeset/webtransport-stream-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"effect-webtransport": patch
+---
+
+Preserve reusable incoming-stream sources, report Web Stream lock failures through typed errors, and abort interrupted writes without hanging resource cleanup.

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -701,7 +701,7 @@ Use `DurableObjectRpcWebSocket.layer(...)` for Effect RPC-over-WebSocket transpo
 
 ## WebTransport and HTTP/3
 
-Cloudflare Workers cannot accept inbound WebTransport sessions today: workerd contains no QUIC/HTTP-3 stack, there is no `WebSocketPair`-style session API, and the maintainers state the feature "is not currently on our priority list" ([cloudflare/workerd#6451](https://github.com/cloudflare/workerd/issues/6451)). Inbound HTTP/3 is a zone-level setting — the edge terminates QUIC and the Worker still receives an ordinary `fetch` Request. Durable Object hibernatable WebSockets remain the only bidirectional push channel into Worker code.
+Cloudflare Workers cannot accept inbound WebTransport sessions today: workerd contains no QUIC/HTTP-3 stack, there is no `WebSocketPair`-style session API, and the maintainers state the feature "is not currently on our priority list" ([cloudflare/workerd#6451](https://github.com/cloudflare/workerd/issues/6451), [discussion #6454](https://github.com/cloudflare/workerd/discussions/6454)). Inbound HTTP/3 is a zone-level setting — the edge terminates QUIC and the Worker still receives an ordinary `fetch` Request. Workers and Durable Objects can accept inbound WebSocket connections; Durable Objects additionally support the hibernation WebSocket API.
 
 The `WebTransport` module gives that boundary a typed shape rather than pretending otherwise:
 

--- a/packages/effect-cf/src/WebTransport.ts
+++ b/packages/effect-cf/src/WebTransport.ts
@@ -15,9 +15,9 @@
  * - There is no outbound WebTransport/QUIC/UDP client capability either;
  *   `cloudflare:sockets` `connect()` is TCP-only, and
  *   `@cloudflare/workers-types` contains no WebTransport types.
- * - Durable Objects' hibernatable WebSockets (`acceptWebSocket`,
- *   `webSocketMessage`, `webSocketClose`) remain the only bidirectional push
- *   channel into a Worker or Durable Object.
+ * - Workers and Durable Objects can accept inbound WebSocket connections;
+ *   Durable Objects additionally support hibernation (`acceptWebSocket`,
+ *   `webSocketMessage`, `webSocketClose`).
  *
  * Consequently a browser's WebTransport session can never reach Worker code:
  * clients should attempt WebTransport only against origins that actually

--- a/packages/effect-webtransport/src/WebTransport.ts
+++ b/packages/effect-webtransport/src/WebTransport.ts
@@ -11,14 +11,17 @@
  * Effect resources with typed errors.
  */
 import {
+  Cause,
+  Channel,
   Context,
   type Duration,
   Effect,
+  Exit,
   Layer,
   Predicate,
   Result,
   Schema,
-  type Scope,
+  Scope,
   Stream,
 } from "effect";
 
@@ -410,6 +413,38 @@ export const WebTransport: Context.Service<WebTransport, WebTransport> =
 
 const constVoid = () => undefined;
 
+const streamFromReadable = <A>(options: {
+  readonly evaluate: () => ReadableStream<A>;
+  readonly source: ReadError["source"];
+  readonly releaseLockOnEnd?: boolean | undefined;
+}): Stream.Stream<A, WebTransportError> =>
+  Stream.fromChannel(
+    Channel.fromTransform(
+      Effect.fnUntraced(function* (_, scope) {
+        const reader = yield* Effect.try({
+          try: () => options.evaluate().getReader(),
+          catch: (cause) => wtError(new ReadError({ source: options.source, cause })),
+        });
+
+        yield* Scope.addFinalizer(
+          scope,
+          options.releaseLockOnEnd
+            ? Effect.sync(() => reader.releaseLock())
+            : Effect.promise(() => reader.cancel().then(constVoid, constVoid)),
+        );
+
+        return Effect.tryPromise({
+          try: () => reader.read(),
+          catch: (cause) => wtError(new ReadError({ source: options.source, cause })),
+        }).pipe(
+          Effect.flatMap((result) =>
+            result.done ? Cause.done() : Effect.succeed([result.value] as [A]),
+          ),
+        );
+      }),
+    ),
+  );
+
 const closeBidirectionalStreamSafely = (stream: NativeBidirectionalStream) =>
   Effect.promise(async () => {
     try {
@@ -490,9 +525,9 @@ const makeDatagrams = (native: NativeWebTransport): Datagrams => {
   );
   const stream = Stream.unwrap(
     Effect.map(requireDatagrams, (datagrams) =>
-      Stream.fromReadableStream({
+      streamFromReadable({
         evaluate: () => datagrams.readable,
-        onError: (cause) => wtError(new ReadError({ source: "datagram", cause })),
+        source: "datagram",
         releaseLockOnEnd: true,
       }),
     ),
@@ -536,18 +571,20 @@ export const fromNative = (native: NativeWebTransport): WebTransport => ({
         (writable) => Effect.promise(() => writable.close().then(constVoid, constVoid)),
       );
     }),
-  incomingBidirectionalStreams: Stream.fromReadableStream({
+  incomingBidirectionalStreams: streamFromReadable({
     evaluate: () => native.incomingBidirectionalStreams,
-    onError: (cause) => wtError(new ReadError({ source: "incomingStreams", cause })),
+    source: "incomingStreams",
+    releaseLockOnEnd: true,
   }),
   incomingUnidirectionalStreams: Stream.unwrap(
     Effect.suspend(() =>
       native.incomingUnidirectionalStreams === undefined
         ? Effect.fail(wtError(new UnsupportedError({ feature: "UnidirectionalStreams" })))
         : Effect.succeed(
-            Stream.fromReadableStream({
+            streamFromReadable({
               evaluate: () => native.incomingUnidirectionalStreams!,
-              onError: (cause) => wtError(new ReadError({ source: "incomingStreams", cause })),
+              source: "incomingStreams",
+              releaseLockOnEnd: true,
             }),
           ),
     ),
@@ -683,9 +720,9 @@ export const layer = (
 export const readStream = (
   readable: ReadableStream<Uint8Array>,
 ): Stream.Stream<Uint8Array, WebTransportError> =>
-  Stream.fromReadableStream({
+  streamFromReadable({
     evaluate: () => readable,
-    onError: (cause) => wtError(new ReadError({ source: "stream", cause })),
+    source: "stream",
   });
 
 /**
@@ -705,7 +742,13 @@ export const writer = (
       try: () => writable.getWriter(),
       catch: (cause) => wtError(new WriteError({ source: "stream", cause })),
     }),
-    (writer) => Effect.promise(() => writer.close().then(constVoid, constVoid)),
+    (writer, exit) =>
+      Effect.promise(() =>
+        (Exit.isSuccess(exit) ? writer.close() : writer.abort(exit.cause)).then(
+          constVoid,
+          constVoid,
+        ),
+      ),
   ).pipe(
     Effect.map(
       (writer) =>

--- a/packages/effect-webtransport/src/WebTransportSocket.ts
+++ b/packages/effect-webtransport/src/WebTransportSocket.ts
@@ -20,7 +20,7 @@
  * writable stream's backpressure, and each finished run closes its stream
  * with a FIN.
  */
-import { Context, Deferred, Effect, FiberSet, Latch, Layer, Scope } from "effect";
+import { Context, Deferred, Effect, Exit, FiberSet, Latch, Layer, Scope } from "effect";
 import { Socket } from "effect/unstable/socket";
 
 import * as WebTransport from "./WebTransport";
@@ -44,7 +44,7 @@ export interface MakeSocketOptions extends FromBidirectionalStreamOptions {
 /** Default close-code classifier: only a graceful end (code 1000) is clean. */
 export const defaultCloseCodeIsError = (code: number): boolean => code !== 1000;
 
-const toSocketOpenError = (error: WebTransport.WebTransportError): Socket.SocketError =>
+const toSocketOpenError = (error: unknown): Socket.SocketError =>
   new Socket.SocketError({
     reason: new Socket.SocketOpenError({ kind: "Unknown", cause: error }),
   });
@@ -83,17 +83,27 @@ export const fromBidirectionalStream = <R>(
       Effect.scopedWith(
         Effect.fnUntraced(function* (scope) {
           const stream = yield* Scope.provide(Effect.mapError(acquire, toSocketOpenError), scope);
-          const reader = stream.readable.getReader();
+          const reader = yield* Effect.try({
+            try: () => stream.readable.getReader(),
+            catch: toSocketOpenError,
+          });
 
           yield* Scope.addFinalizer(
             scope,
             Effect.promise(() => reader.cancel().then(swallow, swallow)),
           );
-          const writer = stream.writable.getWriter();
+          const writer = yield* Effect.try({
+            try: () => stream.writable.getWriter(),
+            catch: toSocketOpenError,
+          });
 
-          yield* Scope.addFinalizer(
-            scope,
-            Effect.promise(() => writer.close().then(swallow, swallow)),
+          yield* Scope.addFinalizerExit(scope, (exit) =>
+            Effect.promise(() =>
+              (Exit.isSuccess(exit) ? writer.close() : writer.abort(exit.cause)).then(
+                swallow,
+                swallow,
+              ),
+            ),
           );
           const fiberSet = yield* FiberSet.make<any, E | Socket.SocketError>().pipe(
             Scope.provide(scope),

--- a/packages/effect-webtransport/tests/WebTransport.test.ts
+++ b/packages/effect-webtransport/tests/WebTransport.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
-import { Effect, Exit, Fiber, Scope, Stream } from "effect";
+import { Deferred, Effect, Exit, Fiber, Option, Scope, Stream } from "effect";
 import { TestClock } from "effect/testing";
 
 import * as WebTransport from "../src/WebTransport";
@@ -243,6 +243,50 @@ describe("streams", () => {
     }),
   );
 
+  it.effect("writer aborts an in-flight write when interrupted", () =>
+    Effect.gen(function* () {
+      const writeStarted = yield* Deferred.make<void>();
+      const writeInterrupted = yield* Deferred.make<void>();
+      let releaseWrite = () => {};
+      let writeController!: WritableStreamDefaultController;
+      const writable = new WritableStream<Uint8Array>({
+        write(_chunk, controller) {
+          writeController = controller;
+          Effect.runSync(Deferred.succeed(writeStarted, undefined));
+
+          return new Promise<void>((resolve, reject) => {
+            releaseWrite = resolve;
+            controller.signal.addEventListener("abort", () => reject(controller.signal.reason), {
+              once: true,
+            });
+          });
+        },
+      });
+      const fiber = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const write = yield* WebTransport.writer(writable);
+
+          yield* write(bytes(1)).pipe(
+            Effect.onInterrupt(() => Deferred.succeed(writeInterrupted, undefined)),
+          );
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* Deferred.await(writeStarted);
+      const interruptFiber = yield* Fiber.interrupt(fiber).pipe(Effect.forkChild);
+
+      yield* Deferred.await(writeInterrupted);
+      for (let i = 0; i < 10 && !writeController.signal.aborted; i++) {
+        yield* Effect.yieldNow;
+      }
+      const wasAborted = writeController.signal.aborted;
+
+      releaseWrite();
+      yield* Fiber.join(interruptFiber);
+      assert.isTrue(wasAborted);
+    }),
+  );
+
   it.effect("incomingBidirectionalStreams surfaces peer-initiated streams", () =>
     Effect.gen(function* () {
       const fake = makeFakeWebTransport();
@@ -259,6 +303,38 @@ describe("streams", () => {
     }),
   );
 
+  it.effect("incomingBidirectionalStreams supports sequential consumers", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+      const first = makeFakeBidi();
+      const second = makeFakeBidi();
+
+      fake.pushIncomingBidi(first.native);
+      fake.pushIncomingBidi(second.native);
+      const firstReceived = yield* Stream.runHead(session.incomingBidirectionalStreams);
+      const secondReceived = yield* Stream.runHead(session.incomingBidirectionalStreams);
+
+      assert.deepStrictEqual(firstReceived, Option.some(first.native));
+      assert.deepStrictEqual(secondReceived, Option.some(second.native));
+    }),
+  );
+
+  it.effect("incomingBidirectionalStreams maps a locked source to ReadError", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+      const reader = fake.native.incomingBidirectionalStreams.getReader();
+      const error = yield* Stream.runHead(session.incomingBidirectionalStreams).pipe(
+        Effect.flip,
+        Effect.ensuring(Effect.sync(() => reader.releaseLock())),
+      );
+      const reason = expectReason(error, "ReadError");
+
+      assert.strictEqual((reason as WebTransport.ReadError).source, "incomingStreams");
+    }),
+  );
+
   it.effect("incomingUnidirectionalStreams fails typed when the platform lacks them", () =>
     Effect.gen(function* () {
       const fake = makeFakeWebTransport({ omitUnidirectional: true });
@@ -272,6 +348,38 @@ describe("streams", () => {
         (reason as WebTransport.UnsupportedError).feature,
         "UnidirectionalStreams",
       );
+    }),
+  );
+
+  it.effect("incomingUnidirectionalStreams supports sequential consumers", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+      const first = new ReadableStream<Uint8Array>();
+      const second = new ReadableStream<Uint8Array>();
+
+      fake.pushIncomingUni(first);
+      fake.pushIncomingUni(second);
+      const firstReceived = yield* Stream.runHead(session.incomingUnidirectionalStreams);
+      const secondReceived = yield* Stream.runHead(session.incomingUnidirectionalStreams);
+
+      assert.deepStrictEqual(firstReceived, Option.some(first));
+      assert.deepStrictEqual(secondReceived, Option.some(second));
+    }),
+  );
+
+  it.effect("incomingUnidirectionalStreams maps a locked source to ReadError", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+      const reader = fake.native.incomingUnidirectionalStreams!.getReader();
+      const error = yield* Stream.runHead(session.incomingUnidirectionalStreams).pipe(
+        Effect.flip,
+        Effect.ensuring(Effect.sync(() => reader.releaseLock())),
+      );
+      const reason = expectReason(error, "ReadError");
+
+      assert.strictEqual((reason as WebTransport.ReadError).source, "incomingStreams");
     }),
   );
 
@@ -298,6 +406,20 @@ describe("streams", () => {
       );
 
       expectReason(error, "ReadError");
+    }),
+  );
+
+  it.effect("readStream maps a locked readable to ReadError", () =>
+    Effect.gen(function* () {
+      const bidi = makeFakeBidi();
+      const reader = bidi.native.readable.getReader();
+      const error = yield* Stream.runCollect(WebTransport.readStream(bidi.native.readable)).pipe(
+        Effect.flip,
+        Effect.ensuring(Effect.sync(() => reader.releaseLock())),
+      );
+      const reason = expectReason(error, "ReadError");
+
+      assert.strictEqual((reason as WebTransport.ReadError).source, "stream");
     }),
   );
 });
@@ -372,6 +494,21 @@ describe("datagrams", () => {
       const collected = yield* Stream.runCollect(session.datagrams.stream);
 
       assert.deepStrictEqual(collected, [bytes(1), bytes(2)]);
+    }),
+  );
+
+  it.effect("stream maps a locked datagram source to ReadError", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+      const reader = fake.datagrams!.native.readable.getReader();
+      const error = yield* Stream.runCollect(session.datagrams.stream).pipe(
+        Effect.flip,
+        Effect.ensuring(Effect.sync(() => reader.releaseLock())),
+      );
+      const reason = expectReason(error, "ReadError");
+
+      assert.strictEqual((reason as WebTransport.ReadError).source, "datagram");
     }),
   );
 

--- a/packages/effect-webtransport/tests/WebTransportSocket.test.ts
+++ b/packages/effect-webtransport/tests/WebTransportSocket.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
-import { Effect, Fiber } from "effect";
+import { Deferred, Effect, Fiber } from "effect";
 import { Socket } from "effect/unstable/socket";
 
 import * as WebTransport from "../src/WebTransport";
@@ -76,6 +76,49 @@ describe("WebTransportSocket", () => {
     }),
   );
 
+  it.effect("aborts an in-flight write when the run is interrupted", () =>
+    Effect.gen(function* () {
+      const writeStarted = yield* Deferred.make<void>();
+      let releaseWrite = () => {};
+      let writeController!: WritableStreamDefaultController;
+      const writable = new WritableStream<Uint8Array>({
+        write(_chunk, controller) {
+          writeController = controller;
+          Effect.runSync(Deferred.succeed(writeStarted, undefined));
+
+          return new Promise<void>((resolve, reject) => {
+            releaseWrite = resolve;
+            controller.signal.addEventListener("abort", () => reject(controller.signal.reason), {
+              once: true,
+            });
+          });
+        },
+      });
+      const socket = yield* WebTransportSocket.fromBidirectionalStream(
+        Effect.succeed({
+          readable: new ReadableStream<Uint8Array>(),
+          writable,
+        }),
+      );
+      const write = yield* socket.writer;
+      const runFiber = yield* socket.run(() => {}).pipe(Effect.forkChild);
+      const writeFiber = yield* write(bytes(1)).pipe(Effect.forkChild);
+
+      yield* Deferred.await(writeStarted);
+      const interruptFiber = yield* Fiber.interrupt(runFiber).pipe(Effect.forkChild);
+
+      for (let i = 0; i < 10 && !writeController.signal.aborted; i++) {
+        yield* Effect.yieldNow;
+      }
+      const wasAborted = writeController.signal.aborted;
+
+      releaseWrite();
+      yield* Fiber.join(interruptFiber);
+      yield* Fiber.await(writeFiber);
+      assert.isTrue(wasAborted);
+    }),
+  );
+
   it.effect("a peer FIN ends the run cleanly by default", () =>
     Effect.gen(function* () {
       const fake = makeFakeWebTransport();
@@ -116,6 +159,38 @@ describe("WebTransportSocket", () => {
 
       assert.strictEqual(reason._tag, "SocketOpenError");
       assert.isTrue(WebTransport.WebTransportError.is((reason as Socket.SocketOpenError).cause));
+    }),
+  );
+
+  it.effect("maps a locked readable to SocketOpenError", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const stream = fake.native.createBidirectionalStream();
+      const native = yield* Effect.promise(() => stream);
+      const reader = native.readable.getReader();
+      const socket = yield* WebTransportSocket.fromBidirectionalStream(Effect.succeed(native));
+      const error = yield* socket
+        .run(() => {})
+        .pipe(Effect.flip, Effect.ensuring(Effect.sync(() => reader.releaseLock())));
+
+      assert.isTrue(Socket.SocketError.is(error));
+      assert.strictEqual((error as Socket.SocketError).reason._tag, "SocketOpenError");
+    }),
+  );
+
+  it.effect("maps a locked writable to SocketOpenError", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const stream = fake.native.createBidirectionalStream();
+      const native = yield* Effect.promise(() => stream);
+      const writer = native.writable.getWriter();
+      const socket = yield* WebTransportSocket.fromBidirectionalStream(Effect.succeed(native));
+      const error = yield* socket
+        .run(() => {})
+        .pipe(Effect.flip, Effect.ensuring(Effect.sync(() => writer.releaseLock())));
+
+      assert.isTrue(Socket.SocketError.is(error));
+      assert.strictEqual((error as Socket.SocketError).reason._tag, "SocketOpenError");
     }),
   );
 


### PR DESCRIPTION
## Summary

- Preserve incoming WebTransport stream sources across sequential consumers and keep Web Stream lock failures in typed error channels.
- Abort interrupted backpressured writes while retaining graceful FIN cleanup on successful exits.
- Correct the Cloudflare WebSocket boundary documentation and add a patch changeset for effect-webtransport.

## Validation

- `vp run check` — passed; builds, formatting, lint, tests, and workspace typechecks completed.
- Test suite — 40 files passed, 305 tests passed, 3 skipped.