### PR TITLE
feat: add Cloudflare Computer workspace integration

### DIFF
--- a/.changeset/curly-computers-work.md
+++ b/.changeset/curly-computers-work.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add Effect-native Cloudflare Computer workspaces, scoped execution handles, a Durable Object host mixin, and session-isolated Artifacts clients.

--- a/bun.lock
+++ b/bun.lock
@@ -290,7 +290,7 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.25.1",
+      "version": "0.25.3",
       "devDependencies": {
         "@cloudflare/computer": "0.2.0",
         "@cloudflare/containers": "catalog:",
@@ -301,6 +301,7 @@
         "@effect/sql-pg": "catalog:",
         "@effect/sql-sqlite-do": "catalog:",
         "@effect/vitest": "catalog:",
+        "@platformatic/vfs": "^0.4.0",
         "effect": "catalog:",
         "vite-plus": "catalog:",
         "vitest": "catalog:",
@@ -369,6 +370,8 @@
 
     "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.1", "", { "dependencies": { "@changesets/config": "^3.1.4", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA=="],
 
     "@changesets/assemble-release-plan": ["@changesets/assemble-release-plan@6.0.10", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "semver": "^7.5.3" } }, "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A=="],
@@ -406,6 +409,8 @@
     "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
+
+    "@cloudflare/computer": ["@cloudflare/computer@0.2.0", "", { "dependencies": { "acorn": "^8.17.0", "capnweb": "^0.8.0", "just-bash": "^3.0.1" }, "peerDependencies": { "@platformatic/vfs": "*", "ai": "^6.0.196 || ^7.0.0", "zod": "^4.4.3" }, "optionalPeers": ["@platformatic/vfs", "ai", "zod"] }, "sha512-J0LQngfZYsmHofamSJfCch6lfqRaa6dnK1qh4jUrvUoix0ggCyR+ndtu1upFRnQVp0EhrvlKuxyGxKt6ApIh3A=="],
 
     "@cloudflare/containers": ["@cloudflare/containers@0.3.7", "", {}, "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw=="],
 
@@ -609,6 +614,16 @@
 
     "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
 
+    "@jitl/quickjs-ffi-types": ["@jitl/quickjs-ffi-types@0.32.0", "", {}, "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="],
+
+    "@jitl/quickjs-wasmfile-debug-asyncify": ["@jitl/quickjs-wasmfile-debug-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw=="],
+
+    "@jitl/quickjs-wasmfile-debug-sync": ["@jitl/quickjs-wasmfile-debug-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q=="],
+
+    "@jitl/quickjs-wasmfile-release-asyncify": ["@jitl/quickjs-wasmfile-release-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q=="],
+
+    "@jitl/quickjs-wasmfile-release-sync": ["@jitl/quickjs-wasmfile-release-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg=="],
+
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
@@ -618,6 +633,10 @@
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@mongodb-js/zstd": ["@mongodb-js/zstd@7.0.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "prebuild-install": "^7.1.3" } }, "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -630,6 +649,8 @@
     "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -731,6 +752,8 @@
 
     "@oxlint/plugins": ["@oxlint/plugins@1.73.0", "", {}, "sha512-OhgMQeMmZA0dcFcX4/priaJZWdFECxiClgq6mRX6aatZEcV9PbKC3P3/v8U1hVjviT1i5U+vR8lAtBV6m4FXAA=="],
 
+    "@platformatic/vfs": ["@platformatic/vfs@0.4.0", "", {}, "sha512-JwRxSIG63e/VaDSkYXkSBajySt5MJzxYIKuknYda28fhhmJMqyUGf5rbKrGW+vO9L83nIjQH3+YI12fp7EKICQ=="],
+
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
@@ -752,6 +775,10 @@
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.3", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
@@ -913,6 +940,8 @@
 
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
@@ -923,7 +952,11 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
@@ -931,7 +964,11 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "capnweb": ["capnweb@0.8.0", "", {}, "sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -945,9 +982,13 @@
 
     "chat-web": ["chat-web@workspace:examples/chat/web"],
 
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
     "cjs-module-lexer": ["cjs-module-lexer@1.2.3", "", {}, "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="],
 
     "cluster-key-slot": ["cluster-key-slot@1.1.1", "", {}, "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="],
+
+    "commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -961,6 +1002,10 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
@@ -970,6 +1015,8 @@
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
@@ -982,6 +1029,8 @@
     "effect-cf": ["effect-cf@workspace:packages/effect-cf"],
 
     "effect-webtransport": ["effect-webtransport@workspace:packages/effect-webtransport"],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
@@ -1013,6 +1062,8 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
@@ -1027,11 +1078,17 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -1041,9 +1098,13 @@
 
     "flatted": ["flatted@3.4.4", "", {}, "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q=="],
 
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -1055,9 +1116,15 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
     "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
 
@@ -1068,6 +1135,8 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-subdir": ["is-subdir@1.2.0", "", { "dependencies": { "better-path-resolve": "1.0.0" } }, "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw=="],
+
+    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
 
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
 
@@ -1086,6 +1155,8 @@
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
+
+    "just-bash": ["just-bash@3.3.0", "", { "dependencies": { "diff": "^8.0.2", "fast-xml-parser": "^5.7.3", "file-type": "^21.2.0", "ini": "^6.0.0", "minimatch": "^10.1.1", "modern-tar": "^0.7.3", "papaparse": "^5.5.3", "quickjs-emscripten": "^0.32.0", "re2js": "^1.2.1", "seek-bzip": "^2.0.0", "smol-toml": "^1.6.0", "sprintf-js": "^1.1.3", "sql.js": "^1.13.0", "turndown": "^7.2.2", "undici": "^7.25.0", "yaml": "^2.8.2" }, "optionalDependencies": { "@mongodb-js/zstd": "^7.0.0", "node-liblzma": "^2.0.3" }, "bin": { "just-bash": "dist/bin/just-bash.js", "just-bash-shell": "dist/bin/shell/shell.js" } }, "sha512-jh+qnThmOZ8V7+NTy6MHR0+7jJGMnsdrm6Cnhjz66cmE9FgYyB+XdMnYj0JD0cMEl+Tnl3bXfEY2lhIiEMBG2g=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -1133,9 +1204,17 @@
 
     "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
     "miniflare": ["miniflare@5.20260811.1-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260811.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA=="],
 
     "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "modern-tar": ["modern-tar@0.7.7", "", {}, "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -1149,15 +1228,27 @@
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
+
+    "node-addon-api": ["node-addon-api@8.9.2", "", {}, "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "node-liblzma": ["node-liblzma@2.2.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "node-gyp-build": "^4.8.4" }, "bin": { "nxz": "lib/cli/nxz.js" } }, "sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g=="],
 
     "obuf": ["obuf@1.1.2", "", {}, "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="],
 
     "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -1181,7 +1272,11 @@
 
     "package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
 
