### PR TITLE
feat: add Cloudflare Artifacts binding support

### DIFF
--- a/.changeset/bright-artifacts-bind.md
+++ b/.changeset/bright-artifacts-bind.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add first-class Cloudflare Artifacts binding support through the new `Artifacts` module. Namespace lifecycle operations, repository token and fork operations, and Git commit-history, commit, and tree reads are available as typed Effects with validated bindings, structured options and results, tracing spans, and Cloudflare error identifiers.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # effect-cf
 
-Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, Cache, KV, Email, Analytics Engine, and Durable Object storage.
+Effect-native primitives for Cloudflare Workers, Durable Objects, bindings, Cache, KV, R2, Artifacts, Email, Analytics Engine, and Durable Object storage.
 
 ## Install
 

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -1,6 +1,6 @@
 # effect-cf
 
-Effect-native Cloudflare primitives for Workers, Durable Objects, Containers, bindings, Cache, KV, D1, Queues, Email, Analytics Engine, Workflows, and Durable Object storage.
+Effect-native Cloudflare primitives for Workers, Durable Objects, Containers, bindings, Cache, KV, D1, R2, Artifacts, Queues, Email, Analytics Engine, Workflows, and Durable Object storage.
 
 ## Install
 
@@ -35,6 +35,7 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `Kv` - typed KV namespace helper
 - `D1` - typed D1 database binding helper with an `@effect/sql-d1` backed SQL layer
 - `R2` - typed R2 bucket binding helper with Effect-wrapped object and multipart operations
+- `Artifacts` - typed Cloudflare Artifacts namespace and repository helpers, including repository lifecycle, tokens, and Git object reads
 - `Hyperdrive` - typed Hyperdrive binding helper for connection strings and optional Postgres SQL integration
 - `Images` - typed Cloudflare Images binding helper with transformation APIs and optional hosted image operations
 - `Email` - typed Cloudflare Email Service binding helper for `send_email` bindings, with limit validation and typed error codes
