### PR TITLE
fix(effect-cf)!: isolate optional Computer entrypoints

### DIFF
--- a/.changeset/clean-optional-computers.md
+++ b/.changeset/clean-optional-computers.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": major
+---
+
+Keep the optional `@cloudflare/computer` integration out of the root bundle so Durable Object and other unrelated consumers can bundle `effect-cf` without installing or externalizing that peer. The synchronous root namespaces could not be preserved without making esbuild resolve the optional dependency before tree-shaking, so update `ComputerWorkspace` imports to `effect-cf/computer-workspace` and `ComputerArtifacts` imports to `effect-cf/computer-artifacts`; `effect-cf/computer-workspace-host` remains unchanged.

--- a/bun.lock
+++ b/bun.lock
@@ -303,6 +303,7 @@
         "@effect/vitest": "catalog:",
         "@platformatic/vfs": "^0.4.0",
         "effect": "catalog:",
+        "esbuild": "^0.28.1",
         "vite-plus": "catalog:",
         "vitest": "catalog:",
       },

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -19,8 +19,8 @@ npm install effect-cf "effect@^4.0.0-beta.105"
 ```
 
 The Computer workspace integration is an optional peer. Install it only in
-applications that import `ComputerWorkspace`, `ComputerArtifacts`, or
-`effect-cf/computer-workspace-host`:
+applications that import `effect-cf/computer-workspace`,
+`effect-cf/computer-artifacts`, or `effect-cf/computer-workspace-host`:
 
 ```bash
 bun add "@cloudflare/computer@^0.2.0"
@@ -51,8 +51,8 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `D1` - typed D1 database binding helper with an `@effect/sql-d1` backed SQL layer
 - `R2` - typed R2 bucket binding helper with Effect-wrapped object and multipart operations
 - `Artifacts` - typed Cloudflare Artifacts namespace and repository helpers, including repository lifecycle, tokens, and Git object reads
-- `ComputerWorkspace` - scoped Effect wrappers for the complete Cloudflare Computer filesystem, Git, runtime, Assets, Artifacts, and Think-compatible client surfaces
-- `ComputerArtifacts` - session-isolated Artifacts repositories backed by `@cloudflare/computer/artifacts`
+- `effect-cf/computer-workspace` - scoped Effect wrappers for the complete Cloudflare Computer filesystem, Git, runtime, Assets, Artifacts, and Think-compatible client surfaces
+- `effect-cf/computer-artifacts` - session-isolated Artifacts repositories backed by `@cloudflare/computer/artifacts`
 - `effect-cf/computer-workspace-host` - optional Durable Object host mixin, worker-shell backend wiring, and `WorkspaceServiceProxy`
 - `Hyperdrive` - typed Hyperdrive binding helper for connection strings and optional Postgres SQL integration
 - `Images` - typed Cloudflare Images binding helper with transformation APIs and optional hosted image operations
@@ -473,7 +473,8 @@ scope closes. The host mixin is a separate optional-dependency entrypoint:
 ```ts
 import shellCurl from "@cloudflare/computer/shell/curl";
 import { Effect, Schema as S } from "effect";
-import { ComputerWorkspace, DurableObjectDefinition } from "effect-cf";
+import { DurableObjectDefinition } from "effect-cf";
+import * as ComputerWorkspace from "effect-cf/computer-workspace";
 import { withComputerWorkspace, WorkspaceServiceProxy } from "effect-cf/computer-workspace-host";
 
 export { WorkspaceServiceProxy };
@@ -561,7 +562,8 @@ Workers can use that session isolation without a Durable Object or workspace:
 
 ```ts
 import { Effect } from "effect";