+    "papaparse": ["papaparse@5.6.0", "", {}, "sha512-N2vuNQAYGK1/4vs6HJX86+VYU6OkiSTgdJz3JQfTk1y51cFCO/U8gnaeTF4iNE4r57Tt0sV47dUua1/19pxO6Q=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1231,11 +1326,15 @@
 
     "postgres-range": ["postgres-range@1.1.4", "", {}, "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -1247,6 +1346,14 @@
 
     "queue-workflow-app": ["queue-workflow-app@workspace:examples/queue-workflow/workers/app"],
 
+    "quickjs-emscripten": ["quickjs-emscripten@0.32.0", "", { "dependencies": { "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-debug-sync": "0.32.0", "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-release-sync": "0.32.0", "quickjs-emscripten-core": "0.32.0" } }, "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA=="],
+
+    "quickjs-emscripten-core": ["quickjs-emscripten-core@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "re2js": ["re2js@1.4.0", "", {}, "sha512-KTOIcZTSOpOxbu3i0+T6mFQ6tkxXKlTxfcMFs1trQbsMnG84qNq+DjXr8Afu+FEFjvF1NNlldpC7roPyazFI8g=="],
+
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
@@ -1254,6 +1361,8 @@
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
 
@@ -1265,9 +1374,13 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "seek-bzip": ["seek-bzip@2.0.0", "", { "dependencies": { "commander": "^6.0.0" }, "bin": { "seek-bunzip": "bin/seek-bunzip", "seek-table": "bin/seek-bzip-table" } }, "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg=="],
 
     "semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
@@ -1281,9 +1394,15 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -1291,7 +1410,9 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
-    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
+    "sql.js": ["sql.js@1.14.2", "", {}, "sha512-3ZGPovObMFrdw79zrUHbfdE/DLIsy8jdNdssmMSQuRAymedU6q84asPt0kgiqrdMYlPegDItiIMfmIXzZnYFcw=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
@@ -1299,11 +1420,23 @@
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
@@ -1339,6 +1472,8 @@
 
     "todos-web-worker": ["todos-web-worker@workspace:examples/todos/workers/web"],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
@@ -1347,9 +1482,15 @@
 
     "tsx": ["tsx@4.22.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
 
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
@@ -1360,6 +1501,8 @@
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
@@ -1383,7 +1526,11 @@
 
     "wrangler": ["wrangler@4.100.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260611.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260611.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260611.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -1429,6 +1576,8 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "just-bash/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "miniflare/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
@@ -1437,9 +1586,13 @@
 
     "pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
+    "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -1539,6 +1692,8 @@
 
     "eslint/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "read-yaml-file/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
     "wrangler/miniflare/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
 
     "wrangler/miniflare/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
@@ -1586,159 +1741,5 @@
     "wrangler/miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "eslint/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
-
-    "@cloudflare/computer": ["@cloudflare/computer@0.2.0", "", { "dependencies": { "acorn": "^8.17.0", "capnweb": "^0.8.0", "just-bash": "^3.0.1" }, "peerDependencies": { "@platformatic/vfs": "*", "ai": "^6.0.196 || ^7.0.0", "zod": "^4.4.3" }, "optionalPeers": ["@platformatic/vfs", "ai", "zod"] }, "sha512-J0LQngfZYsmHofamSJfCch6lfqRaa6dnK1qh4jUrvUoix0ggCyR+ndtu1upFRnQVp0EhrvlKuxyGxKt6ApIh3A=="],
-
-    "@cloudflare/computer/capnweb": ["capnweb@0.8.0", "", {}, "sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA=="],
-
-    "just-bash": ["just-bash@3.3.0", "", { "dependencies": { "diff": "^8.0.2", "fast-xml-parser": "^5.7.3", "file-type": "^21.2.0", "ini": "^6.0.0", "minimatch": "^10.1.1", "modern-tar": "^0.7.3", "papaparse": "^5.5.3", "quickjs-emscripten": "^0.32.0", "re2js": "^1.2.1", "seek-bzip": "^2.0.0", "smol-toml": "^1.6.0", "sprintf-js": "^1.1.3", "sql.js": "^1.13.0", "turndown": "^7.2.2", "undici": "^7.25.0", "yaml": "^2.8.2" }, "optionalDependencies": { "@mongodb-js/zstd": "^7.0.0", "node-liblzma": "^2.0.3" }, "bin": { "just-bash": "dist/bin/just-bash.js", "just-bash-shell": "dist/bin/shell/shell.js" } }, "sha512-jh+qnThmOZ8V7+NTy6MHR0+7jJGMnsdrm6Cnhjz66cmE9FgYyB+XdMnYj0JD0cMEl+Tnl3bXfEY2lhIiEMBG2g=="],
-
-    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
-
-    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
-
-    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
-
-    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
-
-    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
-
-    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
-
-    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
-
-    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
-
-    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
-
-    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
-
-    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
-
-    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
-
-    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
-
-    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
-
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
-
-    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
-
-    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
-
-    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
-
-    "modern-tar": ["modern-tar@0.7.7", "", {}, "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ=="],
-
-    "papaparse": ["papaparse@5.6.0", "", {}, "sha512-N2vuNQAYGK1/4vs6HJX86+VYU6OkiSTgdJz3JQfTk1y51cFCO/U8gnaeTF4iNE4r57Tt0sV47dUua1/19pxO6Q=="],
-
-    "quickjs-emscripten": ["quickjs-emscripten@0.32.0", "", { "dependencies": { "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-debug-sync": "0.32.0", "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-release-sync": "0.32.0", "quickjs-emscripten-core": "0.32.0" } }, "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA=="],
-
-    "@jitl/quickjs-wasmfile-debug-asyncify": ["@jitl/quickjs-wasmfile-debug-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw=="],
-
-    "@jitl/quickjs-ffi-types": ["@jitl/quickjs-ffi-types@0.32.0", "", {}, "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="],
-
-    "@jitl/quickjs-wasmfile-debug-sync": ["@jitl/quickjs-wasmfile-debug-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q=="],
-
-    "@jitl/quickjs-wasmfile-release-asyncify": ["@jitl/quickjs-wasmfile-release-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q=="],
-
-    "@jitl/quickjs-wasmfile-release-sync": ["@jitl/quickjs-wasmfile-release-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg=="],
-
-    "quickjs-emscripten-core": ["quickjs-emscripten-core@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg=="],
-
-    "re2js": ["re2js@1.4.0", "", {}, "sha512-KTOIcZTSOpOxbu3i0+T6mFQ6tkxXKlTxfcMFs1trQbsMnG84qNq+DjXr8Afu+FEFjvF1NNlldpC7roPyazFI8g=="],
-
-    "seek-bzip": ["seek-bzip@2.0.0", "", { "dependencies": { "commander": "^6.0.0" }, "bin": { "seek-bunzip": "bin/seek-bunzip", "seek-table": "bin/seek-bzip-table" } }, "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg=="],
-
-    "seek-bzip/commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
-
-    "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
-
-    "just-bash/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
-
-    "sql.js": ["sql.js@1.14.2", "", {}, "sha512-3ZGPovObMFrdw79zrUHbfdE/DLIsy8jdNdssmMSQuRAymedU6q84asPt0kgiqrdMYlPegDItiIMfmIXzZnYFcw=="],
-
-    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
-
-    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
-
-    "just-bash/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
-
-    "@mongodb-js/zstd": ["@mongodb-js/zstd@7.0.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "prebuild-install": "^7.1.3" } }, "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA=="],
-
-    "node-addon-api": ["node-addon-api@8.9.2", "", {}, "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg=="],
-
-    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
-
-    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
-
-    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
-
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
-
-    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
-
-    "prebuild-install/node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
-
-    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
-
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
-
-    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
-
-    "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
-
-    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
-
-    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
-
-    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
-
-    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
-
-    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
-
-    "prebuild-install/tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
-
-    "prebuild-install/tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
-
-    "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
-
-    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
-
-    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
-
-    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
-
-    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
-    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
-
-    "prebuild-install/tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
-
-    "tunnel-agent/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "node-liblzma": ["node-liblzma@2.2.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "node-gyp-build": "^4.8.4" }, "bin": { "nxz": "lib/cli/nxz.js" } }, "sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g=="],
-
-    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -292,6 +292,7 @@
       "name": "effect-cf",
       "version": "0.25.1",
       "devDependencies": {
+        "@cloudflare/computer": "0.2.0",
         "@cloudflare/containers": "catalog:",
         "@cloudflare/vitest-pool-workers": "catalog:",
         "@cloudflare/workers-types": "catalog:",
@@ -305,6 +306,7 @@
         "vitest": "catalog:",
       },
       "peerDependencies": {
+        "@cloudflare/computer": "^0.2.0",
         "@cloudflare/vitest-pool-workers": "^0.21.3",
         "@cloudflare/workers-types": "^4.20260611.1",
         "@effect/sql-d1": "^4.0.0-beta.107 <4.0.0-rc.0",
@@ -313,6 +315,7 @@
         "effect": "^4.0.0-beta.107 <4.0.0-rc.0",
       },
       "optionalPeers": [
+        "@cloudflare/computer",
         "@cloudflare/vitest-pool-workers",
         "@cloudflare/workers-types",
         "@effect/sql-pg",
@@ -1583,5 +1586,159 @@
     "wrangler/miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "eslint/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "@cloudflare/computer": ["@cloudflare/computer@0.2.0", "", { "dependencies": { "acorn": "^8.17.0", "capnweb": "^0.8.0", "just-bash": "^3.0.1" }, "peerDependencies": { "@platformatic/vfs": "*", "ai": "^6.0.196 || ^7.0.0", "zod": "^4.4.3" }, "optionalPeers": ["@platformatic/vfs", "ai", "zod"] }, "sha512-J0LQngfZYsmHofamSJfCch6lfqRaa6dnK1qh4jUrvUoix0ggCyR+ndtu1upFRnQVp0EhrvlKuxyGxKt6ApIh3A=="],
+
+    "@cloudflare/computer/capnweb": ["capnweb@0.8.0", "", {}, "sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA=="],
+
+    "just-bash": ["just-bash@3.3.0", "", { "dependencies": { "diff": "^8.0.2", "fast-xml-parser": "^5.7.3", "file-type": "^21.2.0", "ini": "^6.0.0", "minimatch": "^10.1.1", "modern-tar": "^0.7.3", "papaparse": "^5.5.3", "quickjs-emscripten": "^0.32.0", "re2js": "^1.2.1", "seek-bzip": "^2.0.0", "smol-toml": "^1.6.0", "sprintf-js": "^1.1.3", "sql.js": "^1.13.0", "turndown": "^7.2.2", "undici": "^7.25.0", "yaml": "^2.8.2" }, "optionalDependencies": { "@mongodb-js/zstd": "^7.0.0", "node-liblzma": "^2.0.3" }, "bin": { "just-bash": "dist/bin/just-bash.js", "just-bash-shell": "dist/bin/shell/shell.js" } }, "sha512-jh+qnThmOZ8V7+NTy6MHR0+7jJGMnsdrm6Cnhjz66cmE9FgYyB+XdMnYj0JD0cMEl+Tnl3bXfEY2lhIiEMBG2g=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
+
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
+
+    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
+
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
+
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "modern-tar": ["modern-tar@0.7.7", "", {}, "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ=="],
+
+    "papaparse": ["papaparse@5.6.0", "", {}, "sha512-N2vuNQAYGK1/4vs6HJX86+VYU6OkiSTgdJz3JQfTk1y51cFCO/U8gnaeTF4iNE4r57Tt0sV47dUua1/19pxO6Q=="],
+
+    "quickjs-emscripten": ["quickjs-emscripten@0.32.0", "", { "dependencies": { "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-debug-sync": "0.32.0", "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-release-sync": "0.32.0", "quickjs-emscripten-core": "0.32.0" } }, "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA=="],
+
+    "@jitl/quickjs-wasmfile-debug-asyncify": ["@jitl/quickjs-wasmfile-debug-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw=="],
+
+    "@jitl/quickjs-ffi-types": ["@jitl/quickjs-ffi-types@0.32.0", "", {}, "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="],
+
+    "@jitl/quickjs-wasmfile-debug-sync": ["@jitl/quickjs-wasmfile-debug-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q=="],
+
+    "@jitl/quickjs-wasmfile-release-asyncify": ["@jitl/quickjs-wasmfile-release-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q=="],
+
+    "@jitl/quickjs-wasmfile-release-sync": ["@jitl/quickjs-wasmfile-release-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg=="],
+
+    "quickjs-emscripten-core": ["quickjs-emscripten-core@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg=="],
+
+    "re2js": ["re2js@1.4.0", "", {}, "sha512-KTOIcZTSOpOxbu3i0+T6mFQ6tkxXKlTxfcMFs1trQbsMnG84qNq+DjXr8Afu+FEFjvF1NNlldpC7roPyazFI8g=="],
+
+    "seek-bzip": ["seek-bzip@2.0.0", "", { "dependencies": { "commander": "^6.0.0" }, "bin": { "seek-bunzip": "bin/seek-bunzip", "seek-table": "bin/seek-bzip-table" } }, "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg=="],
+
+    "seek-bzip/commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
+
+    "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
+
+    "just-bash/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
+    "sql.js": ["sql.js@1.14.2", "", {}, "sha512-3ZGPovObMFrdw79zrUHbfdE/DLIsy8jdNdssmMSQuRAymedU6q84asPt0kgiqrdMYlPegDItiIMfmIXzZnYFcw=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "just-bash/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "@mongodb-js/zstd": ["@mongodb-js/zstd@7.0.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "prebuild-install": "^7.1.3" } }, "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA=="],
+
+    "node-addon-api": ["node-addon-api@8.9.2", "", {}, "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg=="],
+
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
+    "prebuild-install/node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
+    "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "prebuild-install/tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
+
+    "prebuild-install/tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
+    "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
+    "prebuild-install/tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "tunnel-agent/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "node-liblzma": ["node-liblzma@2.2.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "node-gyp-build": "^4.8.4" }, "bin": { "nxz": "lib/cli/nxz.js" } }, "sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
   }
 }

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -26,6 +26,13 @@ applications that import `ComputerWorkspace`, `ComputerArtifacts`, or
 bun add "@cloudflare/computer@^0.2.0"
 ```
 
+Workspace Git operations additionally require `@platformatic/vfs`,
+`@cloudflare/computer/git`'s own optional peer:
+
+```bash
+bun add "@platformatic/vfs@^0.4.0"
+```
+
 ## Goal
 
 Cloudflare APIs return promises and expose platform-specific bindings. `effect-cf` wraps those boundaries as `Context`, `Layer`, and `Effect` values so application code stays inside one managed Effect runtime.

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -18,6 +18,14 @@ pnpm add effect-cf "effect@^4.0.0-beta.105"
 npm install effect-cf "effect@^4.0.0-beta.105"
 ```
 
+The Computer workspace integration is an optional peer. Install it only in
+applications that import `ComputerWorkspace`, `ComputerArtifacts`, or
+`effect-cf/computer-workspace-host`:
+
+```bash
+bun add "@cloudflare/computer@^0.2.0"
+```
+
 ## Goal
 
 Cloudflare APIs return promises and expose platform-specific bindings. `effect-cf` wraps those boundaries as `Context`, `Layer`, and `Effect` values so application code stays inside one managed Effect runtime.
@@ -36,6 +44,9 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `D1` - typed D1 database binding helper with an `@effect/sql-d1` backed SQL layer
 - `R2` - typed R2 bucket binding helper with Effect-wrapped object and multipart operations
 - `Artifacts` - typed Cloudflare Artifacts namespace and repository helpers, including repository lifecycle, tokens, and Git object reads
+- `ComputerWorkspace` - scoped Effect wrappers for the complete Cloudflare Computer filesystem, Git, runtime, Assets, Artifacts, and Think-compatible client surfaces
+- `ComputerArtifacts` - session-isolated Artifacts repositories backed by `@cloudflare/computer/artifacts`
+- `effect-cf/computer-workspace-host` - optional Durable Object host mixin, worker-shell backend wiring, and `WorkspaceServiceProxy`
 - `Hyperdrive` - typed Hyperdrive binding helper for connection strings and optional Postgres SQL integration
 - `Images` - typed Cloudflare Images binding helper with transformation APIs and optional hosted image operations
 - `Email` - typed Cloudflare Email Service binding helper for `send_email` bindings, with limit validation and typed error codes
@@ -444,6 +455,122 @@ export const createWorkspace = Effect.gen(function* () {
 ```
 
 `create`, `import`, and `fork` return an initial plaintext token. Treat returned tokens as secrets and avoid logging or persisting them unnecessarily.
+
+## Computer Workspace Example
+
+`ComputerWorkspace` exposes the complete `@cloudflare/computer`
+`WorkspaceClient` as Effects. The workspace client and every runtime execution
+handle are owned by an Effect `Scope`, so RPC stubs are disposed when their
+scope closes. The host mixin is a separate optional-dependency entrypoint:
+
+```ts
+import shellCurl from "@cloudflare/computer/shell/curl";
+import { Effect, Schema as S } from "effect";
+import { ComputerWorkspace, DurableObjectDefinition } from "effect-cf";
+import { withComputerWorkspace, WorkspaceServiceProxy } from "effect-cf/computer-workspace-host";
+
+export { WorkspaceServiceProxy };
+
+const ResearchWorkspace = DurableObjectDefinition.make("ResearchWorkspace", {
+  inspect: DurableObjectDefinition.method({ success: S.String }),
+});
+
+const ResearchWorkspaceLive = ResearchWorkspace.make(ComputerWorkspace.ComputerWorkspace.layer, {
+  rpc: {
+    inspect: () =>
+      Effect.gen(function* () {
+        const workspace = yield* ComputerWorkspace.ComputerWorkspace;
+
+        // Keep reads bounded when returning their contents over RPC.
+        const readme = yield* workspace.readFile("/repo/README.md", {
+          byteLength: 256 * 1024,
+        });
+        const commits = yield* workspace.git.log({ maxCount: 20 });
+        const run = yield* workspace.execCollect("git status --short", {
+          cwd: "/repo",
+          timeoutMillis: 30_000,
+        });
+
+        return `${commits.length}:${run.exitCode}:${readme.length}`;
+      }),
+  },
+});
+
+const HostedResearchWorkspace = withComputerWorkspace(ResearchWorkspaceLive, (_, state, env) => ({
+  storage: state.storage,
+  sessionId: state.id.toString(),
+  gitIdentity: { name: "Research Agent", email: "agent@example.test" },
+  artifacts: { binding: env.ARTIFACTS },
+  shell: {
+    loader: env.WORKER_LOADER,
+    hostBinding: "RESEARCH_WORKSPACE",
+    hostId: state.id.toString(),
+    executionContext: state,
+    commands: [shellCurl],
+    egress: { mode: "none" },
+  },
+}));
+
+export class ResearchWorkspaceDurableObject extends HostedResearchWorkspace {}
+```
+
+Serialize checkout mutations such as `clone`, `fetch`, and reset/checkout
+sequences with an Effect `Semaphore` when several RPC methods can update the
+same working tree concurrently. Reads can remain concurrent.
+
+The corresponding Wrangler configuration needs SQLite-backed Durable Object
+storage. Worker-shell execution additionally requires the `experimental` flag,
+a Worker Loader binding, the loopback namespace binding named by `hostBinding`,
+and the exact `WorkspaceServiceProxy` export shown above:
+
+```jsonc
+{
+  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "worker_loaders": [{ "binding": "WORKER_LOADER" }],
+  "artifacts": [{ "binding": "ARTIFACTS", "namespace": "default" }],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "RESEARCH_WORKSPACE",
+        "class_name": "ResearchWorkspaceDurableObject",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["ResearchWorkspaceDurableObject"],
+    },
+  ],
+}
+```
+
+Omit `shell` and the Worker Loader configuration when only the SQLite
+filesystem and Git client are needed. Supplying `artifacts` also installs the
+session-scoped client at `workspace.artifacts` and makes the in-shell
+`artifacts` command use the same upstream repository-prefixing convention.
+
+Workers can use that session isolation without a Durable Object or workspace:
+
+```ts
+import { Effect } from "effect";
+import { Artifacts, ComputerArtifacts } from "effect-cf";
+
+export const createSessionRepo = (binding: Artifacts.ArtifactsBinding, sessionId: string) =>
+  Effect.gen(function* () {
+    const artifacts = yield* ComputerArtifacts.makeClient(binding, sessionId);
+    const created = yield* artifacts.create("build-cache", {
+      description: "CI artifacts",
+    });
+    const token = yield* artifacts.createToken("build-cache", "read", 3600);
+
+    return { remote: created.remote, token: token.plaintext };
+  });
+```
+
+Repository prefixing, list filtering, and the argv API are delegated directly
+to `@cloudflare/computer/artifacts`, keeping this API and the in-shell command
+in agreement.
 
 ## Hyperdrive Example
 

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -59,6 +59,7 @@
     "@effect/sql-pg": "catalog:",
     "@effect/sql-sqlite-do": "catalog:",
     "@effect/vitest": "catalog:",
+    "@platformatic/vfs": "^0.4.0",
     "effect": "catalog:",
     "vite-plus": "catalog:",
     "vitest": "catalog:"

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/HyperdrivePg.mjs",
       "default": "./dist/HyperdrivePg.mjs"
     },
+    "./computer-workspace-host": {
+      "types": "./dist/ComputerWorkspaceHost.d.mts",
+      "import": "./dist/ComputerWorkspaceHost.mjs",
+      "default": "./dist/ComputerWorkspaceHost.mjs"
+    },
     "./vitest": {
       "types": "./dist/Vitest.d.mts",
       "import": "./dist/Vitest.mjs",
@@ -45,6 +50,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@cloudflare/computer": "0.2.0",
     "@cloudflare/containers": "catalog:",
     "@cloudflare/vitest-pool-workers": "catalog:",
     "@cloudflare/workers-types": "catalog:",
@@ -58,6 +64,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
+    "@cloudflare/computer": "^0.2.0",
     "@cloudflare/vitest-pool-workers": "^0.21.3",
     "@cloudflare/workers-types": "^4.20260611.1",
     "@effect/sql-d1": "^4.0.0-beta.107 <4.0.0-rc.0",
@@ -66,6 +73,9 @@
     "effect": "^4.0.0-beta.107 <4.0.0-rc.0"
   },
   "peerDependenciesMeta": {
+    "@cloudflare/computer": {
+      "optional": true
+    },
     "@cloudflare/vitest-pool-workers": {
       "optional": true
     },

--- a/packages/effect-cf/src/Artifacts.ts
+++ b/packages/effect-cf/src/Artifacts.ts
@@ -1,4 +1,5 @@
 import type {
+  ArtifactsCreateRepoResult as CloudflareArtifactsCreateRepoResult,
   ArtifactsCreateTokenResult as CloudflareArtifactsCreateTokenResult,
   ArtifactsErrorCode as CloudflareArtifactsErrorCode,
   ArtifactsRepoInfo as CloudflareArtifactsRepoInfo,
@@ -19,6 +20,7 @@ const expectedArtifactsRepo =
 
 /** Artifacts operation represented by {@link ArtifactsOperationError}. */
 export type ArtifactsOperation =
+  | "createClient"
   | "create"
   | "get"
   | "import"
@@ -26,11 +28,13 @@ export type ArtifactsOperation =
   | "delete"
   | "createToken"
   | "listTokens"
+  | "getToken"
   | "revokeToken"
   | "fork"
   | "log"
   | "readCommit"
-  | "readTree";
+  | "readTree"
+  | "cli";
 
 /** Documented string error codes returned by Cloudflare Artifacts. */
 export const artifactsErrorCodes = [
@@ -109,15 +113,7 @@ export type ArtifactsRepoStatus = "ready" | "importing" | "forking";
 export type ArtifactsRepoInfo = CloudflareArtifactsRepoInfo;
 
 /** Result of creating, importing, or forking a repository. */
-export interface ArtifactsCreateRepoResult {
-  readonly id: string;
-  readonly name: RepoName;
-  readonly description: string | null;
-  readonly defaultBranch: string;
-  readonly remote: string;
-  /** Initial plaintext Git token. The token itself encodes its expiry. */
-  readonly token: string;
-}
+export type ArtifactsCreateRepoResult = Readonly<CloudflareArtifactsCreateRepoResult>;
 
 /** Repository metadata returned by `list()`. */
 export interface ArtifactsRepoListEntry extends ArtifactsRepoInfo {

--- a/packages/effect-cf/src/ComputerArtifacts.ts
+++ b/packages/effect-cf/src/ComputerArtifacts.ts
@@ -1,0 +1,255 @@
+import type {
+  ArtifactClient as CloudflareComputerArtifactClient,
+  ArtifactImportOptions as CloudflareComputerArtifactImportOptions,
+  ArtifactImportSource as CloudflareComputerArtifactImportSource,
+  ArtifactRepoSummary as CloudflareComputerArtifactRepoSummary,
+  ArtifactScope as CloudflareComputerArtifactScope,
+  ArtifactsCLIInput as CloudflareComputerArtifactsCliInput,
+  ArtifactsCLIResult as CloudflareComputerArtifactsCliResult,
+  RemoteAddFn as CloudflareComputerRemoteAdd,
+} from "@cloudflare/computer/artifacts";
+import { Effect } from "effect";
+
+import * as Artifacts from "./Artifacts";
+
+/** External Git source accepted by a session-scoped repository import. */
+export type ComputerArtifactImportSource = Readonly<CloudflareComputerArtifactImportSource>;
+
+/** Target options accepted by a session-scoped repository import. */
+export type ComputerArtifactImportOptions = Readonly<CloudflareComputerArtifactImportOptions>;
+
+/** Repository metadata returned by a session-scoped list operation. */
+export type ComputerArtifactRepoSummary = Readonly<CloudflareComputerArtifactRepoSummary>;
+
+/** Token scope accepted by the upstream session facade. */
+export type ComputerArtifactScope = CloudflareComputerArtifactScope;
+
+/** Optional Git remote-registration seam accepted by the argv API. */
+export type ComputerArtifactsRemoteAdd = CloudflareComputerRemoteAdd;
+
+/** Input to the session-scoped `artifacts` argv API. */
+export type ComputerArtifactsCliInput = CloudflareComputerArtifactsCliInput;
+
+/** Result from the session-scoped `artifacts` argv API. */
+export type ComputerArtifactsCliResult = Readonly<CloudflareComputerArtifactsCliResult>;
+
+/** Options used when wrapping a session-scoped Artifacts client. */
+export interface ComputerArtifactsClientOptions {
+  /** Binding name attached to errors and tracing spans. Defaults to `ARTIFACTS`. */
+  readonly binding?: string;
+}
+
+/**
+ * Effect-native facade over `@cloudflare/computer/artifacts`.
+ *
+ * Repository names are local to {@link sessionId}. Prefixing and filtering are
+ * intentionally delegated to the upstream `createArtifact` implementation so
+ * this client and the worker-shell `artifacts` command always use the same
+ * namespace convention.
+ */
+export interface ComputerArtifactsClient {
+  readonly sessionId: string;
+  readonly create: (
+    name: Artifacts.RepoName,
+    options?: Artifacts.ArtifactsCreateOptions,
+  ) => Effect.Effect<Artifacts.ArtifactsCreateRepoResult, Artifacts.ArtifactsOperationError>;
+  readonly get: (
+    name: Artifacts.RepoName,
+  ) => Effect.Effect<Artifacts.ArtifactsRepoInfo, Artifacts.ArtifactsOperationError>;
+  readonly list: Effect.Effect<
+    ReadonlyArray<ComputerArtifactRepoSummary>,
+    Artifacts.ArtifactsOperationError
+  >;
+  readonly import: (
+    name: Artifacts.RepoName,
+    source: ComputerArtifactImportSource,
+    options?: ComputerArtifactImportOptions,
+  ) => Effect.Effect<Artifacts.ArtifactsCreateRepoResult, Artifacts.ArtifactsOperationError>;
+  readonly delete: (
+    name: Artifacts.RepoName,
+  ) => Effect.Effect<boolean, Artifacts.ArtifactsOperationError>;
+  readonly createToken: (
+    name: Artifacts.RepoName,
+    scope?: ComputerArtifactScope,
+    ttl?: number,
+  ) => Effect.Effect<Artifacts.ArtifactsCreateTokenResult, Artifacts.ArtifactsOperationError>;
+  readonly listTokens: (
+    name: Artifacts.RepoName,
+  ) => Effect.Effect<Artifacts.ArtifactsTokenListResult, Artifacts.ArtifactsOperationError>;
+  readonly getToken: (
+    name: Artifacts.RepoName,
+    id: string,
+  ) => Effect.Effect<Artifacts.ArtifactsTokenInfo, Artifacts.ArtifactsOperationError>;
+  readonly revokeToken: (
+    name: Artifacts.RepoName,
+    tokenOrId: string,
+  ) => Effect.Effect<boolean, Artifacts.ArtifactsOperationError>;
+  readonly cli: (
+    input: ComputerArtifactsCliInput,
+  ) => Effect.Effect<ComputerArtifactsCliResult, Artifacts.ArtifactsOperationError>;
+  readonly rawUnsafe: Effect.Effect<CloudflareComputerArtifactClient>;
+}
+
+const artifactsErrorDetails = (
+  cause: unknown,
+): Pick<Artifacts.ArtifactsOperationError, "code" | "numericCode"> => {
+  if (typeof cause !== "object" || cause === null) {
+    return {};
+  }
+
+  const code = Reflect.get(cause, "code");
+  const numericCode = Reflect.get(cause, "numericCode");
+
+  return {
+    ...(typeof code === "string" ? { code } : {}),
+    ...(typeof numericCode === "number" ? { numericCode } : {}),
+  };
+};
+
+const operationError = (binding: string, operation: Artifacts.ArtifactsOperation, cause: unknown) =>
+  new Artifacts.ArtifactsOperationError({
+    binding,
+    operation,
+    cause,
+    ...artifactsErrorDetails(cause),
+  });
+
+const tryOperation = <A>(
+  binding: string,
+  operation: Artifacts.ArtifactsOperation,
+  evaluate: () => Promise<A>,
+) =>
+  Effect.tryPromise({
+    try: evaluate,
+    catch: (cause) => operationError(binding, operation, cause),
+  });
+
+const spanOptions = (
+  binding: string,
+  sessionId: string,
+  operation: Artifacts.ArtifactsOperation,
+) => ({ attributes: { binding, sessionId, operation } });
+
+/** Wraps an already-created upstream session client. */
+export const fromClient = (
+  client: CloudflareComputerArtifactClient,
+  options: ComputerArtifactsClientOptions = {},
+): ComputerArtifactsClient => {
+  const binding = options.binding ?? "ARTIFACTS";
+  const { sessionId } = client;
+
+  return {
+    sessionId,
+    create: Effect.fn(
+      "ComputerArtifacts.create",
+      spanOptions(binding, sessionId, "create"),
+    )(function* (name: Artifacts.RepoName, createOptions?: Artifacts.ArtifactsCreateOptions) {
+      yield* Effect.annotateCurrentSpan("repo", name);
+
+      return yield* tryOperation(binding, "create", () => client.create(name, createOptions));
+    }),
+    get: Effect.fn(
+      "ComputerArtifacts.get",
+      spanOptions(binding, sessionId, "get"),
+    )(function* (name: Artifacts.RepoName) {
+      yield* Effect.annotateCurrentSpan("repo", name);
+
+      return yield* tryOperation(binding, "get", () => client.get(name));
+    }),
+    list: tryOperation(binding, "list", () => client.list()).pipe(
+      Effect.withSpan("ComputerArtifacts.list", spanOptions(binding, sessionId, "list")),
+    ),
+    import: Effect.fn(
+      "ComputerArtifacts.import",
+      spanOptions(binding, sessionId, "import"),
+    )(function* (
+      name: Artifacts.RepoName,
+      source: ComputerArtifactImportSource,
+      importOptions?: ComputerArtifactImportOptions,
+    ) {
+      yield* Effect.annotateCurrentSpan("repo", name);
+
+      return yield* tryOperation(binding, "import", () =>
+        client.import(name, source, importOptions),
+      );
+    }),
+    delete: Effect.fn(
+      "ComputerArtifacts.delete",
+      spanOptions(binding, sessionId, "delete"),
+    )(function* (name: Artifacts.RepoName) {
+      yield* Effect.annotateCurrentSpan("repo", name);
+
+      return yield* tryOperation(binding, "delete", () => client.delete(name));
+    }),
+    createToken: Effect.fn(
+      "ComputerArtifacts.createToken",
+      spanOptions(binding, sessionId, "createToken"),
+    )(function* (name: Artifacts.RepoName, scope?: ComputerArtifactScope, ttl?: number) {
+      yield* Effect.annotateCurrentSpan("repo", name);
+
+      return yield* tryOperation(binding, "createToken", () =>
+        client.createToken(name, scope, ttl),
+      );
+    }),
+    listTokens: Effect.fn(
+      "ComputerArtifacts.listTokens",
+      spanOptions(binding, sessionId, "listTokens"),
+    )(function* (name: Artifacts.RepoName) {
+      yield* Effect.annotateCurrentSpan("repo", name);
+
+      return yield* tryOperation(binding, "listTokens", () => client.listTokens(name));
+    }),
+    getToken: Effect.fn(
+      "ComputerArtifacts.getToken",
+      spanOptions(binding, sessionId, "getToken"),
+    )(function* (name: Artifacts.RepoName, id: string) {
+      yield* Effect.annotateCurrentSpan({ repo: name, tokenId: id });
+
+      return yield* tryOperation(binding, "getToken", () => client.getToken(name, id));
+    }),
+    revokeToken: Effect.fn(
+      "ComputerArtifacts.revokeToken",
+      spanOptions(binding, sessionId, "revokeToken"),
+    )(function* (name: Artifacts.RepoName, tokenOrId: string) {
+      yield* Effect.annotateCurrentSpan("repo", name);
+
+      return yield* tryOperation(binding, "revokeToken", () => client.revokeToken(name, tokenOrId));
+    }),
+    cli: Effect.fn(
+      "ComputerArtifacts.cli",
+      spanOptions(binding, sessionId, "cli"),
+    )(function* (input: ComputerArtifactsCliInput) {
+      yield* Effect.annotateCurrentSpan("argv", input.argv.join(" "));
+
+      return yield* tryOperation(binding, "cli", () => client.cli(input));
+    }),
+    rawUnsafe: Effect.succeed(client),
+  };
+};
+
+/**
+ * Creates an Effect-native session client directly from a Worker Artifacts
+ * binding. `@cloudflare/computer` is loaded only when this Effect runs, keeping
+ * the optional peer out of applications that do not use this integration.
+ */
+export const makeClient = Effect.fn("ComputerArtifacts.makeClient")(function* (
+  bindingValue: Artifacts.ArtifactsBinding,
+  sessionId: string,
+  options: ComputerArtifactsClientOptions = {},
+) {
+  const binding = options.binding ?? "ARTIFACTS";
+  const computerArtifacts = yield* Effect.tryPromise({
+    try: () => import("@cloudflare/computer/artifacts"),
+    catch: (cause) => operationError(binding, "createClient", cause),
+  });
+  const client = yield* Effect.try({
+    try: () =>
+      computerArtifacts.createArtifact(
+        bindingValue as unknown as Parameters<typeof computerArtifacts.createArtifact>[0],
+        sessionId,
+      ),
+    catch: (cause) => operationError(binding, "createClient", cause),
+  });
+
+  return fromClient(client, { binding });
+});

--- a/packages/effect-cf/src/ComputerWorkspace.ts
+++ b/packages/effect-cf/src/ComputerWorkspace.ts
@@ -1,0 +1,1098 @@
+import type {
+  ExecSyncResult as CloudflareExecSyncResult,
+  RuntimeExecOptions as CloudflareRuntimeExecOptions,
+  RuntimeGetOptions as CloudflareRuntimeGetOptions,
+  RuntimeKillOptions as CloudflareRuntimeKillOptions,
+  ShellValue as CloudflareShellValue,
+  SkippedEntry as CloudflareSkippedEntry,
+  ThinkWorkspaceCompatibility as CloudflareThinkWorkspaceCompatibility,
+  WorkspaceClient as CloudflareWorkspaceClient,
+  WorkspaceRuntimeEvent as CloudflareWorkspaceRuntimeEvent,
+  WorkspaceRuntimeExecHandle as CloudflareWorkspaceRuntimeExecHandle,
+  WorkspaceRuntimeResult as CloudflareWorkspaceRuntimeResult,
+  WorkspaceRuntimeValue as CloudflareWorkspaceRuntimeValue,
+} from "@cloudflare/computer";
+import type { ArtifactClient as CloudflareComputerArtifactClient } from "@cloudflare/computer/artifacts";
+import type {
+  AssetsClient as CloudflareComputerAssetsClient,
+  ShareOptions as CloudflareComputerShareOptions,
+} from "@cloudflare/computer/assets";
+import type {
+  CommitView as CloudflareCommitView,
+  GitClient as CloudflareGitClient,
+  GitCloneOptions as CloudflareGitCloneOptions,
+  GitCommitOptions as CloudflareGitCommitOptions,
+  GitDiffOptions as CloudflareGitDiffOptions,
+  GitFetchOptions as CloudflareGitFetchOptions,
+  GitLogOptions as CloudflareGitLogOptions,
+  GitUpdateRefOptions as CloudflareGitUpdateRefOptions,
+} from "@cloudflare/computer/git";
+import { Context, Effect, Layer, Schema, type Scope, Stream } from "effect";
+
+import * as ComputerArtifacts from "./ComputerArtifacts";
+import { DurableObjectState } from "./DurableObjectState";
+import * as HostRegistry from "./internal/ComputerWorkspaceHostRegistry";
+
+type CloudflareWorkspaceFilesystem = CloudflareWorkspaceClient["fs"];
+type CloudflareReadFileOptions = Parameters<CloudflareWorkspaceFilesystem["readFile"]>[1];
+type CloudflareReaddirOptions = Parameters<CloudflareWorkspaceFilesystem["readdir"]>[1];
+type CloudflareFindOptions = Parameters<CloudflareWorkspaceFilesystem["find"]>[2];
+type CloudflareGrepOptions = Parameters<CloudflareWorkspaceFilesystem["grep"]>[2];
+type CloudflareRmOptions = Parameters<CloudflareWorkspaceFilesystem["rm"]>[1];
+type CloudflareMkdirOptions = Parameters<CloudflareWorkspaceFilesystem["mkdir"]>[1];
+type CloudflareWriteFileContent = Parameters<CloudflareWorkspaceFilesystem["writeFile"]>[1];
+type CloudflareWriteFileOptions = Parameters<CloudflareWorkspaceFilesystem["writeFile"]>[2];
+type CloudflareWorkspaceDirentResult = Awaited<
+  ReturnType<CloudflareWorkspaceFilesystem["readdir"]>
+>[number];
+type CloudflareWorkspaceStatResult = Awaited<ReturnType<CloudflareWorkspaceFilesystem["stat"]>>;
+type CloudflareWorkspaceFoundEntry = Awaited<
+  ReturnType<CloudflareWorkspaceFilesystem["find"]>
+>[number];
+type CloudflareWorkspaceGrepMatch = Awaited<
+  ReturnType<CloudflareWorkspaceFilesystem["grep"]>
+>[number];
+
+/**
+ * Workspace errors use `Schema.TaggedError`, unlike most local binding errors,
+ * because workspace operations commonly sit behind Durable Object RPC methods.
+ * The schema form preserves the operation-family tags across that boundary.
+ */
+export class WorkspaceFsError extends Schema.TaggedError<WorkspaceFsError>()("WorkspaceFsError", {
+  operation: Schema.String,
+  path: Schema.String,
+  message: Schema.String,
+  code: Schema.optionalKey(Schema.String),
+  cause: Schema.optionalKey(Schema.Defect({ includeStack: true })),
+}) {}
+
+/** Schema-serializable error for a workspace Git operation. */
+export class WorkspaceGitError extends Schema.TaggedError<WorkspaceGitError>()(
+  "WorkspaceGitError",
+  {
+    operation: Schema.String,
+    message: Schema.String,
+    code: Schema.optionalKey(Schema.String),
+    cause: Schema.optionalKey(Schema.Defect({ includeStack: true })),
+  },
+) {}
+
+/** Schema-serializable error for a workspace runtime operation. */
+export class WorkspaceExecError extends Schema.TaggedError<WorkspaceExecError>()(
+  "WorkspaceExecError",
+  {
+    operation: Schema.String,
+    message: Schema.String,
+    code: Schema.optionalKey(Schema.String),
+    cause: Schema.optionalKey(Schema.Defect({ includeStack: true })),
+  },
+) {}
+
+/** Schema-serializable error for a workspace Assets operation. */
+export class WorkspaceAssetsError extends Schema.TaggedError<WorkspaceAssetsError>()(
+  "WorkspaceAssetsError",
+  {
+    operation: Schema.String,
+    path: Schema.String,
+    message: Schema.String,
+    code: Schema.optionalKey(Schema.String),
+    cause: Schema.optionalKey(Schema.Defect({ includeStack: true })),
+  },
+) {}
+
+export type WorkspaceReadFileOptions = Omit<CloudflareReadFileOptions, "encoding">;
+export type ReadTextFileOptions = WorkspaceReadFileOptions;
+export type ListDirectoryOptions = CloudflareReaddirOptions;
+export type WorkspaceDirectoryEntry = CloudflareWorkspaceDirentResult;
+export type WorkspaceEntryStat = CloudflareWorkspaceStatResult;
+export type WorkspaceFindOptions = CloudflareFindOptions;
+export type WorkspaceFoundEntry = CloudflareWorkspaceFoundEntry;
+export type WorkspaceGrepOptions = CloudflareGrepOptions;
+export type WorkspaceGrepMatch = CloudflareWorkspaceGrepMatch;
+export type RemovePathOptions = CloudflareRmOptions;
+export type WorkspaceMkdirOptions = CloudflareMkdirOptions;
+export type WorkspaceWriteFileContent = CloudflareWriteFileContent;
+export type WorkspaceWriteFileOptions = CloudflareWriteFileOptions;
+
+/** Explicit read mode. Text remains the default for consumer-port compatibility. */
+export type WorkspaceReadEncoding = "utf8" | "stream";
+
+export interface WorkspaceReadFile {
+  (
+    path: string,
+    options?: WorkspaceReadFileOptions & { readonly encoding?: "utf8" },
+  ): Effect.Effect<string, WorkspaceFsError>;
+  (
+    path: string,
+    options: WorkspaceReadFileOptions & { readonly encoding: "stream" },
+  ): Effect.Effect<ReadableStream<Uint8Array>, WorkspaceFsError>;
+}
+
+/** Complete Effect wrapper of `WorkspaceClient.fs`. */
+export interface ComputerWorkspaceFilesystem {
+  readonly readFile: WorkspaceReadFile;
+  readonly stat: (path: string) => Effect.Effect<WorkspaceEntryStat, WorkspaceFsError>;
+  readonly lstat: (path: string) => Effect.Effect<WorkspaceEntryStat, WorkspaceFsError>;
+  readonly exists: (path: string) => Effect.Effect<boolean, WorkspaceFsError>;
+  readonly readlink: (path: string) => Effect.Effect<string, WorkspaceFsError>;
+  readonly readdir: (
+    path: string,
+    options?: ListDirectoryOptions,
+  ) => Effect.Effect<ReadonlyArray<WorkspaceDirectoryEntry>, WorkspaceFsError>;
+  readonly find: (
+    directory: string,
+    pattern?: string,
+    options?: WorkspaceFindOptions,
+  ) => Effect.Effect<ReadonlyArray<WorkspaceFoundEntry>, WorkspaceFsError>;
+  readonly ls: (prefix: string) => Effect.Effect<ReadonlyArray<string>, WorkspaceFsError>;
+  readonly grep: (
+    pattern: string,
+    path: string,
+    options?: WorkspaceGrepOptions,
+  ) => Effect.Effect<ReadonlyArray<WorkspaceGrepMatch>, WorkspaceFsError>;
+  readonly writeFile: (
+    path: string,
+    content: WorkspaceWriteFileContent,
+    options?: WorkspaceWriteFileOptions,
+  ) => Effect.Effect<void, WorkspaceFsError>;
+  readonly mkdir: (
+    path: string,
+    options?: WorkspaceMkdirOptions,
+  ) => Effect.Effect<void, WorkspaceFsError>;
+  readonly rm: (path: string, options?: RemovePathOptions) => Effect.Effect<void, WorkspaceFsError>;
+  readonly chmod: (path: string, mode: number) => Effect.Effect<void, WorkspaceFsError>;
+  readonly symlink: (target: string, path: string) => Effect.Effect<void, WorkspaceFsError>;
+}
+
+export type WorkspaceGitCloneOptions = CloudflareGitCloneOptions;
+export type WorkspaceGitFetchOptions = CloudflareGitFetchOptions;
+export type WorkspaceGitFetchResult = Awaited<ReturnType<CloudflareGitClient["fetch"]>>;
+export type WorkspaceGitCheckoutOptions = Parameters<CloudflareGitClient["checkout"]>[0];
+export type WorkspaceGitUpdateRefOptions = CloudflareGitUpdateRefOptions;
+export type WorkspaceGitDiffOptions = CloudflareGitDiffOptions;
+export type WorkspaceGitCommitOptions = CloudflareGitCommitOptions;
+
+export interface WorkspaceGitLogOptions extends Omit<CloudflareGitLogOptions, "depth"> {
+  /** Preferred upstream name for the history bound. */
+  readonly depth?: number;
+  /** Consumer-port compatibility alias for `depth`. */
+  readonly maxCount?: number;
+}
+
+export type WorkspaceGitPerson = CloudflareCommitView["author"] & {
+  /** Consumer-port compatibility alias for `timestamp`. */
+  readonly timestampSeconds: number;
+};
+
+export interface WorkspaceGitCommit {
+  readonly oid: string;
+  readonly message: string;
+  readonly tree: string;
+  readonly parent: ReadonlyArray<string>;
+  /** Consumer-port compatibility alias for `parent`. */
+  readonly parents: ReadonlyArray<string>;
+  readonly author: WorkspaceGitPerson;
+  readonly committer: WorkspaceGitPerson;
+}
+
+type EffectGitMethod<Method> = Method extends (...args: infer Args) => Promise<infer Success>
+  ? (...args: Args) => Effect.Effect<Success, WorkspaceGitError>
+  : never;
+
+type EffectGitClient = {
+  readonly [Name in keyof CloudflareGitClient]: EffectGitMethod<CloudflareGitClient[Name]>;
+};
+
+/** Complete Effect wrapper of the `@cloudflare/computer/git` client. */
+export type ComputerWorkspaceGit = Omit<EffectGitClient, "log" | "revParse"> & {
+  readonly log: (
+    options?: WorkspaceGitLogOptions,
+  ) => Effect.Effect<ReadonlyArray<WorkspaceGitCommit>, WorkspaceGitError>;
+  readonly revParse: {
+    (ref: string): Effect.Effect<string, WorkspaceGitError>;
+    (
+      options: Parameters<CloudflareGitClient["revParse"]>[0],
+    ): Effect.Effect<string, WorkspaceGitError>;
+  };
+};
+
+export type WorkspaceExecSignal = NonNullable<CloudflareRuntimeKillOptions["signal"]>;
+export type WorkspaceRuntimeValue = CloudflareWorkspaceRuntimeValue;
+export type WorkspaceExecEncoding = "utf8" | "binary";
+export type WorkspaceExecSyncResult = CloudflareExecSyncResult;
+export type WorkspaceExecSkippedEntry = CloudflareSkippedEntry;
+
+type CloudflareEncoding<Encoding extends WorkspaceExecEncoding> = Encoding extends "utf8"
+  ? "utf8"
+  : undefined;
+
+export type WorkspaceExecChunk<Encoding extends WorkspaceExecEncoding> = Encoding extends "utf8"
+  ? string
+  : Uint8Array;
+
+export type WorkspaceExecOptions<Encoding extends WorkspaceExecEncoding = "utf8"> = Omit<
+  CloudflareRuntimeExecOptions,
+  "encoding" | "timeoutMs"
+> & {
+  readonly encoding?: Encoding;
+  /** Upstream runtime option name. */
+  readonly timeoutMs?: number;
+  /** Consumer-port compatibility alias for `timeoutMs`. */
+  readonly timeoutMillis?: number;
+};
+
+export type WorkspaceGetExecOptions<Encoding extends WorkspaceExecEncoding = "utf8"> = Omit<
+  CloudflareRuntimeGetOptions,
+  "encoding"
+> & {
+  readonly encoding?: Encoding;
+};
+
+export type WorkspaceExecEvent<Encoding extends WorkspaceExecEncoding = "utf8"> =
+  | ({
+      readonly _tag: "Stdout";
+      readonly id: string;
+      readonly sequence: number;
+      readonly chunk: WorkspaceExecChunk<Encoding>;
+    } & (Encoding extends "utf8" ? { readonly text: string } : { readonly bytes: Uint8Array }))
+  | ({
+      readonly _tag: "Stderr";
+      readonly id: string;
+      readonly sequence: number;
+      readonly chunk: WorkspaceExecChunk<Encoding>;
+    } & (Encoding extends "utf8" ? { readonly text: string } : { readonly bytes: Uint8Array }))
+  | {
+      readonly _tag: "Exit";
+      readonly id: string;
+      readonly sequence: number;
+      readonly exitCode: number;
+      readonly value?: WorkspaceRuntimeValue;
+    };
+
+export interface WorkspaceExecResult<Encoding extends WorkspaceExecEncoding = "utf8"> {
+  readonly status: CloudflareWorkspaceRuntimeResult<CloudflareEncoding<Encoding>>["status"];
+  readonly exitCode: number;
+  readonly stdout: WorkspaceExecChunk<Encoding>;
+  readonly stderr: WorkspaceExecChunk<Encoding>;
+  readonly value?: WorkspaceRuntimeValue;
+  readonly pushed: number;
+  readonly pulled: number;
+  readonly skipped: ReadonlyArray<WorkspaceExecSkippedEntry>;
+  readonly sync: WorkspaceExecSyncResult;
+}
+
+export interface WorkspaceExecRun<Encoding extends WorkspaceExecEncoding = "utf8"> {
+  readonly id: string;
+  readonly backend: string;
+  /**
+   * Live output. Like the upstream handle, `events` and `result` are mutually
+   * exclusive consumers of a run.
+   */
+  readonly events: Stream.Stream<WorkspaceExecEvent<Encoding>, WorkspaceExecError>;
+  readonly result: Effect.Effect<WorkspaceExecResult<Encoding>, WorkspaceExecError>;
+  readonly kill: (signal?: WorkspaceExecSignal) => Effect.Effect<void, WorkspaceExecError>;
+}
+
+export interface WorkspaceExec {
+  (
+    strings: TemplateStringsArray,
+    ...values: Array<CloudflareShellValue>
+  ): Effect.Effect<WorkspaceExecRun<"utf8">, WorkspaceExecError, Scope.Scope>;
+  (
+    command: string,
+    options?: WorkspaceExecOptions<"utf8">,
+  ): Effect.Effect<WorkspaceExecRun<"utf8">, WorkspaceExecError, Scope.Scope>;
+  (
+    command: string,
+    options: WorkspaceExecOptions<"binary">,
+  ): Effect.Effect<WorkspaceExecRun<"binary">, WorkspaceExecError, Scope.Scope>;
+}
+
+export interface WorkspaceGetExec {
+  (
+    id: string,
+    options?: WorkspaceGetExecOptions<"utf8">,
+  ): Effect.Effect<WorkspaceExecRun<"utf8">, WorkspaceExecError, Scope.Scope>;
+  (
+    id: string,
+    options: WorkspaceGetExecOptions<"binary">,
+  ): Effect.Effect<WorkspaceExecRun<"binary">, WorkspaceExecError, Scope.Scope>;
+}
+
+export interface WorkspaceExecCollect {
+  (
+    strings: TemplateStringsArray,
+    ...values: Array<CloudflareShellValue>
+  ): Effect.Effect<WorkspaceExecResult<"utf8">, WorkspaceExecError>;
+  (
+    command: string,
+    options?: WorkspaceExecOptions<"utf8">,
+  ): Effect.Effect<WorkspaceExecResult<"utf8">, WorkspaceExecError>;
+  (
+    command: string,
+    options: WorkspaceExecOptions<"binary">,
+  ): Effect.Effect<WorkspaceExecResult<"binary">, WorkspaceExecError>;
+}
+
+/** Complete Effect wrapper of `WorkspaceClient.runtime`. */
+export interface ComputerWorkspaceRuntime {
+  readonly exec: WorkspaceExec;
+  readonly execCollect: WorkspaceExecCollect;
+  readonly getExec: WorkspaceGetExec;
+  readonly killExec: (
+    id: string,
+    options?: CloudflareRuntimeKillOptions,
+  ) => Effect.Effect<void, WorkspaceExecError>;
+  readonly disposeExec: (
+    id: string,
+    options?: { readonly backend?: string },
+  ) => Effect.Effect<void, WorkspaceExecError>;
+}
+
+/** Effect wrapper over a configured local `Workspace.assets` client. */
+export interface ComputerWorkspaceAssets {
+  readonly share: (
+    path: string,
+    options: CloudflareComputerShareOptions,
+  ) => Effect.Effect<string, WorkspaceAssetsError>;
+}
+
+type EffectThinkMethod<Method> = Method extends (...args: infer Args) => Promise<infer Success>
+  ? (...args: Args) => Effect.Effect<Success, WorkspaceFsError>
+  : never;
+
+/** Effect wrapper of the optional Think compatibility surface. */
+export type ComputerWorkspaceThink = {
+  readonly [Name in keyof CloudflareThinkWorkspaceCompatibility]: EffectThinkMethod<
+    CloudflareThinkWorkspaceCompatibility[Name]
+  >;
+};
+
+/** Effect service over every client surface exposed by Cloudflare Computer. */
+export interface ComputerWorkspaceShape {
+  readonly fs: ComputerWorkspaceFilesystem;
+  readonly git: ComputerWorkspaceGit;
+  readonly runtime: ComputerWorkspaceRuntime;
+  readonly artifacts: ComputerArtifacts.ComputerArtifactsClient;
+  readonly assets: ComputerWorkspaceAssets | undefined;
+  readonly think: ComputerWorkspaceThink | undefined;
+
+  /** Flat filesystem aliases retained for mechanical consumer migration. */
+  readonly readFile: WorkspaceReadFile;
+  readonly stat: ComputerWorkspaceFilesystem["stat"];
+  readonly lstat: ComputerWorkspaceFilesystem["lstat"];
+  readonly exists: ComputerWorkspaceFilesystem["exists"];
+  readonly readlink: ComputerWorkspaceFilesystem["readlink"];
+  readonly readdir: ComputerWorkspaceFilesystem["readdir"];
+  readonly listDirectory: ComputerWorkspaceFilesystem["readdir"];
+  readonly find: ComputerWorkspaceFilesystem["find"];
+  readonly ls: ComputerWorkspaceFilesystem["ls"];
+  readonly grep: ComputerWorkspaceFilesystem["grep"];
+  readonly writeFile: ComputerWorkspaceFilesystem["writeFile"];
+  readonly mkdir: ComputerWorkspaceFilesystem["mkdir"];
+  readonly rm: ComputerWorkspaceFilesystem["rm"];
+  readonly removePath: ComputerWorkspaceFilesystem["rm"];
+  readonly chmod: ComputerWorkspaceFilesystem["chmod"];
+  readonly symlink: ComputerWorkspaceFilesystem["symlink"];
+
+  /** Flat runtime aliases retained for mechanical consumer migration. */
+  readonly exec: WorkspaceExec;
+  readonly execCollect: WorkspaceExecCollect;
+  readonly getExec: WorkspaceGetExec;
+  readonly killExec: ComputerWorkspaceRuntime["killExec"];
+  readonly disposeExec: ComputerWorkspaceRuntime["disposeExec"];
+}
+
+const errorMessage = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause);
+
+const errorCode = (cause: unknown): string | undefined => {
+  if (typeof cause !== "object" || cause === null) {
+    return undefined;
+  }
+
+  const code = Reflect.get(cause, "code");
+
+  return typeof code === "string" ? code : undefined;
+};
+
+const fsError = (operation: string, path: string, cause: unknown) =>
+  WorkspaceFsError.make({
+    operation,
+    path,
+    message: errorMessage(cause),
+    cause,
+    ...(errorCode(cause) === undefined ? {} : { code: errorCode(cause) }),
+  });
+
+const gitError = (operation: string, cause: unknown) =>
+  WorkspaceGitError.make({
+    operation,
+    message: errorMessage(cause),
+    cause,
+    ...(errorCode(cause) === undefined ? {} : { code: errorCode(cause) }),
+  });
+
+const execError = (operation: string, cause: unknown) =>
+  WorkspaceExecError.make({
+    operation,
+    message: errorMessage(cause),
+    cause,
+    ...(errorCode(cause) === undefined ? {} : { code: errorCode(cause) }),
+  });
+
+const assetsError = (operation: string, path: string, cause: unknown) =>
+  WorkspaceAssetsError.make({
+    operation,
+    path,
+    message: errorMessage(cause),
+    cause,
+    ...(errorCode(cause) === undefined ? {} : { code: errorCode(cause) }),
+  });
+
+const tryFs = <A>(operation: string, path: string, evaluate: () => Promise<A>) =>
+  Effect.tryPromise({
+    try: evaluate,
+    catch: (cause) => fsError(operation, path, cause),
+  });
+
+const isNotFound = (error: WorkspaceFsError): boolean =>
+  error.code === "ENOENT" || /ENOENT|no such/i.test(error.message);
+
+const makeFilesystem = (fsClient: CloudflareWorkspaceFilesystem): ComputerWorkspaceFilesystem => {
+  const readFileImplementation = Effect.fn("ComputerWorkspace.fs.readFile", {
+    attributes: { family: "fs", operation: "readFile" },
+  })(function* (
+    path: string,
+    options: WorkspaceReadFileOptions & { readonly encoding?: WorkspaceReadEncoding } = {},
+  ) {
+    yield* Effect.annotateCurrentSpan("path", path);
+
+    const { encoding = "utf8", ...readOptions } = options;
+
+    if (encoding === "stream") {
+      return yield* tryFs("readFile", path, () => fsClient.readFile(path, readOptions));
+    }
+
+    return yield* tryFs("readFile", path, () =>
+      fsClient.readFile(path, { ...readOptions, encoding: "utf8" }),
+    );
+  });
+
+  const readFile = readFileImplementation as WorkspaceReadFile;
+
+  const stat = Effect.fn("ComputerWorkspace.fs.stat", {
+    attributes: { family: "fs", operation: "stat" },
+  })(function* (path: string) {
+    yield* Effect.annotateCurrentSpan("path", path);
+
+    return yield* tryFs("stat", path, () => fsClient.stat(path));
+  });
+
+  const lstat = Effect.fn("ComputerWorkspace.fs.lstat", {
+    attributes: { family: "fs", operation: "lstat" },
+  })(function* (path: string) {
+    yield* Effect.annotateCurrentSpan("path", path);
+
+    return yield* tryFs("lstat", path, () => fsClient.lstat(path));
+  });
+
+  const exists = Effect.fn("ComputerWorkspace.fs.exists", {
+    attributes: { family: "fs", operation: "exists" },
+  })(function* (path: string) {
+    yield* Effect.annotateCurrentSpan("path", path);
+
+    return yield* stat(path).pipe(
+      Effect.as(true),
+      Effect.catch((error) => (isNotFound(error) ? Effect.succeed(false) : Effect.fail(error))),
+    );
+  });
+
+  const readlink = Effect.fn("ComputerWorkspace.fs.readlink", {
+    attributes: { family: "fs", operation: "readlink" },
+  })(function* (path: string) {
+    yield* Effect.annotateCurrentSpan("path", path);
+
+    return yield* tryFs("readlink", path, () => fsClient.readlink(path));
+  });
+
+  const readdir = Effect.fn("ComputerWorkspace.fs.readdir", {
+    attributes: { family: "fs", operation: "readdir" },
+  })(function* (path: string, options?: ListDirectoryOptions) {
+    yield* Effect.annotateCurrentSpan("path", path);
+
+    return yield* tryFs("readdir", path, () => fsClient.readdir(path, options));
+  });
+
+  const find = Effect.fn("ComputerWorkspace.fs.find", {
+    attributes: { family: "fs", operation: "find" },
+  })(function* (directory: string, pattern?: string, options?: WorkspaceFindOptions) {
+    yield* Effect.annotateCurrentSpan({ path: directory, pattern });
+
+    return yield* tryFs("find", directory, () => fsClient.find(directory, pattern, options));
+  });
+
+  const ls = Effect.fn("ComputerWorkspace.fs.ls", {
+    attributes: { family: "fs", operation: "ls" },
+  })(function* (prefix: string) {
+    yield* Effect.annotateCurrentSpan("path", prefix);
+
+    return yield* tryFs("ls", prefix, () => fsClient.ls(prefix));
+  });
+
+  const grep = Effect.fn("ComputerWorkspace.fs.grep", {
+    attributes: { family: "fs", operation: "grep" },
+  })(function* (pattern: string, path: string, options?: WorkspaceGrepOptions) {
+    yield* Effect.annotateCurrentSpan({ path, pattern });
+
+    return yield* tryFs("grep", path, () => fsClient.grep(pattern, path, options));
+  });
+
+  const writeFile = Effect.fn("ComputerWorkspace.fs.writeFile", {
+    attributes: { family: "fs", operation: "writeFile" },
+  })(function* (
+    path: string,
+    content: WorkspaceWriteFileContent,
+    options?: WorkspaceWriteFileOptions,
+  ) {
+    yield* Effect.annotateCurrentSpan("path", path);
+    yield* tryFs("writeFile", path, () => fsClient.writeFile(path, content, options));
+  });
+
+  const mkdir = Effect.fn("ComputerWorkspace.fs.mkdir", {
+    attributes: { family: "fs", operation: "mkdir" },
+  })(function* (path: string, options?: WorkspaceMkdirOptions) {
+    yield* Effect.annotateCurrentSpan("path", path);
+    yield* tryFs("mkdir", path, () => fsClient.mkdir(path, options));
+  });
+
+  const rm = Effect.fn("ComputerWorkspace.fs.rm", {
+    attributes: { family: "fs", operation: "rm" },
+  })(function* (path: string, options?: RemovePathOptions) {
+    yield* Effect.annotateCurrentSpan("path", path);
+    yield* tryFs("rm", path, () => fsClient.rm(path, options));
+  });
+
+  const chmod = Effect.fn("ComputerWorkspace.fs.chmod", {
+    attributes: { family: "fs", operation: "chmod" },
+  })(function* (path: string, mode: number) {
+    yield* Effect.annotateCurrentSpan({ path, mode });
+    yield* tryFs("chmod", path, () => fsClient.chmod(path, mode));
+  });
+
+  const symlink = Effect.fn("ComputerWorkspace.fs.symlink", {
+    attributes: { family: "fs", operation: "symlink" },
+  })(function* (target: string, path: string) {
+    yield* Effect.annotateCurrentSpan({ path, target });
+    yield* tryFs("symlink", path, () => fsClient.symlink(target, path));
+  });
+
+  return {
+    readFile,
+    stat,
+    lstat,
+    exists,
+    readlink,
+    readdir,
+    find,
+    ls,
+    grep,
+    writeFile,
+    mkdir,
+    rm,
+    chmod,
+    symlink,
+  };
+};
+
+const gitPerson = (person: CloudflareCommitView["author"]): WorkspaceGitPerson => ({
+  ...person,
+  timestampSeconds: person.timestamp,
+});
+
+const gitCommit = (
+  commit: Awaited<ReturnType<CloudflareGitClient["show"]>>,
+): WorkspaceGitCommit => ({
+  oid: commit.oid,
+  message: commit.message,
+  tree: commit.tree,
+  parent: commit.parent,
+  parents: commit.parent,
+  author: gitPerson(commit.author),
+  committer: gitPerson(commit.committer),
+});
+
+const makeGit = (gitClient: CloudflareGitClient): ComputerWorkspaceGit => {
+  const method = <Args extends Array<unknown>, Success>(
+    operation: string,
+    evaluate: (...args: Args) => Promise<Success>,
+  ) =>
+    Effect.fn(`ComputerWorkspace.git.${operation}`, {
+      attributes: { family: "git", operation },
+    })(function* (...args: Args) {
+      return yield* Effect.tryPromise({
+        try: () => evaluate(...args),
+        catch: (cause) => gitError(operation, cause),
+      });
+    });
+
+  const log = Effect.fn("ComputerWorkspace.git.log", {
+    attributes: { family: "git", operation: "log" },
+  })(function* (options?: WorkspaceGitLogOptions) {
+    const { maxCount, ...upstreamOptions } = options ?? {};
+    const commits = yield* Effect.tryPromise({
+      try: () =>
+        gitClient.log({
+          ...upstreamOptions,
+          ...(upstreamOptions.depth === undefined && maxCount !== undefined
+            ? { depth: maxCount }
+            : {}),
+        }),
+      catch: (cause) => gitError("log", cause),
+    });
+
+    return commits.map(gitCommit);
+  });
+
+  const revParseImplementation = Effect.fn("ComputerWorkspace.git.revParse", {
+    attributes: { family: "git", operation: "revParse" },
+  })(function* (input: string | Parameters<CloudflareGitClient["revParse"]>[0]) {
+    const options = typeof input === "string" ? { ref: input } : input;
+
+    return yield* Effect.tryPromise({
+      try: () => gitClient.revParse(options),
+      catch: (cause) => gitError("revParse", cause),
+    });
+  });
+
+  const revParse = revParseImplementation as ComputerWorkspaceGit["revParse"];
+
+  return {
+    clone: method("clone", (options) => gitClient.clone(options as CloudflareGitCloneOptions)),
+    diff: method("diff", (options) => gitClient.diff(options as CloudflareGitDiffOptions)),
+    diffSummary: method("diffSummary", (options) =>
+      gitClient.diffSummary(options as CloudflareGitDiffOptions),
+    ),
+    init: method("init", (options) => gitClient.init(options)),
+    status: method("status", (options) => gitClient.status(options)),
+    add: method("add", (options) => gitClient.add(options)),
+    rm: method("rm", (options) => gitClient.rm(options)),
+    commit: method("commit", (options) => gitClient.commit(options as CloudflareGitCommitOptions)),
+    log,
+    show: method("show", (options) => gitClient.show(options)),
+    revParse,
+    repoRoot: method("repoRoot", (options) => gitClient.repoRoot(options)),
+    currentBranch: method("currentBranch", (options) => gitClient.currentBranch(options)),
+    lsFiles: method("lsFiles", (options) => gitClient.lsFiles(options)),
+    lsTree: method("lsTree", (options) => gitClient.lsTree(options)),
+    branch: method("branch", (options) => gitClient.branch(options)),
+    branchDelete: method("branchDelete", (options) => gitClient.branchDelete(options)),
+    branchList: method("branchList", (options) => gitClient.branchList(options)),
+    tag: method("tag", (options) => gitClient.tag(options)),
+    tagDelete: method("tagDelete", (options) => gitClient.tagDelete(options)),
+    tagList: method("tagList", (options) => gitClient.tagList(options)),
+    checkout: method("checkout", (options) => gitClient.checkout(options)),
+    fetch: method("fetch", (options) => gitClient.fetch(options as CloudflareGitFetchOptions)),
+    push: method("push", (options) => gitClient.push(options)),
+    pull: method("pull", (options) => gitClient.pull(options)),
+    merge: method("merge", (options) => gitClient.merge(options)),
+    remoteAdd: method("remoteAdd", (options) => gitClient.remoteAdd(options)),
+    remoteRemove: method("remoteRemove", (options) => gitClient.remoteRemove(options)),
+    remoteList: method("remoteList", (options) => gitClient.remoteList(options)),
+    hashObject: method("hashObject", (options) => gitClient.hashObject(options)),
+    catFile: method("catFile", (options) => gitClient.catFile(options)),
+    updateRef: method("updateRef", (options) =>
+      gitClient.updateRef(options as CloudflareGitUpdateRefOptions),
+    ),
+    configGet: method("configGet", (options) => gitClient.configGet(options)),
+    configSet: method("configSet", (options) => gitClient.configSet(options)),
+    stashPush: method("stashPush", (options) => gitClient.stashPush(options)),
+    stashList: method("stashList", (options) => gitClient.stashList(options)),
+    stashPop: method("stashPop", (options) => gitClient.stashPop(options)),
+    reset: method("reset", (options) => gitClient.reset(options)),
+    clean: method("clean", (options) => gitClient.clean(options)),
+    cli: method("cli", (input) => gitClient.cli(input)),
+  } as ComputerWorkspaceGit;
+};
+
+const runtimeExecOptions = <Encoding extends WorkspaceExecEncoding>(
+  options?: WorkspaceExecOptions<Encoding>,
+): CloudflareRuntimeExecOptions => {
+  const { encoding = "utf8", timeoutMillis, timeoutMs, ...rest } = options ?? {};
+
+  return {
+    ...rest,
+    ...(encoding === "utf8" ? { encoding: "utf8" as const } : {}),
+    ...(timeoutMs === undefined && timeoutMillis === undefined
+      ? {}
+      : { timeoutMs: timeoutMs ?? timeoutMillis }),
+  };
+};
+
+const runtimeGetOptions = <Encoding extends WorkspaceExecEncoding>(
+  options?: WorkspaceGetExecOptions<Encoding>,
+): CloudflareRuntimeGetOptions => {
+  const { encoding = "utf8", ...rest } = options ?? {};
+
+  return {
+    ...rest,
+    ...(encoding === "utf8" ? { encoding: "utf8" as const } : {}),
+  };
+};
+
+const wrapRuntimeResult = <Encoding extends WorkspaceExecEncoding>(
+  result: CloudflareWorkspaceRuntimeResult<CloudflareEncoding<Encoding>>,
+): WorkspaceExecResult<Encoding> => ({
+  status: result.status,
+  exitCode: result.exitCode,
+  stdout: result.stdout as WorkspaceExecChunk<Encoding>,
+  stderr: result.stderr as WorkspaceExecChunk<Encoding>,
+  ...(result.value === undefined ? {} : { value: result.value }),
+  pushed: result.pushed,
+  pulled: result.pulled,
+  skipped: result.skipped,
+  sync: result.sync,
+});
+
+const wrapRuntimeEvent = <Encoding extends WorkspaceExecEncoding>(
+  event: CloudflareWorkspaceRuntimeEvent<CloudflareEncoding<Encoding>>,
+): WorkspaceExecEvent<Encoding> => {
+  switch (event.name) {
+    case "stdout": {
+      const chunk = event.value as unknown as string | Uint8Array;
+
+      return (typeof chunk === "string"
+        ? { _tag: "Stdout", id: event.id, sequence: event.seq, chunk, text: chunk }
+        : {
+            _tag: "Stdout",
+            id: event.id,
+            sequence: event.seq,
+            chunk,
+            bytes: chunk,
+          }) as unknown as WorkspaceExecEvent<Encoding>;
+    }
+    case "stderr": {
+      const chunk = event.value as unknown as string | Uint8Array;
+
+      return (typeof chunk === "string"
+        ? { _tag: "Stderr", id: event.id, sequence: event.seq, chunk, text: chunk }
+        : {
+            _tag: "Stderr",
+            id: event.id,
+            sequence: event.seq,
+            chunk,
+            bytes: chunk,
+          }) as unknown as WorkspaceExecEvent<Encoding>;
+    }
+    case "exit":
+      return {
+        _tag: "Exit",
+        id: event.id,
+        sequence: event.seq,
+        exitCode: event.code,
+        ...(event.result === undefined ? {} : { value: event.result }),
+      };
+  }
+};
+
+const wrapRun = <Encoding extends WorkspaceExecEncoding>(
+  handle: CloudflareWorkspaceRuntimeExecHandle<CloudflareEncoding<Encoding>>,
+): WorkspaceExecRun<Encoding> => {
+  const events = Stream.fromReadableStream<
+    CloudflareWorkspaceRuntimeEvent<CloudflareEncoding<Encoding>>,
+    WorkspaceExecError
+  >({
+    evaluate: () => handle,
+    onError: (cause) => execError("events", cause),
+  }).pipe(Stream.map(wrapRuntimeEvent<Encoding>));
+
+  const result = Effect.tryPromise({
+    try: () => handle.result(),
+    catch: (cause) => execError("result", cause),
+  }).pipe(Effect.map(wrapRuntimeResult<Encoding>));
+
+  const kill = Effect.fn("ComputerWorkspace.runtime.run.kill", {
+    attributes: { family: "runtime", operation: "run.kill", runId: handle.id },
+  })(function* (signal?: WorkspaceExecSignal) {
+    yield* Effect.tryPromise({
+      try: () => handle.kill(signal),
+      catch: (cause) => execError("run.kill", cause),
+    });
+  });
+
+  return { id: handle.id, backend: handle.backend, events, result, kill };
+};
+
+const releaseRun = (handle: CloudflareWorkspaceRuntimeExecHandle<"utf8" | undefined>) =>
+  Effect.sync(() => handle[Symbol.dispose]());
+
+const makeRuntime = (client: CloudflareWorkspaceClient): ComputerWorkspaceRuntime => {
+  const execImplementation = Effect.fn("ComputerWorkspace.runtime.exec", {
+    attributes: { family: "runtime", operation: "exec" },
+  })(function* <Encoding extends WorkspaceExecEncoding = "utf8">(
+    source: string | TemplateStringsArray,
+    optionsOrValue?: WorkspaceExecOptions<Encoding> | CloudflareShellValue,
+    ...remainingValues: Array<CloudflareShellValue>
+  ) {
+    const options =
+      typeof source === "string"
+        ? (optionsOrValue as WorkspaceExecOptions<Encoding> | undefined)
+        : undefined;
+
+    yield* Effect.annotateCurrentSpan({ backend: options?.backend, runId: options?.id });
+    const handle = yield* Effect.acquireRelease(
+      Effect.tryPromise({
+        try: () => {
+          if (typeof source === "string") {
+            return client.runtime.exec(source, runtimeExecOptions(options));
+          }
+
+          const values =
+            optionsOrValue === undefined
+              ? remainingValues
+              : [optionsOrValue as CloudflareShellValue, ...remainingValues];
+
+          return client.runtime.exec(source, ...values);
+        },
+        catch: (cause) => execError("exec", cause),
+      }),
+      releaseRun,
+    );
+
+    return wrapRun<Encoding>(
+      handle as CloudflareWorkspaceRuntimeExecHandle<CloudflareEncoding<Encoding>>,
+    );
+  });
+  const exec = execImplementation as WorkspaceExec;
+
+  const getExecImplementation = Effect.fn("ComputerWorkspace.runtime.getExec", {
+    attributes: { family: "runtime", operation: "getExec" },
+  })(function* <Encoding extends WorkspaceExecEncoding = "utf8">(
+    id: string,
+    options?: WorkspaceGetExecOptions<Encoding>,
+  ) {
+    yield* Effect.annotateCurrentSpan({ backend: options?.backend, runId: id });
+    const handle = yield* Effect.acquireRelease(
+      Effect.tryPromise({
+        try: () => client.runtime.getExec(id, runtimeGetOptions(options)),
+        catch: (cause) => execError("getExec", cause),
+      }),
+      releaseRun,
+    );
+
+    return wrapRun<Encoding>(
+      handle as CloudflareWorkspaceRuntimeExecHandle<CloudflareEncoding<Encoding>>,
+    );
+  });
+  const getExec = getExecImplementation as WorkspaceGetExec;
+
+  const killExec = Effect.fn("ComputerWorkspace.runtime.killExec", {
+    attributes: { family: "runtime", operation: "killExec" },
+  })(function* (id: string, options?: CloudflareRuntimeKillOptions) {
+    yield* Effect.annotateCurrentSpan({ backend: options?.backend, runId: id });
+    yield* Effect.tryPromise({
+      try: () => client.runtime.killExec(id, options),
+      catch: (cause) => execError("killExec", cause),
+    });
+  });
+
+  const disposeExec = Effect.fn("ComputerWorkspace.runtime.disposeExec", {
+    attributes: { family: "runtime", operation: "disposeExec" },
+  })(function* (id: string, options?: { readonly backend?: string }) {
+    yield* Effect.annotateCurrentSpan({ backend: options?.backend, runId: id });
+    yield* Effect.tryPromise({
+      try: () => client.runtime.disposeExec(id, options),
+      catch: (cause) => execError("disposeExec", cause),
+    });
+  });
+
+  const execCollectImplementation = Effect.fn("ComputerWorkspace.runtime.execCollect", {
+    attributes: { family: "runtime", operation: "execCollect" },
+  })(function* <Encoding extends WorkspaceExecEncoding = "utf8">(
+    source: string | TemplateStringsArray,
+    optionsOrValue?: WorkspaceExecOptions<Encoding> | CloudflareShellValue,
+    ...remainingValues: Array<CloudflareShellValue>
+  ) {
+    return yield* Effect.scoped(
+      Effect.gen(function* () {
+        const run = yield* execImplementation(source, optionsOrValue, ...remainingValues);
+
+        return yield* run.result;
+      }),
+    );
+  });
+  const execCollect = execCollectImplementation as WorkspaceExecCollect;
+
+  return { exec, execCollect, getExec, killExec, disposeExec };
+};
+
+const makeAssets = (
+  client: CloudflareComputerAssetsClient | undefined,
+): ComputerWorkspaceAssets | undefined =>
+  client === undefined
+    ? undefined
+    : {
+        share: Effect.fn("ComputerWorkspace.assets.share", {
+          attributes: { family: "assets", operation: "share" },
+        })(function* (path: string, options: CloudflareComputerShareOptions) {
+          yield* Effect.annotateCurrentSpan("path", path);
+
+          return yield* Effect.tryPromise({
+            try: () => client.share(path, options),
+            catch: (cause) => assetsError("share", path, cause),
+          });
+        }),
+      };
+
+const makeThink = (client: CloudflareWorkspaceClient): ComputerWorkspaceThink | undefined => {
+  if (
+    client.readFile === undefined ||
+    client.readFileBytes === undefined ||
+    client.writeFile === undefined ||
+    client.readDir === undefined ||
+    client.rm === undefined ||
+    client.glob === undefined ||
+    client.mkdir === undefined ||
+    client.stat === undefined
+  ) {
+    return undefined;
+  }
+
+  const method = <Args extends Array<unknown>, Success>(
+    operation: string,
+    pathOf: (...args: Args) => string,
+    evaluate: (...args: Args) => Promise<Success>,
+  ) =>
+    Effect.fn(`ComputerWorkspace.think.${operation}`, {
+      attributes: { family: "think", operation },
+    })(function* (...args: Args) {
+      const path = pathOf(...args);
+
+      yield* Effect.annotateCurrentSpan("path", path);
+
+      return yield* tryFs(`think.${operation}`, path, () => evaluate(...args));
+    });
+
+  return {
+    readFile: method(
+      "readFile",
+      (path) => path as string,
+      (path) => client.readFile!(path as string),
+    ),
+    readFileBytes: method(
+      "readFileBytes",
+      (path) => path as string,
+      (path) => client.readFileBytes!(path as string),
+    ),
+    writeFile: method(
+      "writeFile",
+      (path: string, _content: string) => path,
+      (path: string, content: string) => client.writeFile!(path, content),
+    ),
+    readDir: method(
+      "readDir",
+      (path: string, _options?: { readonly limit?: number; readonly offset?: number }) => path,
+      (path: string, options?: { readonly limit?: number; readonly offset?: number }) =>
+        client.readDir!(path, options),
+    ),
+    rm: method(
+      "rm",
+      (path: string, _options?: { readonly recursive?: boolean; readonly force?: boolean }) => path,
+      (path: string, options?: { readonly recursive?: boolean; readonly force?: boolean }) =>
+        client.rm!(path, options),
+    ),
+    glob: method(
+      "glob",
+      (pattern) => pattern as string,
+      (pattern) => client.glob!(pattern as string),
+    ),
+    mkdir: method(
+      "mkdir",
+      (path: string, _options?: { readonly recursive?: boolean }) => path,
+      (path: string, options?: { readonly recursive?: boolean }) => client.mkdir!(path, options),
+    ),
+    stat: method(
+      "stat",
+      (path) => path as string,
+      (path) => client.stat!(path as string),
+    ),
+  } as ComputerWorkspaceThink;
+};
+
+/**
+ * Wraps a client whose lifetime is owned by the caller. Prefer
+ * {@link ComputerWorkspace.layer} in Durable Objects so the parent client and
+ * every runtime handle are disposed by Effect `Scope`.
+ */
+export const fromWorkspaceClient = (client: CloudflareWorkspaceClient): ComputerWorkspaceShape => {
+  const fs = makeFilesystem(client.fs);
+  const git = makeGit(client.git as CloudflareGitClient);
+  const runtime = makeRuntime(client);
+  const artifacts = ComputerArtifacts.fromClient(
+    client.artifacts as CloudflareComputerArtifactClient,
+    { binding: "ComputerWorkspace.artifacts" },
+  );
+  const assets = makeAssets(client.assets as CloudflareComputerAssetsClient | undefined);
+  const think = makeThink(client);
+
+  return {
+    fs,
+    git,
+    runtime,
+    artifacts,
+    assets,
+    think,
+    readFile: fs.readFile,
+    stat: fs.stat,
+    lstat: fs.lstat,
+    exists: fs.exists,
+    readlink: fs.readlink,
+    readdir: fs.readdir,
+    listDirectory: fs.readdir,
+    find: fs.find,
+    ls: fs.ls,
+    grep: fs.grep,
+    writeFile: fs.writeFile,
+    mkdir: fs.mkdir,
+    rm: fs.rm,
+    removePath: fs.rm,
+    chmod: fs.chmod,
+    symlink: fs.symlink,
+    exec: runtime.exec,
+    execCollect: runtime.execCollect,
+    getExec: runtime.getExec,
+    killExec: runtime.killExec,
+    disposeExec: runtime.disposeExec,
+  };
+};
+
+/** Effect service for the workspace owned by the enclosing Durable Object. */
+export class ComputerWorkspace extends Context.Service<ComputerWorkspace, ComputerWorkspaceShape>()(
+  "effect-cf/ComputerWorkspace",
+) {
+  /**
+   * Acquires the single workspace registered by `withComputerWorkspace` and
+   * releases its RPC client when the layer scope closes.
+   */
+  static readonly layer: Layer.Layer<ComputerWorkspace, never, DurableObjectState> = Layer.effect(
+    ComputerWorkspace,
+    Effect.gen(function* () {
+      const state = yield* DurableObjectState;
+      const host = HostRegistry.lookup(state.raw);
+
+      if (host === undefined) {
+        return yield* Effect.die(
+          "ComputerWorkspace.layer requires a Durable Object class built with withComputerWorkspace",
+        );
+      }
+
+      const computer = yield* Effect.promise(() => import("@cloudflare/computer"));
+      const client = yield* Effect.acquireRelease(
+        Effect.promise(() => computer.getWorkspace(host)),
+        (workspace) => Effect.sync(() => workspace[Symbol.dispose]()),
+      );
+
+      return ComputerWorkspace.of(fromWorkspaceClient(client));
+    }),
+  );
+}

--- a/packages/effect-cf/src/ComputerWorkspaceHost.ts
+++ b/packages/effect-cf/src/ComputerWorkspaceHost.ts
@@ -1,0 +1,216 @@
+import { createGitClient, type GitClientFactory } from "@cloudflare/computer/git";
+import {
+  type DurableObjectStorageLike,
+  type WithWorkspaceCtor,
+  type WorkspaceHandle,
+  type WorkspaceObserver,
+  type WorkspaceOptions,
+  type WorkspaceRegisteredBackend,
+  type WorkspaceRetryPendingSyncResult,
+  type WorkspaceSpan,
+  type WorkspaceAttributes,
+  type WorkspaceAttributeValue,
+  type SyncRetryIntent,
+  type SyncRetryOptions,
+  type SyncRetryScheduler,
+  withWorkspace,
+} from "@cloudflare/computer";
+import {
+  WorkerShellBackend,
+  type ShellModuleGroup,
+  type WorkerShellBackendOptions,
+  type WorkerShellLoader,
+  type WorkspaceEgressPolicy,
+} from "@cloudflare/computer/backends/worker-shell";
+
+import type * as Artifacts from "./Artifacts";
+import * as HostRegistry from "./internal/ComputerWorkspaceHostRegistry";
+
+/**
+ * The worker-shell backend resolves this exact export through
+ * `ctx.exports.WorkspaceServiceProxy`. Every Worker that configures
+ * {@link withComputerWorkspace} with `shell` must re-export it from its main
+ * module.
+ */
+export { WorkspaceServiceProxy } from "@cloudflare/computer";
+
+export type {
+  ShellModuleGroup,
+  SyncRetryIntent,
+  SyncRetryOptions,
+  SyncRetryScheduler,
+  WorkspaceAttributeValue,
+  WorkspaceAttributes,
+  WorkspaceEgressPolicy,
+  WorkspaceObserver,
+  WorkspaceRetryPendingSyncResult,
+  WorkspaceSpan,
+};
+
+/** The value of a `worker_loaders` binding. */
+export type DynamicWorkerLoader = WorkerShellLoader;
+
+/** Default author and committer identity for workspace Git operations. */
+export interface ComputerWorkspaceGitIdentity {
+  readonly name: string;
+  readonly email: string;
+}
+
+/** Session-scoped Artifacts configuration passed through to `Workspace`. */
+export interface ComputerWorkspaceArtifactsOptions {
+  readonly binding: Artifacts.ArtifactsBinding;
+  /**
+   * Session prefix for repository names. When omitted, `sessionId` from the
+   * enclosing host configuration is used.
+   */
+  readonly sessionId?: string;
+}
+
+/**
+ * Worker-shell backend options with the loopback workspace wiring named in
+ * Durable Object terms.
+ */
+export interface ComputerWorkspaceShellOptions extends Omit<
+  WorkerShellBackendOptions,
+  "source" | "loader" | "workspace" | "ctx" | "egress"
+> {
+  readonly loader: DynamicWorkerLoader;
+  /** Durable Object namespace binding that points back to the wrapped class. */
+  readonly hostBinding: string;
+  /** Current Durable Object id, normally `ctx.id.toString()`. */
+  readonly hostId: string;
+  /** Current Durable Object execution context, normally `ctx`. */
+  readonly executionContext: unknown;
+  /** Dynamic Worker egress policy. Defaults to `{ mode: "none" }`. */
+  readonly egress?: WorkspaceEgressPolicy;
+}
+
+/** Configuration accepted by {@link withComputerWorkspace}. */
+export interface ComputerWorkspaceHostConfig {
+  /** Native SQLite-backed Durable Object storage (`ctx.storage`). */
+  readonly storage: globalThis.DurableObjectStorage | DurableObjectStorageLike;
+  /** Stable workspace id used by mounts and as the default Artifacts session. */
+  readonly sessionId?: string;
+  readonly gitIdentity?: ComputerWorkspaceGitIdentity;
+  /** Override the default `createGitClient()` factory. */
+  readonly git?: GitClientFactory;
+  /** Additional container, Worker JavaScript, shell, or custom backends. */
+  readonly backends?: ReadonlyArray<WorkspaceRegisteredBackend>;
+  /** Convenience wiring for one Worker Shell backend. */
+  readonly shell?: ComputerWorkspaceShellOptions;
+  readonly mounts?: WorkspaceOptions["mounts"];
+  readonly observer?: WorkspaceOptions["observer"];
+  readonly retryScheduler?: WorkspaceOptions["retryScheduler"];
+  readonly retry?: WorkspaceOptions["retry"];
+  readonly assets?: WorkspaceOptions["assets"];
+  readonly artifacts?: ComputerWorkspaceArtifactsOptions;
+  readonly now?: WorkspaceOptions["now"];
+  readonly useThink?: WorkspaceOptions["useThink"];
+}
+
+const toWorkspaceOptions = (config: ComputerWorkspaceHostConfig): WorkspaceOptions => {
+  const backends = [...(config.backends ?? [])];
+
+  if (config.shell !== undefined) {
+    const { egress, executionContext, hostBinding, hostId, loader, ...shellOptions } = config.shell;
+
+    backends.push(
+      new WorkerShellBackend({
+        ...shellOptions,
+        loader,
+        workspace: { binding: hostBinding, id: hostId },
+        ctx: executionContext,
+        egress: egress ?? { mode: "none" },
+      }),
+    );
+  }
+
+  return {
+    storage: config.storage as DurableObjectStorageLike,
+    git: config.git ?? createGitClient(),
+    ...(config.gitIdentity === undefined ? {} : { defaultGitIdentity: config.gitIdentity }),
+    ...(backends.length === 0 ? {} : { backends }),
+    ...(config.sessionId === undefined ? {} : { sessionId: config.sessionId }),
+    ...(config.mounts === undefined ? {} : { mounts: config.mounts }),
+    ...(config.observer === undefined ? {} : { observer: config.observer }),
+    ...(config.retryScheduler === undefined ? {} : { retryScheduler: config.retryScheduler }),
+    ...(config.retry === undefined ? {} : { retry: config.retry }),
+    ...(config.assets === undefined ? {} : { assets: config.assets }),
+    ...(config.artifacts === undefined
+      ? {}
+      : {
+          artifacts: {
+            binding: config.artifacts.binding as unknown as NonNullable<
+              WorkspaceOptions["artifacts"]
+            >["binding"],
+            ...(config.artifacts.sessionId === undefined
+              ? {}
+              : { sessionId: config.artifacts.sessionId }),
+          },
+        }),
+    ...(config.now === undefined ? {} : { now: config.now }),
+    ...(config.useThink === undefined ? {} : { useThink: config.useThink }),
+  };
+};
+
+// Cloudflare constructs Durable Objects with `(state, env)`. Keeping the
+// remaining tuple open preserves arbitrary Effect-backed base constructors.
+type DurableObjectConstructor = new (...args: Array<any>) => object;
+
+const HostArguments = Symbol("effect-cf/ComputerWorkspaceHost/arguments");
+
+interface CapturedHostArguments {
+  readonly state: globalThis.DurableObjectState;
+  readonly env: unknown;
+}
+
+interface HostArgumentsInstance {
+  readonly [HostArguments]: CapturedHostArguments;
+}
+
+/**
+ * Wraps a Durable Object class with one SQLite-backed Cloudflare Computer
+ * workspace and registers that local workspace for {@link ComputerWorkspace}
+ * to acquire through its Effect layer.
+ *
+ * The class must use a `new_sqlite_classes` migration. If `shell` is present,
+ * its Worker must also configure a `worker_loaders` binding, enable the
+ * `experimental` compatibility flag, and export `WorkspaceServiceProxy`.
+ */
+export const withComputerWorkspace = <TBase extends DurableObjectConstructor>(
+  Base: TBase,
+  config: (
+    self: InstanceType<TBase>,
+    state: globalThis.DurableObjectState,
+    env: ConstructorParameters<TBase>[1],
+  ) => ComputerWorkspaceHostConfig,
+): WithWorkspaceCtor<TBase> => {
+  const CapturedBase = class extends (Base as DurableObjectConstructor) {
+    readonly [HostArguments]: CapturedHostArguments;
+
+    constructor(...args: Array<any>) {
+      super(...args);
+      this[HostArguments] = {
+        state: args[0] as globalThis.DurableObjectState,
+        env: args[1],
+      };
+    }
+  };
+
+  const WithWorkspace = withWorkspace(CapturedBase, (self) => {
+    const { env, state } = (self as HostArgumentsInstance)[HostArguments];
+
+    return toWorkspaceOptions(
+      config(self as InstanceType<TBase>, state, env as ConstructorParameters<TBase>[1]),
+    );
+  }) as unknown as DurableObjectConstructor;
+
+  class WithComputerWorkspace extends WithWorkspace {
+    constructor(...args: Array<any>) {
+      super(...args);
+      HostRegistry.register(args[0] as globalThis.DurableObjectState, this as WorkspaceHandle);
+    }
+  }
+
+  return WithComputerWorkspace as unknown as WithWorkspaceCtor<TBase>;
+};

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -5,6 +5,8 @@ export * as Binding from "./Binding";
 export * as BrowserRendering from "./BrowserRendering";
 export * as Cache from "./Cache";
 export * as CloudflareOtlp from "./CloudflareOtlp";
+export * as ComputerArtifacts from "./ComputerArtifacts";
+export * as ComputerWorkspace from "./ComputerWorkspace";
 export * as ContainerNamespace from "./ContainerNamespace";
 export * as D1 from "./D1";
 export * as DurableObject from "./DurableObject";

--- a/packages/effect-cf/src/internal/ComputerWorkspaceHostRegistry.ts
+++ b/packages/effect-cf/src/internal/ComputerWorkspaceHostRegistry.ts
@@ -1,0 +1,10 @@
+import type { WorkspaceHandle } from "@cloudflare/computer";
+
+const hosts = new WeakMap<globalThis.DurableObjectState, WorkspaceHandle>();
+
+export const register = (state: globalThis.DurableObjectState, host: WorkspaceHandle): void => {
+  hosts.set(state, host);
+};
+
+export const lookup = (state: globalThis.DurableObjectState): WorkspaceHandle | undefined =>
+  hosts.get(state);

--- a/packages/effect-cf/tests/Artifacts.test.ts
+++ b/packages/effect-cf/tests/Artifacts.test.ts
@@ -28,6 +28,7 @@ const createResult = (
   defaultBranch: "main",
   remote: `https://git.cloudflare.com/default/${name}`,
   token: `${name}-token?expires=1786752000`,
+  tokenExpiresAt: "2026-08-16T00:00:00.000Z",
 });
 
 interface Calls {

--- a/packages/effect-cf/tests/ComputerArtifacts.test.ts
+++ b/packages/effect-cf/tests/ComputerArtifacts.test.ts
@@ -1,0 +1,156 @@
+import { assert, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { Artifacts, ComputerArtifacts } from "../src/index";
+
+const repoInfo = (name: string): Artifacts.ArtifactsRepoInfo => ({
+  id: `${name}-id`,
+  name,
+  description: null,
+  defaultBranch: "main",
+  createdAt: "2026-08-15T00:00:00.000Z",
+  updatedAt: "2026-08-15T00:00:00.000Z",
+  lastPushAt: null,
+  source: null,
+  readOnly: false,
+  remote: `https://git.cloudflare.com/default/${name}`,
+});
+
+const createResult = (name: string): Artifacts.ArtifactsCreateRepoResult => ({
+  id: `${name}-id`,
+  name,
+  description: null,
+  defaultBranch: "main",
+  remote: `https://git.cloudflare.com/default/${name}`,
+  token: `${name}-token`,
+  tokenExpiresAt: "2026-08-16T00:00:00.000Z",
+});
+
+it.effect("delegates session naming and filtering to the upstream Artifacts facade", () =>
+  Effect.gen(function* () {
+    const calls = {
+      create: [] as Array<string>,
+      get: [] as Array<string>,
+      import: [] as Array<string>,
+      list: [] as Array<string | undefined>,
+      delete: [] as Array<string>,
+    };
+    const token = {
+      id: "token-1",
+      scope: "read" as const,
+      state: "active" as const,
+      createdAt: "2026-08-15T00:00:00.000Z",
+      expiresAt: "2026-08-16T00:00:00.000Z",
+    };
+    const repo = (name: string) => ({
+      ...repoInfo(name),
+      info: () => Promise.resolve(repoInfo(name)),
+      createToken: () =>
+        Promise.resolve({
+          id: token.id,
+          plaintext: "plaintext-token",
+          scope: token.scope,
+          expiresAt: token.expiresAt,
+        }),
+      listTokens: () => Promise.resolve({ tokens: [token], total: 1 }),
+      revokeToken: () => Promise.resolve(true),
+      fork: (target: string) => Promise.resolve(createResult(target)),
+    });
+    const binding = {
+      create: (name: string) => {
+        calls.create.push(name);
+
+        return Promise.resolve(createResult(name));
+      },
+      get: (name: string) => {
+        calls.get.push(name);
+
+        return Promise.resolve(repo(name));
+      },
+      import: (params: Artifacts.ArtifactsImportParams) => {
+        calls.import.push(params.target.name);
+
+        return Promise.resolve(createResult(params.target.name));
+      },
+      list: (options?: Artifacts.ArtifactsListOptions) => {
+        calls.list.push(options?.cursor);
+
+        return Promise.resolve(
+          options?.cursor === undefined
+            ? {
+                repos: [
+                  { ...repoInfo("session-1__build-cache"), status: "ready" as const },
+                  { ...repoInfo("another-session__hidden"), status: "ready" as const },
+                ],
+                total: 3,
+                cursor: "next",
+              }
+            : {
+                repos: [{ ...repoInfo("session-1__reports"), status: "ready" as const }],
+                total: 3,
+              },
+        );
+      },
+      delete: (name: string) => {
+        calls.delete.push(name);
+
+        return Promise.resolve(true);
+      },
+    } as unknown as Artifacts.ArtifactsBinding;
+
+    const artifacts = yield* ComputerArtifacts.makeClient(binding, "session-1");
+    const created = yield* artifacts.create("build-cache");
+    const resolved = yield* artifacts.get("build-cache");
+    const listed = yield* artifacts.list;
+    const imported = yield* artifacts.import("source", {
+      url: "https://github.com/cloudflare/workers-sdk",
+      branch: "main",
+      depth: 1,
+    });
+    const createdToken = yield* artifacts.createToken("build-cache", "read", 3_600);
+    const tokens = yield* artifacts.listTokens("build-cache");
+    const foundToken = yield* artifacts.getToken("build-cache", "token-1");
+    const revoked = yield* artifacts.revokeToken("build-cache", "token-1");
+    const deleted = yield* artifacts.delete("reports");
+    const cli = yield* artifacts.cli({ argv: ["help"] });
+
+    assert.strictEqual(artifacts.sessionId, "session-1");
+    assert.strictEqual(created.name, "build-cache");
+    assert.strictEqual(resolved.name, "build-cache");
+    assert.deepStrictEqual(
+      listed.map(({ name }) => name),
+      ["build-cache", "reports"],
+    );
+    assert.strictEqual(imported.name, "source");
+    assert.strictEqual(createdToken.id, "token-1");
+    assert.strictEqual(tokens.total, 1);
+    assert.strictEqual(foundToken.id, "token-1");
+    assert.isTrue(revoked);
+    assert.isTrue(deleted);
+    assert.strictEqual(cli.exitCode, 0);
+    assert.deepStrictEqual(calls.create, ["session-1__build-cache"]);
+    assert.deepStrictEqual(calls.import, ["session-1__source"]);
+    assert.deepStrictEqual(calls.list, [undefined, "next"]);
+    assert.deepStrictEqual(calls.delete, ["session-1__reports"]);
+    assert.deepStrictEqual(calls.get, [
+      "session-1__build-cache",
+      "session-1__build-cache",
+      "session-1__build-cache",
+      "session-1__build-cache",
+      "session-1__build-cache",
+    ]);
+  }),
+);
+
+it.effect("maps upstream session validation into the Artifacts error channel", () =>
+  Effect.gen(function* () {
+    const error = yield* ComputerArtifacts.makeClient(
+      {} as Artifacts.ArtifactsBinding,
+      "invalid__session",
+    ).pipe(Effect.flip);
+
+    assert.strictEqual(error._tag, "ArtifactsOperationError");
+    assert.strictEqual(error.operation, "createClient");
+    assert.strictEqual(error.code, "EINVALIDSESSION");
+  }),
+);

--- a/packages/effect-cf/tests/ComputerWorkspace.test.ts
+++ b/packages/effect-cf/tests/ComputerWorkspace.test.ts
@@ -1,0 +1,202 @@
+import type {
+  WorkspaceClient,
+  WorkspaceRuntimeEvent,
+  WorkspaceRuntimeExecHandle,
+} from "@cloudflare/computer";
+import type { ArtifactClient } from "@cloudflare/computer/artifacts";
+import { assert, it } from "@effect/vitest";
+import { Effect, Stream } from "effect";
+
+import { ComputerWorkspace } from "../src/index";
+
+const emptyArtifacts = {
+  sessionId: "test-session",
+  create: () => Promise.reject(new Error("unused")),
+  get: () => Promise.reject(new Error("unused")),
+  list: () => Promise.resolve([]),
+  import: () => Promise.reject(new Error("unused")),
+  delete: () => Promise.resolve(false),
+  createToken: () => Promise.reject(new Error("unused")),
+  listTokens: () => Promise.reject(new Error("unused")),
+  getToken: () => Promise.reject(new Error("unused")),
+  revokeToken: () => Promise.resolve(false),
+  cli: () => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }),
+} as ArtifactClient;
+
+const runtimeResult = {
+  status: "completed" as const,
+  exitCode: 0,
+  stdout: "hello\n",
+  stderr: "",
+  value: { ok: true },
+  pushed: 2,
+  pulled: 3,
+  skipped: [],
+  sync: { status: "complete" as const, applied: 3, skipped: [] },
+};
+
+const makeHandle = (id: string, disposed: Array<string>): WorkspaceRuntimeExecHandle<"utf8"> => {
+  const events: Array<WorkspaceRuntimeEvent<"utf8">> = [
+    { id, seq: 0, name: "stdout", value: "hello\n" },
+    { id, seq: 1, name: "exit", code: 0, result: { ok: true } },
+  ];
+  const stream = new ReadableStream<WorkspaceRuntimeEvent<"utf8">>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(event);
+      }
+      controller.close();
+    },
+  });
+
+  Object.defineProperties(stream, {
+    id: { value: id },
+    backend: { value: "fake" },
+    result: { value: () => Promise.resolve(runtimeResult) },
+    kill: { value: () => Promise.resolve() },
+    [Symbol.dispose]: {
+      value: () => {
+        disposed.push(id);
+      },
+    },
+  });
+
+  return stream as WorkspaceRuntimeExecHandle<"utf8">;
+};
+
+it.effect("wraps text, binary streams, runtime metadata, and scoped run disposal", () =>
+  Effect.gen(function* () {
+    const disposed: Array<string> = [];
+    const killed: Array<string> = [];
+    const disposedExecs: Array<string> = [];
+    const execCalls: Array<ReadonlyArray<unknown>> = [];
+    let nextRun = 0;
+    const client = {
+      fs: {
+        readFile: (_path: string, options?: "utf8" | { readonly encoding?: "utf8" }) =>
+          options === "utf8" || options?.encoding === "utf8"
+            ? Promise.resolve("hello")
+            : Promise.resolve(
+                new ReadableStream<Uint8Array>({
+                  start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2, 3]));
+                    controller.close();
+                  },
+                }),
+              ),
+        stat: (path: string) =>
+          path === "/missing"
+            ? Promise.reject(Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" }))
+            : Promise.resolve({
+                name: "hello.txt",
+                inode: 1,
+                mode: 0o644,
+                mtime: 0,
+                size: 5,
+                isFile: true,
+                isDirectory: false,
+                isSymbolicLink: false,
+              }),
+      },
+      git: {},
+      artifacts: emptyArtifacts,
+      assets: undefined,
+      runtime: {
+        exec: (...args: Array<unknown>) => {
+          execCalls.push(args);
+
+          return Promise.resolve(makeHandle(`exec-${++nextRun}`, disposed));
+        },
+        getExec: (id: string) => Promise.resolve(makeHandle(id, disposed)),
+        killExec: (id: string) => {
+          killed.push(id);
+
+          return Promise.resolve();
+        },
+        disposeExec: (id: string) => {
+          disposedExecs.push(id);
+
+          return Promise.resolve();
+        },
+      },
+      [Symbol.dispose]: () => {},
+    } as unknown as WorkspaceClient;
+    const workspace = ComputerWorkspace.fromWorkspaceClient(client);
+
+    assert.strictEqual(yield* workspace.readFile("/hello.txt"), "hello");
+    const binary = yield* workspace.readFile("/blob.bin", { encoding: "stream" });
+    const bytes = yield* Effect.promise(
+      async () => new Uint8Array(await new Response(binary).arrayBuffer()),
+    );
+
+    assert.deepStrictEqual(Array.from(bytes), [1, 2, 3]);
+    assert.isTrue(yield* workspace.exists("/hello.txt"));
+    assert.isFalse(yield* workspace.exists("/missing"));
+
+    const result = yield* workspace.execCollect("echo hello");
+
+    assert.deepStrictEqual(result, runtimeResult);
+    assert.deepStrictEqual(disposed, ["exec-1"]);
+
+    const taggedResult = yield* workspace.execCollect`echo ${"tagged"}`;
+
+    assert.deepStrictEqual(taggedResult, runtimeResult);
+    assert.deepStrictEqual(Array.from(execCalls[1]?.[0] as TemplateStringsArray), ["echo ", ""]);
+    assert.strictEqual(execCalls[1]?.[1], "tagged");
+    assert.deepStrictEqual(disposed, ["exec-1", "exec-2"]);
+
+    const events = yield* Effect.scoped(
+      Effect.flatMap(workspace.exec("echo hello"), (run) => Stream.runCollect(run.events)),
+    );
+
+    assert.deepStrictEqual(events, [
+      {
+        _tag: "Stdout",
+        id: "exec-3",
+        sequence: 0,
+        chunk: "hello\n",
+        text: "hello\n",
+      },
+      {
+        _tag: "Exit",
+        id: "exec-3",
+        sequence: 1,
+        exitCode: 0,
+        value: { ok: true },
+      },
+    ]);
+    assert.deepStrictEqual(disposed, ["exec-1", "exec-2", "exec-3"]);
+
+    yield* Effect.scoped(Effect.flatMap(workspace.getExec("existing"), (run) => run.result));
+    yield* workspace.killExec("existing", { signal: "SIGTERM" });
+    yield* workspace.disposeExec("existing");
+
+    assert.deepStrictEqual(disposed, ["exec-1", "exec-2", "exec-3", "existing"]);
+    assert.deepStrictEqual(killed, ["existing"]);
+    assert.deepStrictEqual(disposedExecs, ["existing"]);
+  }),
+);
+
+it.effect("maps filesystem failures to schema-serializable family errors", () =>
+  Effect.gen(function* () {
+    const cause = Object.assign(new Error("read-only mount"), { code: "EROFS" });
+    const client = {
+      fs: {
+        writeFile: () => Promise.reject(cause),
+      },
+      git: {},
+      artifacts: emptyArtifacts,
+      assets: undefined,
+      runtime: {},
+      [Symbol.dispose]: () => {},
+    } as unknown as WorkspaceClient;
+    const workspace = ComputerWorkspace.fromWorkspaceClient(client);
+    const error = yield* workspace.writeFile("/mounted/file", "nope").pipe(Effect.flip);
+
+    assert.strictEqual(error._tag, "WorkspaceFsError");
+    assert.strictEqual(error.operation, "writeFile");
+    assert.strictEqual(error.path, "/mounted/file");
+    assert.strictEqual(error.code, "EROFS");
+    assert.strictEqual(error.cause, cause);
+  }),
+);

