### PR TITLE
fix(release): keep effect-cf on pre-1.0 line

### DIFF
--- a/.changeset/clean-optional-computers.md
+++ b/.changeset/clean-optional-computers.md
@@ -1,5 +1,5 @@
 ---
-"effect-cf": major
+"effect-cf": minor
 ---
 
 Keep the optional `@cloudflare/computer` integration out of the root bundle so Durable Object and other unrelated consumers can bundle `effect-cf` without installing or externalizing that peer. The synchronous root namespaces could not be preserved without making esbuild resolve the optional dependency before tree-shaking, so update `ComputerWorkspace` imports to `effect-cf/computer-workspace` and `ComputerArtifacts` imports to `effect-cf/computer-artifacts`; `effect-cf/computer-workspace-host` remains unchanged.


### PR DESCRIPTION
## Summary

- Change the optional Computer packaging changeset from `major` to `minor` so the release remains on the pre-1.0 line.
- Refresh the Version Packages PR from `effect-cf@1.0.0` to `effect-cf@0.27.0` after this correction merges.

## Validation

- `vp exec changeset status` — reports `effect-cf` at minor and no packages at major.
- `vp fmt --check .changeset/clean-optional-computers.md` — passed.
- Tests skipped because this changes only Changesets release metadata.