-import { Artifacts, ComputerArtifacts } from "effect-cf";
+import { Artifacts } from "effect-cf";
+import * as ComputerArtifacts from "effect-cf/computer-artifacts";
 
 export const createSessionRepo = (binding: Artifacts.ArtifactsBinding, sessionId: string) =>
   Effect.gen(function* () {

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -27,6 +27,16 @@
       "import": "./dist/HyperdrivePg.mjs",
       "default": "./dist/HyperdrivePg.mjs"
     },
+    "./computer-artifacts": {
+      "types": "./dist/ComputerArtifacts.d.mts",
+      "import": "./dist/ComputerArtifacts.mjs",
+      "default": "./dist/ComputerArtifacts.mjs"
+    },
+    "./computer-workspace": {
+      "types": "./dist/ComputerWorkspace.d.mts",
+      "import": "./dist/ComputerWorkspace.mjs",
+      "default": "./dist/ComputerWorkspace.mjs"
+    },
     "./computer-workspace-host": {
       "types": "./dist/ComputerWorkspaceHost.d.mts",
       "import": "./dist/ComputerWorkspaceHost.mjs",
@@ -61,6 +71,7 @@
     "@effect/vitest": "catalog:",
     "@platformatic/vfs": "^0.4.0",
     "effect": "catalog:",
+    "esbuild": "^0.28.1",
     "vite-plus": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -5,8 +5,6 @@ export * as Binding from "./Binding";
 export * as BrowserRendering from "./BrowserRendering";
 export * as Cache from "./Cache";
 export * as CloudflareOtlp from "./CloudflareOtlp";
-export * as ComputerArtifacts from "./ComputerArtifacts";
-export * as ComputerWorkspace from "./ComputerWorkspace";
 export * as ContainerNamespace from "./ContainerNamespace";
 export * as D1 from "./D1";
 export * as DurableObject from "./DurableObject";

--- a/packages/effect-cf/tests/ComputerArtifacts.test.ts
+++ b/packages/effect-cf/tests/ComputerArtifacts.test.ts
@@ -1,7 +1,8 @@
 import { assert, it } from "@effect/vitest";
 import { Effect } from "effect";
 
-import { Artifacts, ComputerArtifacts } from "../src/index";
+import * as ComputerArtifacts from "../src/ComputerArtifacts";
+import { Artifacts } from "../src/index";
 
 const repoInfo = (name: string): Artifacts.ArtifactsRepoInfo => ({
   id: `${name}-id`,

--- a/packages/effect-cf/tests/ComputerWorkspace.test.ts
+++ b/packages/effect-cf/tests/ComputerWorkspace.test.ts
@@ -7,7 +7,7 @@ import type { ArtifactClient } from "@cloudflare/computer/artifacts";
 import { assert, it } from "@effect/vitest";
 import { Effect, Stream } from "effect";
 
-import { ComputerWorkspace } from "../src/index";
+import * as ComputerWorkspace from "../src/ComputerWorkspace";
 
 const emptyArtifacts = {
   sessionId: "test-session",

--- a/packages/effect-cf/tests/Packaging.test.ts
+++ b/packages/effect-cf/tests/Packaging.test.ts
@@ -1,0 +1,25 @@
+import { build, type Plugin } from "esbuild";
+import { expect, test } from "vitest";
+
+const rejectCloudflareComputer: Plugin = {
+  name: "reject-cloudflare-computer",
+  setup(build) {
+    build.onResolve({ filter: /^@cloudflare\/computer(?:\/.*)?$/ }, (args) => ({
+      errors: [{ text: `unexpected optional peer import: ${args.path}` }],
+    }));
+  },
+};
+
+test("the root package bundles Durable Object consumers without Cloudflare Computer", async () => {
+  const result = await build({
+    entryPoints: [new URL("./fixtures/durable-object-consumer.ts", import.meta.url).pathname],
+    bundle: true,
+    external: ["cloudflare:*"],
+    format: "esm",
+    platform: "browser",
+    plugins: [rejectCloudflareComputer],
+    write: false,
+  });
+
+  expect(result.outputFiles).toHaveLength(1);
+});

--- a/packages/effect-cf/tests/computer-workspace.test-d.ts
+++ b/packages/effect-cf/tests/computer-workspace.test-d.ts
@@ -7,7 +7,8 @@ import type { GitClient } from "@cloudflare/computer/git";
 import { expectTypeOf } from "vitest";
 import { Effect, type Scope } from "effect";
 
-import { ComputerArtifacts, ComputerWorkspace } from "../src/index";
+import * as ComputerArtifacts from "effect-cf/computer-artifacts";
+import * as ComputerWorkspace from "effect-cf/computer-workspace";
 import {
   type ComputerWorkspaceHostConfig,
   withComputerWorkspace,

--- a/packages/effect-cf/tests/fixtures/durable-object-consumer.ts
+++ b/packages/effect-cf/tests/fixtures/durable-object-consumer.ts
@@ -1,0 +1,4 @@
+import { Layer } from "effect";
+import { DurableObject } from "effect-cf";
+
+export const ExampleDurableObject = DurableObject.make(Layer.empty, {});

--- a/packages/effect-cf/tests/worker-fixture.ts
+++ b/packages/effect-cf/tests/worker-fixture.ts
@@ -1,7 +1,7 @@
 import { Effect, Layer, Option, Schema as S } from "effect";
 
+import * as ComputerWorkspace from "../src/ComputerWorkspace";
 import {
-  ComputerWorkspace,
   DurableObjectDefinition,
   DurableObjectState,
   Worker,

--- a/packages/effect-cf/vite.config.ts
+++ b/packages/effect-cf/vite.config.ts
@@ -53,7 +53,14 @@ export default defineConfig({
     ],
   },
   pack: {
-    entry: ["src/index.ts", "src/ComputerWorkspaceHost.ts", "src/HyperdrivePg.ts", "src/Vitest.ts"],
+    entry: [
+      "src/index.ts",
+      "src/ComputerArtifacts.ts",
+      "src/ComputerWorkspace.ts",
+      "src/ComputerWorkspaceHost.ts",
+      "src/HyperdrivePg.ts",
+      "src/Vitest.ts",
+    ],
     deps: {
       neverBundle: ["cloudflare:test", "cloudflare:workers"],
     },


### PR DESCRIPTION
## Summary

- Keep `@cloudflare/computer` out of the root `effect-cf` JavaScript and declaration graphs so Durable Object consumers bundle without installing or externalizing the optional peer.
- Publish Computer integrations through `effect-cf/computer-workspace` and `effect-cf/computer-artifacts`; the existing `effect-cf/computer-workspace-host` path is unchanged.
- Document the root-import migration and include a major changeset because preserving the synchronous root namespaces would retain pre-tree-shaking optional-peer resolution.

## Validation

- `vp run check` — passed: 45 test files, 317 tests passed, 3 skipped; 5 existing lint warnings and no errors.
- `vp test packages/effect-cf/tests/Packaging.test.ts packages/effect-cf/tests/ComputerArtifacts.test.ts packages/effect-cf/tests/ComputerWorkspace.test.ts` — passed: 5 tests.
- Removed the local `@cloudflare/computer` package link and bundled the Durable Object fixture with esbuild and no Computer externals — passed; produced a 789.4 kB bundle.