--- a/packages/effect-cf/tests/ComputerWorkspace.worker.test.ts
+++ b/packages/effect-cf/tests/ComputerWorkspace.worker.test.ts
@@ -23,8 +23,9 @@ test("SQLite-backed workspaces persist filesystem and local Git operations", asy
   expect(result.branch).toBe("main");
   expect(result.branches).toContain("feature");
   expect(result.tags).toContain("v1");
-  expect(result.logMessage).toBe("initial commit");
-  expect(result.shownMessage).toBe("initial commit");
+  // Git preserves the canonical trailing newline on commit messages.
+  expect(result.logMessage).toBe("initial commit\n");
+  expect(result.shownMessage).toBe("initial commit\n");
   expect(result.files).toContain("README.md");
   expect(result.treePaths).toContain("README.md");
   expect(result.statusPaths).toContain("README.md");

--- a/packages/effect-cf/tests/ComputerWorkspace.worker.test.ts
+++ b/packages/effect-cf/tests/ComputerWorkspace.worker.test.ts
@@ -1,0 +1,33 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+import { env } from "cloudflare:test";
+import { expect, test } from "vite-plus/test";
+
+test("SQLite-backed workspaces persist filesystem and local Git operations", async () => {
+  const namespace = env.TEST_COMPUTER_DO;
+
+  if (namespace === undefined) {
+    throw new Error("TEST_COMPUTER_DO is not configured");
+  }
+
+  const stub = namespace.get(namespace.idFromName(crypto.randomUUID()));
+  const result = await stub.exercise();
+
+  expect(result.text).toBe("Ship it");
+  expect(result.bytes).toEqual([1, 2, 3]);
+  expect(result.directoryNames).toEqual(expect.arrayContaining(["blob.bin", "notes", "todo-link"]));
+  expect(result.foundPaths).toEqual(expect.arrayContaining(["/notes/todo.md", "/blob.bin"]));
+  expect(result.grepLines).toEqual([2]);
+  expect(result.linkTarget).toBe("/notes/todo.md");
+  expect(result.commit).toMatch(/^[0-9a-f]{40}$/);
+  expect(result.branch).toBe("main");
+  expect(result.branches).toContain("feature");
+  expect(result.tags).toContain("v1");
+  expect(result.logMessage).toBe("initial commit");
+  expect(result.shownMessage).toBe("initial commit");
+  expect(result.files).toContain("README.md");
+  expect(result.treePaths).toContain("README.md");
+  expect(result.statusPaths).toContain("README.md");
+  expect(result.diffContainsUpdate).toBe(true);
+  expect(result.configValue).toBe("works");
+});

--- a/packages/effect-cf/tests/computer-workspace.test-d.ts
+++ b/packages/effect-cf/tests/computer-workspace.test-d.ts
@@ -1,0 +1,108 @@
+import type {
+  ThinkWorkspaceCompatibility,
+  WorkspaceClient,
+  WorkspaceRuntimeClient,
+} from "@cloudflare/computer";
+import type { GitClient } from "@cloudflare/computer/git";
+import { expectTypeOf } from "vitest";
+import { Effect, type Scope } from "effect";
+
+import { ComputerArtifacts, ComputerWorkspace } from "../src/index";
+import {
+  type ComputerWorkspaceHostConfig,
+  withComputerWorkspace,
+} from "../src/ComputerWorkspaceHost";
+
+type MissingFilesystemMethods = Exclude<
+  Exclude<keyof WorkspaceClient["fs"], "db" | "now">,
+  keyof ComputerWorkspace.ComputerWorkspaceFilesystem
+>;
+type MissingGitMethods = Exclude<keyof GitClient, keyof ComputerWorkspace.ComputerWorkspaceGit>;
+type MissingRuntimeMethods = Exclude<
+  keyof WorkspaceRuntimeClient,
+  keyof ComputerWorkspace.ComputerWorkspaceRuntime
+>;
+type MissingThinkMethods = Exclude<
+  keyof ThinkWorkspaceCompatibility,
+  keyof ComputerWorkspace.ComputerWorkspaceThink
+>;
+
+expectTypeOf<MissingFilesystemMethods>().toEqualTypeOf<never>();
+expectTypeOf<MissingGitMethods>().toEqualTypeOf<never>();
+expectTypeOf<MissingRuntimeMethods>().toEqualTypeOf<never>();
+expectTypeOf<MissingThinkMethods>().toEqualTypeOf<never>();
+
+const program = Effect.gen(function* () {
+  const workspace = yield* ComputerWorkspace.ComputerWorkspace;
+
+  expectTypeOf(workspace.readFile("/README.md")).toEqualTypeOf<
+    Effect.Effect<string, ComputerWorkspace.WorkspaceFsError>
+  >();
+  expectTypeOf(
+    workspace.readFile("/archive.bin", { encoding: "stream", byteLength: 1_024 }),
+  ).toEqualTypeOf<Effect.Effect<ReadableStream<Uint8Array>, ComputerWorkspace.WorkspaceFsError>>();
+  expectTypeOf(workspace.git.log({ maxCount: 10 })).toEqualTypeOf<
+    Effect.Effect<
+      ReadonlyArray<ComputerWorkspace.WorkspaceGitCommit>,
+      ComputerWorkspace.WorkspaceGitError
+    >
+  >();
+  expectTypeOf(workspace.git.revParse("HEAD")).toEqualTypeOf<
+    Effect.Effect<string, ComputerWorkspace.WorkspaceGitError>
+  >();
+  expectTypeOf(workspace.git.cli({ argv: ["status"], cwd: "/" })).toEqualTypeOf<
+    Effect.Effect<
+      { stdout: string; stderr: string; exitCode: number },
+      ComputerWorkspace.WorkspaceGitError
+    >
+  >();
+  expectTypeOf(workspace.exec("printf ok")).toEqualTypeOf<
+    Effect.Effect<
+      ComputerWorkspace.WorkspaceExecRun<"utf8">,
+      ComputerWorkspace.WorkspaceExecError,
+      Scope.Scope
+    >
+  >();
+  expectTypeOf(workspace.exec("printf ok", { encoding: "binary" })).toEqualTypeOf<
+    Effect.Effect<
+      ComputerWorkspace.WorkspaceExecRun<"binary">,
+      ComputerWorkspace.WorkspaceExecError,
+      Scope.Scope
+    >
+  >();
+  expectTypeOf(workspace.exec`printf ${"ok"}`).toEqualTypeOf<
+    Effect.Effect<
+      ComputerWorkspace.WorkspaceExecRun<"utf8">,
+      ComputerWorkspace.WorkspaceExecError,
+      Scope.Scope
+    >
+  >();
+  expectTypeOf(workspace.artifacts).toEqualTypeOf<ComputerArtifacts.ComputerArtifactsClient>();
+});
+
+class BaseDurableObject {
+  constructor(
+    readonly state: globalThis.DurableObjectState,
+    readonly env: Cloudflare.Env,
+  ) {}
+}
+
+const WrappedDurableObject = withComputerWorkspace(BaseDurableObject, (_, state, env) => ({
+  storage: state.storage,
+  sessionId: state.id.toString(),
+  gitIdentity: { name: "Agent", email: "agent@example.test" },
+  artifacts: {
+    binding: env.ARTIFACTS as never,
+  },
+}));
+
+expectTypeOf<InstanceType<typeof WrappedDurableObject>>().toMatchTypeOf<BaseDurableObject>();
+expectTypeOf<ComputerWorkspaceHostConfig["artifacts"]>().toEqualTypeOf<
+  | {
+      readonly binding: import("../src/Artifacts").ArtifactsBinding;
+      readonly sessionId?: string;
+    }
+  | undefined
+>();
+
+void program;

--- a/packages/effect-cf/tests/env.d.ts
+++ b/packages/effect-cf/tests/env.d.ts
@@ -7,6 +7,7 @@ declare global {
   namespace Cloudflare {
     interface Env {
       TEST_COUNTER_DO?: DurableObjectNamespace<TestWorkerModule.TestCounterDurableObject>;
+      TEST_COMPUTER_DO?: DurableObjectNamespace<TestWorkerModule.TestComputerWorkspaceDurableObject>;
       TEST_KV?: KVNamespace;
       TEST_DB?: D1Database;
       TEST_SECRET?: SecretsStoreSecret;
@@ -35,7 +36,7 @@ declare global {
 
     interface GlobalProps {
       mainModule: typeof TestWorkerModule;
-      durableNamespaces: "TestCounterDurableObject";
+      durableNamespaces: "TestComputerWorkspaceDurableObject" | "TestCounterDurableObject";
     }
   }
 }

--- a/packages/effect-cf/tests/worker-fixture.ts
+++ b/packages/effect-cf/tests/worker-fixture.ts
@@ -1,12 +1,14 @@
 import { Effect, Layer, Option, Schema as S } from "effect";
 
 import {
+  ComputerWorkspace,
   DurableObjectDefinition,
   DurableObjectState,
   Worker,
   WorkerDefinition,
   Workflow,
 } from "../src/index";
+import { withComputerWorkspace } from "../src/ComputerWorkspaceHost";
 
 export const TestWorkerDefinition = WorkerDefinition.make("TestWorker", {
   parseNumber: WorkerDefinition.method({
@@ -24,6 +26,33 @@ export const TestCounterDefinition = DurableObjectDefinition.make("TestCounter",
     success: S.Number,
   }),
 });
+
+const ComputerWorkspaceResult = S.Struct({
+  text: S.String,
+  bytes: S.Array(S.Number),
+  directoryNames: S.Array(S.String),
+  foundPaths: S.Array(S.String),
+  grepLines: S.Array(S.Number),
+  linkTarget: S.String,
+  commit: S.String,
+  branch: S.String,
+  branches: S.Array(S.String),
+  tags: S.Array(S.String),
+  logMessage: S.String,
+  shownMessage: S.String,
+  files: S.Array(S.String),
+  treePaths: S.Array(S.String),
+  statusPaths: S.Array(S.String),
+  diffContainsUpdate: S.Boolean,
+  configValue: S.String,
+});
+
+export const TestComputerWorkspaceDefinition = DurableObjectDefinition.make(
+  "TestComputerWorkspace",
+  {
+    exercise: DurableObjectDefinition.method({ success: ComputerWorkspaceResult }),
+  },
+);
 
 const CounterValue = S.Struct({ count: S.Number });
 
@@ -91,6 +120,87 @@ const TestCounterLive = TestCounterDefinition.make(Layer.empty, {
 export class TestCounterDurableObject extends TestCounterLive {
   readonly instanceId = crypto.randomUUID();
 }
+
+const TestComputerWorkspaceLive = TestComputerWorkspaceDefinition.make(
+  ComputerWorkspace.ComputerWorkspace.layer,
+  {
+    rpc: {
+      exercise: () =>
+        Effect.gen(function* () {
+          const workspace = yield* ComputerWorkspace.ComputerWorkspace;
+
+          yield* workspace.mkdir("/notes", { recursive: true });
+          yield* workspace.writeFile("/notes/todo.md", "Ship it\nTODO verify\n");
+          yield* workspace.writeFile("/blob.bin", new Uint8Array([1, 2, 3]));
+          yield* workspace.symlink("/notes/todo.md", "/todo-link");
+          yield* workspace.chmod("/notes/todo.md", 0o640);
+
+          const text = yield* workspace.readFile("/notes/todo.md", { byteLength: 7 });
+          const byteStream = yield* workspace.readFile("/blob.bin", { encoding: "stream" });
+          const bytes = yield* Effect.promise(async () =>
+            Array.from(new Uint8Array(await new Response(byteStream).arrayBuffer())),
+          );
+          const directory = yield* workspace.readdir("/");
+          const found = yield* workspace.find("/");
+          const grep = yield* workspace.grep("todo", "/", { ignoreCase: true });
+          const linkTarget = yield* workspace.readlink("/todo-link");
+
+          yield* workspace.git.init({ defaultBranch: "main" });
+          yield* workspace.writeFile("/README.md", "first\n");
+          yield* workspace.git.add({ paths: ["README.md"] });
+          const committed = yield* workspace.git.commit({ message: "initial commit" });
+
+          yield* workspace.git.branch({ name: "feature" });
+          yield* workspace.git.tag({ name: "v1" });
+          yield* workspace.git.configSet({ path: "effect-cf.test", value: "works" });
+
+          const branch = (yield* workspace.git.currentBranch()) ?? "detached";
+          const branches = yield* workspace.git.branchList();
+          const tags = yield* workspace.git.tagList();
+          const log = yield* workspace.git.log({ maxCount: 1 });
+          const shown = yield* workspace.git.show({ ref: "HEAD" });
+          const files = yield* workspace.git.lsFiles();
+          const tree = yield* workspace.git.lsTree({ ref: "HEAD" });
+          const resolved = yield* workspace.git.revParse("HEAD");
+
+          yield* workspace.writeFile("/README.md", "first\nupdated\n");
+          const status = yield* workspace.git.status();
+          const diff = yield* workspace.git.diff();
+          const configValue = yield* workspace.git.configGet({ path: "effect-cf.test" });
+
+          return {
+            text,
+            bytes,
+            directoryNames: directory.map((entry) => entry.name),
+            foundPaths: found.map((entry) => entry.path),
+            grepLines: grep.map((match) => match.line),
+            linkTarget,
+            commit: resolved === committed.oid ? committed.oid : "mismatch",
+            branch,
+            branches,
+            tags,
+            logMessage: log[0]?.message ?? "",
+            shownMessage: shown.message,
+            files,
+            treePaths: tree.map((entry) => entry.path),
+            statusPaths: status.map((entry) => entry.path),
+            diffContainsUpdate: diff.includes("updated"),
+            configValue: Array.isArray(configValue) ? configValue.join(",") : (configValue ?? ""),
+          };
+        }),
+    },
+  },
+);
+
+const TestComputerWorkspaceHost = withComputerWorkspace(TestComputerWorkspaceLive, (_, state) => {
+  return {
+    storage: state.storage,
+    sessionId: state.id.toString(),
+    gitIdentity: { name: "effect-cf", email: "tests@effect-cf.example" },
+  };
+});
+
+export class TestComputerWorkspaceDurableObject extends TestComputerWorkspaceHost {}
 
 export interface TestWorkflowPayload {
   readonly value: string;

--- a/packages/effect-cf/tests/wrangler.jsonc
+++ b/packages/effect-cf/tests/wrangler.jsonc
@@ -38,12 +38,16 @@
         "name": "TEST_COUNTER_DO",
         "class_name": "TestCounterDurableObject",
       },
+      {
+        "name": "TEST_COMPUTER_DO",
+        "class_name": "TestComputerWorkspaceDurableObject",
+      },
     ],
   },
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["TestCounterDurableObject"],
+      "new_sqlite_classes": ["TestCounterDurableObject", "TestComputerWorkspaceDurableObject"],
     },
   ],
 }

--- a/packages/effect-cf/vite.config.ts
+++ b/packages/effect-cf/vite.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
     ],
   },
   pack: {
-    entry: ["src/index.ts", "src/HyperdrivePg.ts", "src/Vitest.ts"],
+    entry: ["src/index.ts", "src/ComputerWorkspaceHost.ts", "src/HyperdrivePg.ts", "src/Vitest.ts"],
     deps: {
       neverBundle: ["cloudflare:test", "cloudflare:workers"],
     },


### PR DESCRIPTION
## Summary

Follows #97 (now merged; this branch is rebased onto it). Upstreams (and extends) the `@cloudflare/computer` Effect integration originally built in a consumer repo, as three new modules:

- **`ComputerWorkspace`** — Effect service wrapping the complete `@cloudflare/computer@0.2.0` `WorkspaceClient` surface: filesystem (reads and writes, stat/exists/readdir/find/grep/rm, symlinks, binary reads), the full Git client (clone/fetch/checkout/branches/tags/log/show/status/diff/lsTree/config/updateRef/revParse/…), runtime exec as `Scope`-owned runs with a `Stream` of stdout/stderr/exit events plus `execCollect`, and the Assets/Artifacts/Think-compatible client surfaces. Typed `Schema.TaggedError`s per operation family, tracing spans, and disposal mapped to Effect `Scope`/`acquireRelease` per the library's stub-disposal contract.
- **`effect-cf/computer-workspace-host`** (separate subpath entry) — `withComputerWorkspace` Durable Object mixin over the library's `withWorkspace`: worker-shell backend wiring (`WorkspaceServiceProxy` re-export, loader/host binding/egress), git identity, backends/mounts/retry/observer configuration, and Artifacts binding pass-through so the in-shell `artifacts` command works.
- **`ComputerArtifacts`** — Effect-native, session-isolated Artifacts repositories wrapping `@cloudflare/computer/artifacts`' `createArtifact` (upstream's session-prefixing is reused, not re-implemented), usable standalone from any Worker holding an Artifacts binding, sharing types with the `Artifacts` module from #97.

Packaging: `@cloudflare/computer` is an **optional peer dependency** (`^0.2.0`). The root bundle references it only via dynamic `import()` — verified in `dist/index.mjs` — so consumers who don't use these modules need not install it. The host mixin lives on its own subpath like `HyperdrivePg`. Workspace Git support additionally needs `@platformatic/vfs` (upstream's own optional peer); documented in the README install notes.

## Validation

- `vp run check` — passed in full (exit 0) on the rebased branch: build, format, lint, typecheck, 44/44 test files, 316 tests passed (3 pre-existing skips in `CloudflareOtlp.test.ts`).
- New coverage: SQLite-backed Workers-pool test running real filesystem + Git operations inside a `withComputerWorkspace` Durable Object (`new_sqlite_classes` migration), node-level unit tests for error mapping and scoping, session-scoped Artifacts tests against the shared `ARTIFACTS` test binding, and type-level tests. Worker-shell **exec** is covered with a fake backend — real worker-shell isolates need a `worker_loaders` binding the vitest pool doesn't provide.
- Verified the built package's root entry contains no static `@cloudflare/computer` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)