@@ -398,6 +399,50 @@ export const readArtifact = (key: string) =>
 ```
 
 Use `createMultipartUpload(...)` or `resumeMultipartUpload(...)` for large objects; returned upload handles wrap `uploadPart`, `complete`, and `abort` in Effect.
+
+## Artifacts Example
+
+Artifacts tags expose every namespace and repository-handle binding operation as an Effect. Configure the binding under Wrangler's `artifacts` field:
+
+```jsonc
+{
+  "artifacts": [
+    {
+      "binding": "ARTIFACTS",
+      "namespace": "default",
+      // Optional in local development:
+      "remote": true,
+    },
+  ],
+}
+```
+
+```ts
+import { Effect } from "effect";
+import { Artifacts } from "effect-cf";
+
+class Repositories extends Artifacts.Tag<Repositories>()("Repositories") {}
+
+export const RepositoriesLayer = Repositories.layer({ binding: "ARTIFACTS" });
+
+export const createWorkspace = Effect.gen(function* () {
+  const artifacts = yield* Repositories;
+  const created = yield* artifacts.create("agent-workspace", {
+    description: "Versioned agent workspace",
+    setDefaultBranch: "main",
+  });
+  const repo = yield* artifacts.get(created.name);
+  const readToken = yield* repo.createToken("read", 3600);
+
+  return {
+    remote: created.remote,
+    token: readToken.plaintext,
+    history: yield* repo.log({ ref: "main", limit: 10 }),
+  };
+});
+```
+
+`create`, `import`, and `fork` return an initial plaintext token. Treat returned tokens as secrets and avoid logging or persisting them unnecessarily.
 
 ## Hyperdrive Example
 

--- a/packages/effect-cf/src/Artifacts.ts
+++ b/packages/effect-cf/src/Artifacts.ts
@@ -1,0 +1,523 @@
+import type {
+  ArtifactsCreateTokenResult as CloudflareArtifactsCreateTokenResult,
+  ArtifactsErrorCode as CloudflareArtifactsErrorCode,
+  ArtifactsRepoInfo as CloudflareArtifactsRepoInfo,
+  ArtifactsTokenInfo as CloudflareArtifactsTokenInfo,
+  ArtifactsTokenListResult as CloudflareArtifactsTokenListResult,
+} from "@cloudflare/workers-types";
+import { Context, Data, Effect, type Layer } from "effect";
+
+import * as Binding from "./Binding";
+import type { WorkerEnvironment } from "./Environment";
+import * as ErrorMessage from "./internal/ErrorMessage";
+
+const expectedArtifactsBinding =
+  "Artifacts binding with create(), get(), import(), list(), and delete()";
+
+const expectedArtifactsRepo =
+  "Artifacts repo handle with createToken(), listTokens(), revokeToken(), fork(), log(), readCommit(), and readTree()";
+
+/** Artifacts operation represented by {@link ArtifactsOperationError}. */
+export type ArtifactsOperation =
+  | "create"
+  | "get"
+  | "import"
+  | "list"
+  | "delete"
+  | "createToken"
+  | "listTokens"
+  | "revokeToken"
+  | "fork"
+  | "log"
+  | "readCommit"
+  | "readTree";
+
+/** Documented string error codes returned by Cloudflare Artifacts. */
+export const artifactsErrorCodes = [
+  "ALREADY_EXISTS",
+  "NOT_FOUND",
+  "IMPORT_IN_PROGRESS",
+  "FORK_IN_PROGRESS",
+  "INVALID_INPUT",
+  "INVALID_REPO_NAME",
+  "INVALID_TTL",
+  "INVALID_URL",
+  "REMOTE_AUTH_REQUIRED",
+  "UPSTREAM_UNAVAILABLE",
+  "MEMORY_LIMIT",
+  "INTERNAL_ERROR",
+] as const satisfies ReadonlyArray<CloudflareArtifactsErrorCode>;
+
+/** Documented numeric error codes returned by Cloudflare Artifacts. */
+export const artifactsErrorNumericCodes = {
+  ALREADY_EXISTS: 10201,
+  NOT_FOUND: 10200,
+  IMPORT_IN_PROGRESS: 10302,
+  FORK_IN_PROGRESS: 10303,
+  INVALID_INPUT: 10100,
+  INVALID_REPO_NAME: 10101,
+  INVALID_TTL: 10103,
+  INVALID_URL: 10104,
+  REMOTE_AUTH_REQUIRED: 10106,
+  UPSTREAM_UNAVAILABLE: 10401,
+  MEMORY_LIMIT: 10402,
+  INTERNAL_ERROR: 10400,
+} as const satisfies Readonly<Record<CloudflareArtifactsErrorCode, number>>;
+
+/** A documented Cloudflare Artifacts string error code. */
+export type ArtifactsErrorCode = CloudflareArtifactsErrorCode;
+
+/** Error raised when a Cloudflare Artifacts operation fails. */
+export class ArtifactsOperationError extends Data.TaggedError("ArtifactsOperationError")<{
+  readonly binding: string;
+  readonly operation: ArtifactsOperation;
+  readonly cause: unknown;
+  /** Cloudflare string error code, when retained by the runtime. */
+  readonly code?: ArtifactsErrorCode | (string & {});
+  /** Cloudflare REST-compatible numeric error code, when retained by the runtime. */
+  readonly numericCode?: number;
+}> {
+  override get message(): string {
+    const code = this.code === undefined ? "" : ` (${this.code})`;
+
+    return `Artifacts ${this.operation} failed for binding "${this.binding}"${code}: ${ErrorMessage.causeMessage(this.cause)}`;
+  }
+}
+
+/** Typed Cloudflare Artifacts binding definition. */
+export interface ArtifactsDefinition {
+  /** Binding name from an `artifacts` entry in `wrangler.jsonc`. */
+  readonly binding: string;
+}
+
+/** Repository name containing alphanumeric characters, dots, hyphens, or underscores. */
+export type RepoName = string;
+
+/** Cursor used by repository list pagination. */
+export type Cursor = string;
+
+/** Scope granted to a repository token. */
+export type ArtifactsTokenScope = "read" | "write";
+
+/** Lifecycle state of a repository token. */
+export type ArtifactsTokenState = "active" | "expired" | "revoked";
+
+/** Lifecycle state included with repositories returned by `list()`. */
+export type ArtifactsRepoStatus = "ready" | "importing" | "forking";
+
+/** Stable repository metadata returned by Cloudflare Artifacts. */
+export type ArtifactsRepoInfo = CloudflareArtifactsRepoInfo;
+
+/** Result of creating, importing, or forking a repository. */
+export interface ArtifactsCreateRepoResult {
+  readonly id: string;
+  readonly name: RepoName;
+  readonly description: string | null;
+  readonly defaultBranch: string;
+  readonly remote: string;
+  /** Initial plaintext Git token. The token itself encodes its expiry. */
+  readonly token: string;
+}
+
+/** Repository metadata returned by `list()`. */
+export interface ArtifactsRepoListEntry extends ArtifactsRepoInfo {
+  readonly status: ArtifactsRepoStatus;
+}
+
+/** Cursor-paginated repository list result. */
+export interface ArtifactsRepoListResult {
+  readonly repos: ReadonlyArray<ArtifactsRepoListEntry>;
+  readonly total: number;
+  readonly cursor?: Cursor;
+}
+
+/** Result of creating a repository token. */
+export type ArtifactsCreateTokenResult = CloudflareArtifactsCreateTokenResult;
+
+/** Repository token metadata, excluding its plaintext secret. */
+export type ArtifactsTokenInfo = CloudflareArtifactsTokenInfo;
+
+/** Repository token list result. */
+export type ArtifactsTokenListResult = CloudflareArtifactsTokenListResult;
+
+/**
+ * Commit history returned by `log()`.
+ *
+ * Cloudflare currently documents this generated type by name but does not
+ * publish its fields in the binding reference or Workers type declarations.
+ */
+export interface ArtifactsLogResult {
+  readonly [field: string]: unknown;
+}
+
+/**
+ * Parsed Git commit returned by `readCommit()`.
+ *
+ * Cloudflare currently documents this generated type by name but does not
+ * publish its fields in the binding reference or Workers type declarations.
+ */
+export interface ArtifactsCommit {
+  readonly [field: string]: unknown;
+}
+
+/**
+ * Parsed Git tree returned by `readTree()`.
+ *
+ * Cloudflare currently documents this generated type by name but does not
+ * publish its fields in the binding reference or Workers type declarations.
+ */
+export interface ArtifactsTree {
+  readonly [field: string]: unknown;
+}
+
+/** Options for `Artifacts.create()`. */
+export interface ArtifactsCreateOptions {
+  /** Prevent pushes to the repository. */
+  readonly readOnly?: boolean;
+  readonly description?: string;
+  /** Initial default branch name. */
+  readonly setDefaultBranch?: string;
+}
+
+/** Options for cursor-paginating `Artifacts.list()`. */
+export interface ArtifactsListOptions {
+  /** Page size from 1 through 200. Defaults to 50. */
+  readonly limit?: number;
+  /** Cursor returned by a previous list result. */
+  readonly cursor?: Cursor;
+}
+
+/** External Git source used by `Artifacts.import()`. */
+export interface ArtifactsImportSource {
+  /** Full HTTPS URL of the Git repository. */
+  readonly url: string;
+  /** Source branch. Defaults to the remote's default branch. */
+  readonly branch?: string;
+  /** Shallow clone depth. */
+  readonly depth?: number;
+}
+
+/** Options for the target of `Artifacts.import()`. */
+export interface ArtifactsImportTargetOptions {
+  readonly description?: string;
+  readonly readOnly?: boolean;
+}
+
+/** Target repository used by `Artifacts.import()`. */
+export interface ArtifactsImportTarget {
+  readonly name: RepoName;
+  readonly opts?: ArtifactsImportTargetOptions;
+}
+
+/** Parameters for `Artifacts.import()`. */
+export interface ArtifactsImportParams {
+  readonly source: ArtifactsImportSource;
+  readonly target: ArtifactsImportTarget;
+}
+
+/** Options for `ArtifactsRepoClient.fork()`. */
+export interface ArtifactsForkOptions {
+  readonly description?: string;
+  readonly readOnly?: boolean;
+  /** Only copy the default branch. Defaults to `true`. */
+  readonly defaultBranchOnly?: boolean;
+}
+
+/** Options for `ArtifactsRepoClient.log()`. */
+export interface ArtifactsLogOptions {
+  /** Branch, tag, or commit hash. */
+  readonly ref?: string;
+  readonly limit?: number;
+  readonly offset?: number;
+}
+
+/** Runtime repository handle, including methods absent from current shipped Workers types. */
+export interface ArtifactsRepoBinding extends ArtifactsRepoInfo {
+  /**
+   * Create a Git token for the repository.
+   *
+   * Scope defaults to `"write"`. TTL is measured in seconds, defaults to
+   * 86,400, and must be between 60 and 31,536,000.
+   */
+  readonly createToken: (
+    scope?: ArtifactsTokenScope,
+    ttl?: number,
+  ) => Promise<ArtifactsCreateTokenResult>;
+  readonly listTokens: () => Promise<ArtifactsTokenListResult>;
+  readonly revokeToken: (tokenOrId: string) => Promise<boolean>;
+  readonly fork: (
+    name: RepoName,
+    options?: ArtifactsForkOptions,
+  ) => Promise<ArtifactsCreateRepoResult>;
+  readonly log: (options?: ArtifactsLogOptions) => Promise<ArtifactsLogResult>;
+  readonly readCommit: (hash: string) => Promise<ArtifactsCommit>;
+  readonly readTree: (hash: string) => Promise<ArtifactsTree>;
+}
+
+/** Cloudflare Artifacts namespace binding. */
+export interface ArtifactsBinding {
+  readonly create: (
+    name: RepoName,
+    options?: ArtifactsCreateOptions,
+  ) => Promise<ArtifactsCreateRepoResult>;
+  readonly get: (name: RepoName) => Promise<ArtifactsRepoBinding>;
+  readonly import: (params: ArtifactsImportParams) => Promise<ArtifactsCreateRepoResult>;
+  readonly list: (options?: ArtifactsListOptions) => Promise<ArtifactsRepoListResult>;
+  readonly delete: (name: RepoName) => Promise<boolean>;
+}
+
+/** Effect wrapper around a repository handle returned by `Artifacts.get()`. */
+export interface ArtifactsRepoClient extends ArtifactsRepoInfo {
+  /**
+   * Create a Git token for the repository.
+   *
+   * Scope defaults to `"write"`. TTL is measured in seconds, defaults to
+   * 86,400, and must be between 60 and 31,536,000.
+   */
+  readonly createToken: (
+    scope?: ArtifactsTokenScope,
+    ttl?: number,
+  ) => Effect.Effect<ArtifactsCreateTokenResult, ArtifactsOperationError>;
+  readonly listTokens: Effect.Effect<ArtifactsTokenListResult, ArtifactsOperationError>;
+  readonly revokeToken: (tokenOrId: string) => Effect.Effect<boolean, ArtifactsOperationError>;
+  readonly fork: (
+    name: RepoName,
+    options?: ArtifactsForkOptions,
+  ) => Effect.Effect<ArtifactsCreateRepoResult, ArtifactsOperationError>;
+  readonly log: (
+    options?: ArtifactsLogOptions,
+  ) => Effect.Effect<ArtifactsLogResult, ArtifactsOperationError>;
+  readonly readCommit: (hash: string) => Effect.Effect<ArtifactsCommit, ArtifactsOperationError>;
+  readonly readTree: (hash: string) => Effect.Effect<ArtifactsTree, ArtifactsOperationError>;
+  readonly raw: ArtifactsRepoBinding;
+}
+
+/** Effect wrapper around a Cloudflare Artifacts namespace binding. */
+export interface ArtifactsClient {
+  readonly create: (
+    name: RepoName,
+    options?: ArtifactsCreateOptions,
+  ) => Effect.Effect<ArtifactsCreateRepoResult, ArtifactsOperationError>;
+  readonly get: (name: RepoName) => Effect.Effect<ArtifactsRepoClient, ArtifactsOperationError>;
+  readonly import: (
+    params: ArtifactsImportParams,
+  ) => Effect.Effect<ArtifactsCreateRepoResult, ArtifactsOperationError>;
+  readonly list: (
+    options?: ArtifactsListOptions,
+  ) => Effect.Effect<ArtifactsRepoListResult, ArtifactsOperationError>;
+  readonly delete: (name: RepoName) => Effect.Effect<boolean, ArtifactsOperationError>;
+  readonly rawUnsafe: Effect.Effect<ArtifactsBinding>;
+  readonly definition: ArtifactsDefinition;
+}
+
+declare const ArtifactsServiceTypeId: unique symbol;
+
+/** Nominal service marker for Artifacts services created with {@link make}. */
+export interface ArtifactsService<Id extends string> {
+  readonly [ArtifactsServiceTypeId]: {
+    readonly id: Id;
+  };
+}
+
+export type LayerOptions = {
+  readonly binding: string;
+};
+
+export interface TagClass<Self, Id extends string> extends Context.ServiceClass<
+  Self,
+  Id,
+  ArtifactsClient
+> {
+  readonly id: Id;
+  readonly layer: (
+    options: LayerOptions,
+  ) => Layer.Layer<
+    Self,
+    Binding.BindingNotFoundError | Binding.BindingValidationError,
+    WorkerEnvironment
+  >;
+}
+
+const artifactsErrorDetails = (
+  cause: unknown,
+): Pick<ArtifactsOperationError, "code" | "numericCode"> => {
+  if (typeof cause !== "object" || cause === null) {
+    return {};
+  }
+
+  const code = Reflect.get(cause, "code");
+  const numericCode = Reflect.get(cause, "numericCode");
+
+  return {
+    ...(typeof code === "string" ? { code } : {}),
+    ...(typeof numericCode === "number" ? { numericCode } : {}),
+  };
+};
+
+const artifactsError = (binding: string, operation: ArtifactsOperation, cause: unknown) =>
+  new ArtifactsOperationError({
+    binding,
+    operation,
+    cause,
+    ...artifactsErrorDetails(cause),
+  });
+
+const tryArtifactsPromise = <A>(
+  binding: string,
+  operation: ArtifactsOperation,
+  evaluate: () => Promise<A>,
+): Effect.Effect<A, ArtifactsOperationError> =>
+  Effect.tryPromise({
+    try: evaluate,
+    catch: (cause) => artifactsError(binding, operation, cause),
+  });
+
+const spanOptions = (binding: string, operation: ArtifactsOperation) => ({
+  attributes: { binding, operation },
+});
+
+const hasFunction = (value: object, key: string): boolean =>
+  typeof Reflect.get(value, key) === "function";
+
+/** Tests whether a value exposes the complete documented Artifacts repo handle API. */
+export const isArtifactsRepoBinding = (value: unknown): value is ArtifactsRepoBinding =>
+  typeof value === "object" &&
+  value !== null &&
+  hasFunction(value, "createToken") &&
+  hasFunction(value, "listTokens") &&
+  hasFunction(value, "revokeToken") &&
+  hasFunction(value, "fork") &&
+  hasFunction(value, "log") &&
+  hasFunction(value, "readCommit") &&
+  hasFunction(value, "readTree");
+
+/** Tests whether a value exposes the complete documented Artifacts namespace API. */
+export const isArtifactsBinding = (value: unknown): value is ArtifactsBinding =>
+  typeof value === "object" &&
+  value !== null &&
+  hasFunction(value, "create") &&
+  hasFunction(value, "get") &&
+  hasFunction(value, "import") &&
+  hasFunction(value, "list") &&
+  hasFunction(value, "delete");
+
+const wrapRepo = (binding: string, repo: ArtifactsRepoBinding): ArtifactsRepoClient => ({
+  id: repo.id,
+  name: repo.name,
+  description: repo.description,
+  defaultBranch: repo.defaultBranch,
+  createdAt: repo.createdAt,
+  updatedAt: repo.updatedAt,
+  lastPushAt: repo.lastPushAt,
+  source: repo.source,
+  readOnly: repo.readOnly,
+  remote: repo.remote,
+  createToken: Effect.fn(
+    "Artifacts.createToken",
+    spanOptions(binding, "createToken"),
+  )((scope?: ArtifactsTokenScope, ttl?: number) =>
+    tryArtifactsPromise(binding, "createToken", () => repo.createToken(scope, ttl)),
+  ),
+  listTokens: tryArtifactsPromise(binding, "listTokens", () => repo.listTokens()).pipe(
+    Effect.withSpan("Artifacts.listTokens", spanOptions(binding, "listTokens")),
+  ),
+  revokeToken: Effect.fn(
+    "Artifacts.revokeToken",
+    spanOptions(binding, "revokeToken"),
+  )((tokenOrId: string) =>
+    tryArtifactsPromise(binding, "revokeToken", () => repo.revokeToken(tokenOrId)),
+  ),
+  fork: Effect.fn(
+    "Artifacts.fork",
+    spanOptions(binding, "fork"),
+  )((name: RepoName, options?: ArtifactsForkOptions) =>
+    tryArtifactsPromise(binding, "fork", () => repo.fork(name, options)),
+  ),
+  log: Effect.fn(
+    "Artifacts.log",
+    spanOptions(binding, "log"),
+  )((options?: ArtifactsLogOptions) =>
+    tryArtifactsPromise(binding, "log", () => repo.log(options)),
+  ),
+  readCommit: Effect.fn(
+    "Artifacts.readCommit",
+    spanOptions(binding, "readCommit"),
+  )((hash: string) => tryArtifactsPromise(binding, "readCommit", () => repo.readCommit(hash))),
+  readTree: Effect.fn(
+    "Artifacts.readTree",
+    spanOptions(binding, "readTree"),
+  )((hash: string) => tryArtifactsPromise(binding, "readTree", () => repo.readTree(hash))),
+  raw: repo,
+});
+
+export const makeClient =
+  (definition: ArtifactsDefinition) =>
+  (artifacts: ArtifactsBinding): ArtifactsClient => ({
+    definition,
+    create: Effect.fn(
+      "Artifacts.create",
+      spanOptions(definition.binding, "create"),
+    )((name: RepoName, options?: ArtifactsCreateOptions) =>
+      tryArtifactsPromise(definition.binding, "create", () => artifacts.create(name, options)),
+    ),
+    get: Effect.fn(
+      "Artifacts.get",
+      spanOptions(definition.binding, "get"),
+    )((name: RepoName) =>
+      tryArtifactsPromise(definition.binding, "get", () => artifacts.get(name)).pipe(
+        Effect.flatMap((repo) =>
+          isArtifactsRepoBinding(repo)
+            ? Effect.succeed(wrapRepo(definition.binding, repo))
+            : Effect.fail(
+                artifactsError(
+                  definition.binding,
+                  "get",
+                  new TypeError(`Expected ${expectedArtifactsRepo}`),
+                ),
+              ),
+        ),
+      ),
+    ),
+    import: Effect.fn(
+      "Artifacts.import",
+      spanOptions(definition.binding, "import"),
+    )((params: ArtifactsImportParams) =>
+      tryArtifactsPromise(definition.binding, "import", () => artifacts.import(params)),
+    ),
+    list: Effect.fn(
+      "Artifacts.list",
+      spanOptions(definition.binding, "list"),
+    )((options?: ArtifactsListOptions) =>
+      tryArtifactsPromise(definition.binding, "list", () => artifacts.list(options)),
+    ),
+    delete: Effect.fn(
+      "Artifacts.delete",
+      spanOptions(definition.binding, "delete"),
+    )((name: RepoName) =>
+      tryArtifactsPromise(definition.binding, "delete", () => artifacts.delete(name)),
+    ),
+    rawUnsafe: Effect.succeed(artifacts),
+  });
+
+export const layer = <Self>(
+  tag: Context.Service<Self, ArtifactsClient>,
+  definition: ArtifactsDefinition,
+) =>
+  Binding.layer(tag, definition.binding, isArtifactsBinding, makeClient(definition), {
+    expected: expectedArtifactsBinding,
+  });
+
+export const make = <Id extends string>(id: Id) => Tag<ArtifactsService<Id>>()<Id>(id);
+
+export const Tag =
+  <Self>() =>
+  <Id extends string>(id: Id) => {
+    const tag = Context.Service<Self, ArtifactsClient>()(id);
+
+    const makeLayer = (definition: LayerOptions) => layer(tag, definition);
+
+    return Object.assign(tag, {
+      id,
+      layer: makeLayer,
+    }) as TagClass<Self, Id>;
+  };

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -1,5 +1,6 @@
 export * as AiGateway from "./AiGateway";
 export * as AnalyticsEngine from "./AnalyticsEngine";
+export * as Artifacts from "./Artifacts";
 export * as Binding from "./Binding";
 export * as BrowserRendering from "./BrowserRendering";
 export * as Cache from "./Cache";

--- a/packages/effect-cf/tests/Artifacts.test.ts
+++ b/packages/effect-cf/tests/Artifacts.test.ts
@@ -1,0 +1,378 @@
+import { assert, expect, layer, test } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import { Artifacts, Binding, WorkerEnvironment } from "../src/index";
+
+class TestArtifacts extends Artifacts.Tag<TestArtifacts>()("test/TestArtifacts") {}
+
+const repoInfo: Artifacts.ArtifactsRepoInfo = {
+  id: "repo-1",
+  name: "starter-repo",
+  description: "Repository for automation experiments",
+  defaultBranch: "main",
+  createdAt: "2026-08-15T00:00:00.000Z",
+  updatedAt: "2026-08-15T01:00:00.000Z",
+  lastPushAt: "2026-08-15T01:00:00.000Z",
+  source: null,
+  readOnly: false,
+  remote: "https://git.cloudflare.com/default/starter-repo",
+};
+
+const createResult = (
+  name: string,
+  description: string | null = null,
+): Artifacts.ArtifactsCreateRepoResult => ({
+  id: `${name}-id`,
+  name,
+  description,
+  defaultBranch: "main",
+  remote: `https://git.cloudflare.com/default/${name}`,
+  token: `${name}-token?expires=1786752000`,
+});
+
+interface Calls {
+  readonly create: Array<
+    readonly [Artifacts.RepoName, Artifacts.ArtifactsCreateOptions | undefined]
+  >;
+  readonly get: Array<Artifacts.RepoName>;
+  readonly import: Array<Artifacts.ArtifactsImportParams>;
+  readonly list: Array<Artifacts.ArtifactsListOptions | undefined>;
+  readonly delete: Array<Artifacts.RepoName>;
+  readonly createToken: Array<
+    readonly [Artifacts.ArtifactsTokenScope | undefined, number | undefined]
+  >;
+  readonly listTokens: Array<true>;
+  readonly revokeToken: Array<string>;
+  readonly fork: Array<readonly [Artifacts.RepoName, Artifacts.ArtifactsForkOptions | undefined]>;
+  readonly log: Array<Artifacts.ArtifactsLogOptions | undefined>;
+  readonly readCommit: Array<string>;
+  readonly readTree: Array<string>;
+}
+
+const makeCalls = (): Calls => ({
+  create: [],
+  get: [],
+  import: [],
+  list: [],
+  delete: [],
+  createToken: [],
+  listTokens: [],
+  revokeToken: [],
+  fork: [],
+  log: [],
+  readCommit: [],
+  readTree: [],
+});
+
+const makeRepo = (calls: Calls): Artifacts.ArtifactsRepoBinding => ({
+  ...repoInfo,
+  createToken: async (scope, ttl) => {
+    calls.createToken.push([scope, ttl]);
+
+    return {
+      id: "token-1",
+      plaintext: "art_v1_token?expires=1786752000",
+      scope: scope ?? "write",
+      expiresAt: "2026-08-16T00:00:00.000Z",
+    };
+  },
+  listTokens: async () => {
+    calls.listTokens.push(true);
+
+    return {
+      tokens: [
+        {
+          id: "token-1",
+          scope: "read",
+          state: "active",
+          createdAt: "2026-08-15T00:00:00.000Z",
+          expiresAt: "2026-08-16T00:00:00.000Z",
+        },
+      ],
+      total: 1,
+    };
+  },
+  revokeToken: async (tokenOrId) => {
+    calls.revokeToken.push(tokenOrId);
+
+    return true;
+  },
+  fork: async (name, options) => {
+    calls.fork.push([name, options]);
+
+    return createResult(name, options?.description ?? null);
+  },
+  log: async (options) => {
+    calls.log.push(options);
+
+    return { commits: ["commit-1"] };
+  },
+  readCommit: async (hash) => {
+    calls.readCommit.push(hash);
+
+    return { hash, tree: "tree-1" };
+  },
+  readTree: async (hash) => {
+    calls.readTree.push(hash);
+
+    return { hash, entries: [{ name: "README.md", type: "blob" }] };
+  },
+});
+
+const makeArtifacts = (calls: Calls): Artifacts.ArtifactsBinding => {
+  const repo = makeRepo(calls);
+
+  return {
+    create: async (name, options) => {
+      calls.create.push([name, options]);
+
+      return createResult(name, options?.description ?? null);
+    },
+    get: async (name) => {
+      calls.get.push(name);
+
+      return repo;
+    },
+    import: async (params) => {
+      calls.import.push(params);
+
+      return createResult(params.target.name, params.target.opts?.description ?? null);
+    },
+    list: async (options) => {
+      calls.list.push(options);
+
+      return {
+        repos: [{ ...repoInfo, status: "ready" }],
+        total: 1,
+        cursor: "next-cursor",
+      };
+    },
+    delete: async (name) => {
+      calls.delete.push(name);
+
+      return true;
+    },
+  };
+};
+
+const artifactsLayer = (artifacts: Artifacts.ArtifactsBinding) =>
+  TestArtifacts.layer({ binding: "ARTIFACTS" }).pipe(
+    Layer.provide(Layer.succeed(WorkerEnvironment, { ARTIFACTS: artifacts })),
+  );
+
+{
+  const calls = makeCalls();
+  const artifacts = makeArtifacts(calls);
+
+  layer(artifactsLayer(artifacts))("Artifacts namespace", (it) => {
+    it.effect("wraps every namespace operation and forwards every option", () =>
+      Effect.gen(function* () {
+        const client = yield* TestArtifacts;
+        const created = yield* client.create("new-repo", {
+          description: "New repository",
+          readOnly: true,
+          setDefaultBranch: "trunk",
+        });
+        const repo = yield* client.get("starter-repo");
+        const imported = yield* client.import({
+          source: {
+            url: "https://github.com/cloudflare/workers-sdk",
+            branch: "main",
+            depth: 5,
+          },
+          target: {
+            name: "workers-sdk",
+            opts: {
+              description: "Imported Workers SDK",
+              readOnly: true,
+            },
+          },
+        });
+        const listed = yield* client.list({ limit: 10, cursor: "cursor-1" });
+        const deleted = yield* client.delete("old-repo");
+        const raw = yield* client.rawUnsafe;
+
+        assert.strictEqual(created.name, "new-repo");
+        assert.strictEqual(repo.name, "starter-repo");
+        assert.strictEqual(imported.name, "workers-sdk");
+        assert.strictEqual(listed.repos[0]?.status, "ready");
+        assert.strictEqual(listed.repos[0]?.remote, repoInfo.remote);
+        assert.strictEqual(listed.total, 1);
+        assert.strictEqual(listed.cursor, "next-cursor");
+        assert.strictEqual(deleted, true);
+        assert.strictEqual(raw, artifacts);
+        assert.deepStrictEqual(calls.create, [
+          [
+            "new-repo",
+            {
+              description: "New repository",
+              readOnly: true,
+              setDefaultBranch: "trunk",
+            },
+          ],
+        ]);
+        assert.deepStrictEqual(calls.get, ["starter-repo"]);
+        assert.deepStrictEqual(calls.import, [
+          {
+            source: {
+              url: "https://github.com/cloudflare/workers-sdk",
+              branch: "main",
+              depth: 5,
+            },
+            target: {
+              name: "workers-sdk",
+              opts: {
+                description: "Imported Workers SDK",
+                readOnly: true,
+              },
+            },
+          },
+        ]);
+        assert.deepStrictEqual(calls.list, [{ limit: 10, cursor: "cursor-1" }]);
+        assert.deepStrictEqual(calls.delete, ["old-repo"]);
+      }),
+    );
+  });
+}
+
+{
+  const calls = makeCalls();
+
+  layer(artifactsLayer(makeArtifacts(calls)))("Artifacts repository", (it) => {
+    it.effect("wraps every repo operation and forwards every option", () =>
+      Effect.gen(function* () {
+        const artifacts = yield* TestArtifacts;
+        const repo = yield* artifacts.get("starter-repo");
+        const token = yield* repo.createToken("read", 3600);
+        const tokens = yield* repo.listTokens;
+        const revoked = yield* repo.revokeToken("token-1");
+        const forked = yield* repo.fork("starter-repo-copy", {
+          description: "Fork for testing",
+          readOnly: true,
+          defaultBranchOnly: false,
+        });
+        const history = yield* repo.log({ ref: "main", limit: 10, offset: 2 });
+        const commit = yield* repo.readCommit("commit-1");
+        const tree = yield* repo.readTree("tree-1");
+
+        assert.strictEqual(repo.raw.name, "starter-repo");
+        assert.deepStrictEqual(token, {
+          id: "token-1",
+          plaintext: "art_v1_token?expires=1786752000",
+          scope: "read",
+          expiresAt: "2026-08-16T00:00:00.000Z",
+        });
+        assert.strictEqual(tokens.total, 1);
+        assert.strictEqual(tokens.tokens[0]?.state, "active");
+        assert.strictEqual(revoked, true);
+        assert.strictEqual(forked.name, "starter-repo-copy");
+        assert.deepStrictEqual(history, { commits: ["commit-1"] });
+        assert.deepStrictEqual(commit, { hash: "commit-1", tree: "tree-1" });
+        assert.deepStrictEqual(tree, {
+          hash: "tree-1",
+          entries: [{ name: "README.md", type: "blob" }],
+        });
+        assert.deepStrictEqual(calls.createToken, [["read", 3600]]);
+        assert.deepStrictEqual(calls.listTokens, [true]);
+        assert.deepStrictEqual(calls.revokeToken, ["token-1"]);
+        assert.deepStrictEqual(calls.fork, [
+          [
+            "starter-repo-copy",
+            {
+              description: "Fork for testing",
+              readOnly: true,
+              defaultBranchOnly: false,
+            },
+          ],
+        ]);
+        assert.deepStrictEqual(calls.log, [{ ref: "main", limit: 10, offset: 2 }]);
+        assert.deepStrictEqual(calls.readCommit, ["commit-1"]);
+        assert.deepStrictEqual(calls.readTree, ["tree-1"]);
+      }),
+    );
+  });
+}
+
+test("Artifacts layer validates the namespace binding shape", async () => {
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestArtifacts;
+      }).pipe(
+        Effect.provide(
+          TestArtifacts.layer({ binding: "ARTIFACTS" }).pipe(
+            Layer.provide(
+              Layer.succeed(WorkerEnvironment, {
+                ARTIFACTS: {} as Artifacts.ArtifactsBinding,
+              }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toBeInstanceOf(Binding.BindingValidationError);
+});
+
+test("Artifacts layer reports a missing configured binding", async () => {
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestArtifacts;
+      }).pipe(
+        Effect.provide(
+          TestArtifacts.layer({ binding: "MISSING_ARTIFACTS" }).pipe(
+            Layer.provide(Layer.succeed(WorkerEnvironment, {})),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toBeInstanceOf(Binding.BindingNotFoundError);
+});
+
+test("Artifacts get rejects incomplete repo handles", async () => {
+  const calls = makeCalls();
+  const artifacts = {
+    ...makeArtifacts(calls),
+    get: async () => repoInfo as Artifacts.ArtifactsRepoBinding,
+  } satisfies Artifacts.ArtifactsBinding;
+
+  const error = await Effect.runPromise(
+    Effect.gen(function* () {
+      const client = yield* TestArtifacts;
+
+      return yield* Effect.flip(client.get("starter-repo"));
+    }).pipe(Effect.provide(artifactsLayer(artifacts))),
+  );
+
+  assert.strictEqual(error._tag, "ArtifactsOperationError");
+  assert.strictEqual(error.operation, "get");
+  assert.match(error.message, /Artifacts repo handle with/);
+});
+
+test("Artifacts preserves Cloudflare error identifiers", async () => {
+  const calls = makeCalls();
+  const cause = Object.assign(new Error("repository already exists"), {
+    name: "ArtifactsError",
+    code: "ALREADY_EXISTS",
+    numericCode: 10201,
+  });
+  const artifacts = {
+    ...makeArtifacts(calls),
+    create: async () => Promise.reject(cause),
+  } satisfies Artifacts.ArtifactsBinding;
+
+  const error = await Effect.runPromise(
+    Effect.gen(function* () {
+      const client = yield* TestArtifacts;
+
+      return yield* Effect.flip(client.create("starter-repo"));
+    }).pipe(Effect.provide(artifactsLayer(artifacts))),
+  );
+
+  assert.strictEqual(error._tag, "ArtifactsOperationError");
+  assert.strictEqual(error.operation, "create");
+  assert.strictEqual(error.cause, cause);
+  assert.strictEqual(error.code, "ALREADY_EXISTS");
+  assert.strictEqual(error.numericCode, 10201);
+  assert.match(error.message, /\(ALREADY_EXISTS\)/);
+});

--- a/packages/effect-cf/tests/binding-ergonomics.test-d.ts
+++ b/packages/effect-cf/tests/binding-ergonomics.test-d.ts
@@ -12,6 +12,7 @@ import {
   type WorkflowBinding,
   AiGateway,
   AnalyticsEngine,
+  Artifacts,
   BrowserRendering,
   DurableObject,
   Email,
@@ -75,6 +76,92 @@ expectTypeOf(AvatarQueue.send({ requestId: "r1", userId: "u1" })).toEqualTypeOf<
 
 void missingQueueLayer;
 void providedQueueProgram;
+
+export class ArtifactRepositories extends Artifacts.Tag<ArtifactRepositories>()(
+  "ArtifactRepositories",
+) {}
+
+export const ArtifactRepositoriesLayer = ArtifactRepositories.layer({
+  binding: "ARTIFACTS",
+});
+
+const artifactsProgram = Effect.gen(function* () {
+  const artifacts = yield* ArtifactRepositories;
+
+  expectTypeOf(
+    artifacts.create("agent-workspace", {
+      description: "Agent workspace",
+      readOnly: false,
+      setDefaultBranch: "main",
+    }),
+  ).toEqualTypeOf<
+    Effect.Effect<Artifacts.ArtifactsCreateRepoResult, Artifacts.ArtifactsOperationError>
+  >();
+
+  expectTypeOf(
+    artifacts.import({
+      source: {
+        url: "https://github.com/cloudflare/workers-sdk",
+        branch: "main",
+        depth: 1,
+      },
+      target: {
+        name: "workers-sdk",
+        opts: { description: "Workers SDK", readOnly: true },
+      },
+    }),
+  ).toEqualTypeOf<
+    Effect.Effect<Artifacts.ArtifactsCreateRepoResult, Artifacts.ArtifactsOperationError>
+  >();
+
+  expectTypeOf(artifacts.list({ limit: 20, cursor: "next" })).toEqualTypeOf<
+    Effect.Effect<Artifacts.ArtifactsRepoListResult, Artifacts.ArtifactsOperationError>
+  >();
+
+  expectTypeOf(artifacts.delete("agent-workspace")).toEqualTypeOf<
+    Effect.Effect<boolean, Artifacts.ArtifactsOperationError>
+  >();
+
+  const repo = yield* artifacts.get("agent-workspace");
+
+  expectTypeOf(repo).toEqualTypeOf<Artifacts.ArtifactsRepoClient>();
+  expectTypeOf(repo.createToken("read", 3600)).toEqualTypeOf<
+    Effect.Effect<Artifacts.ArtifactsCreateTokenResult, Artifacts.ArtifactsOperationError>
+  >();
+  expectTypeOf(repo.listTokens).toEqualTypeOf<
+    Effect.Effect<Artifacts.ArtifactsTokenListResult, Artifacts.ArtifactsOperationError>
+  >();
+  expectTypeOf(repo.revokeToken("token-id")).toEqualTypeOf<
+    Effect.Effect<boolean, Artifacts.ArtifactsOperationError>
+  >();
+  expectTypeOf(
+    repo.fork("agent-workspace-copy", {
+      description: "Review copy",
+      readOnly: true,
+      defaultBranchOnly: true,
+    }),
+  ).toEqualTypeOf<
+    Effect.Effect<Artifacts.ArtifactsCreateRepoResult, Artifacts.ArtifactsOperationError>
+  >();
+  expectTypeOf(repo.log({ ref: "main", limit: 10, offset: 0 })).toEqualTypeOf<
+    Effect.Effect<Artifacts.ArtifactsLogResult, Artifacts.ArtifactsOperationError>
+  >();
+  expectTypeOf(repo.readCommit("commit-sha")).toEqualTypeOf<
+    Effect.Effect<Artifacts.ArtifactsCommit, Artifacts.ArtifactsOperationError>
+  >();
+  expectTypeOf(repo.readTree("tree-sha")).toEqualTypeOf<
+    Effect.Effect<Artifacts.ArtifactsTree, Artifacts.ArtifactsOperationError>
+  >();
+  expectTypeOf(artifacts.rawUnsafe).toEqualTypeOf<Effect.Effect<Artifacts.ArtifactsBinding>>();
+
+  // @ts-expect-error token scopes are read or write.
+  yield* repo.createToken("admin", 3600);
+});
+
+expectTypeOf(Artifacts.artifactsErrorNumericCodes.INVALID_TTL).toEqualTypeOf<10103>();
+expectTypeOf(EffectCf.Artifacts).toEqualTypeOf<typeof Artifacts>();
+
+void artifactsProgram;
 
 export const ReportWorkflowPayload = Schema.Struct({
   reportId: Schema.String,

--- a/packages/effect-cf/tests/env.d.ts
+++ b/packages/effect-cf/tests/env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="@cloudflare/vitest-pool-workers/types" />
 
+import type * as EffectArtifacts from "../src/Artifacts";
 import type * as TestWorkerModule from "./worker-fixture";
 
 declare global {
@@ -16,6 +17,7 @@ declare global {
       IMAGES?: ImagesBinding;
       AI?: Ai;
       REQUEST_ANALYTICS?: AnalyticsEngineDataset;
+      ARTIFACTS?: EffectArtifacts.ArtifactsBinding;
       RECIPE_VECTORS?: Vectorize;
       MYBROWSER?: unknown;
       DATABASE_URL?: string;


### PR DESCRIPTION
## Summary

Adds a new `Artifacts` module giving first-class Effect coverage of the complete [Cloudflare Artifacts Workers binding](https://developers.cloudflare.com/artifacts/api/workers-binding/) surface:

- All five namespace methods: `create`, `get`, `list`, `import`, `delete`.
- All seven repo-handle methods: `createToken`, `listTokens`, `revokeToken`, `fork`, `log`, `readCommit`, `readTree`.
- Typed options/results, binding validation, tracing spans, and a typed `ArtifactsOperationError` channel carrying the [documented Cloudflare error identifiers](https://developers.cloudflare.com/artifacts/api/errors/) (string and numeric codes), plus a `rawUnsafe` escape hatch matching sibling modules.
- The Git result types Cloudflare names but does not yet specify fields for (`ArtifactsLogResult`, `ArtifactsCommit`, `ArtifactsTree`) are typed as safe structural records rather than invented shapes.
- Exported from `index.ts`, registered in the test env types, documented in the package README (including wrangler binding configuration), with a `minor` changeset.

## Validation

- `vp run check` — passed (build, format, lint, typecheck, all tests).
- New runtime tests in `packages/effect-cf/tests/Artifacts.test.ts` cover every wrapped method (6 tests, all passing), plus compile-time ergonomics coverage in `binding-ergonomics.test-d.ts`.
- Implementation cross-checked against the live Cloudflare Artifacts API docs for full method/option/return-type coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)