### PR TITLE
fix(effect-cf): align Artifacts and Workflow runtime boundaries

### DIFF
--- a/.changeset/add-non-retryable-workflow-steps.md
+++ b/.changeset/add-non-retryable-workflow-steps.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Allow workflow step Effects to fail terminally with `WorkflowStepNonRetryableError`, which is rethrown to Cloudflare as its native `NonRetryableError`.

--- a/.changeset/fix-remote-artifacts-repos.md
+++ b/.changeset/fix-remote-artifacts-repos.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Support method-only remote Artifacts repository bindings with a typed `info()` client operation and live commit history shapes.

--- a/packages/effect-cf/src/Artifacts.ts
+++ b/packages/effect-cf/src/Artifacts.ts
@@ -6,7 +6,7 @@ import type {
   ArtifactsTokenInfo as CloudflareArtifactsTokenInfo,
   ArtifactsTokenListResult as CloudflareArtifactsTokenListResult,
 } from "@cloudflare/workers-types";
-import { Context, Data, Effect, type Layer, Predicate } from "effect";
+import { Context, Data, Effect, type Layer, Predicate, Schema } from "effect";
 
 import * as Binding from "./Binding";
 import type { WorkerEnvironment } from "./Environment";
@@ -31,6 +31,7 @@ export type ArtifactsOperation =
   | "getToken"
   | "revokeToken"
   | "fork"
+  | "info"
   | "log"
   | "readCommit"
   | "readTree"
@@ -136,25 +137,28 @@ export type ArtifactsTokenInfo = CloudflareArtifactsTokenInfo;
 /** Repository token list result. */
 export type ArtifactsTokenListResult = CloudflareArtifactsTokenListResult;
 
-/**
- * Commit history returned by `log()`.
- *
- * Cloudflare currently documents this generated type by name but does not
- * publish its fields in the binding reference or Workers type declarations.
- */
-export interface ArtifactsLogResult<Field = unknown> {
-  readonly [field: string]: Field;
+/** Identity recorded for a Git commit author or committer. */
+export interface ArtifactsCommitIdentity {
+  readonly name: string;
+  readonly email: string;
 }
 
-/**
- * Parsed Git commit returned by `readCommit()`.
- *
- * Cloudflare currently documents this generated type by name but does not
- * publish its fields in the binding reference or Workers type declarations.
- */
-export interface ArtifactsCommit<Field = unknown> {
-  readonly [field: string]: Field;
+/** Parsed Git commit returned by `readCommit()` and `log()`. */
+export interface ArtifactsCommit {
+  readonly hash: string;
+  readonly treeHash: string;
+  readonly message: string;
+  readonly author: ArtifactsCommitIdentity;
+  readonly committer: ArtifactsCommitIdentity;
+  readonly parents: ReadonlyArray<string>;
+  /** Unix timestamp in seconds. */
+  readonly authoredAt: number;
+  /** Unix timestamp in seconds. */
+  readonly committedAt: number;
 }
+
+/** Bare commit array returned by `log()`. */
+export type ArtifactsLogResult = ReadonlyArray<ArtifactsCommit>;
 
 /**
  * Parsed Git tree returned by `readTree()`.
@@ -228,7 +232,15 @@ export interface ArtifactsLogOptions {
 }
 
 /** Runtime repository handle, including methods absent from current shipped Workers types. */
-export interface ArtifactsRepoBinding extends ArtifactsRepoInfo {
+export interface ArtifactsRepoBinding extends Partial<ArtifactsRepoInfo> {
+  /**
+   * Read repository metadata.
+   *
+   * Remote bindings expose method-only RPC handles and provide metadata only
+   * through this method. It is optional solely for compatibility with older
+   * local handles that expose metadata as data properties.
+   */
+  readonly info?: () => Promise<ArtifactsRepoInfo>;
   /**
    * Create a Git token for the repository.
    *
@@ -262,8 +274,15 @@ export interface ArtifactsBinding {
   readonly delete: (name: RepoName) => Promise<boolean>;
 }
 
-/** Effect wrapper around a repository handle returned by `Artifacts.get()`. */
+/**
+ * Effect wrapper around a repository handle returned by `Artifacts.get()`.
+ *
+ * The inherited metadata is the snapshot read while resolving the client.
+ * Use `info()` to refresh it from the repository handle.
+ */
 export interface ArtifactsRepoClient extends ArtifactsRepoInfo {
+  /** Read and validate the repository's current metadata. */
+  readonly info: () => Effect.Effect<ArtifactsRepoInfo, ArtifactsOperationError>;
   /**
    * Create a Git token for the repository.
    *
@@ -378,8 +397,48 @@ const spanOptions = (binding: string, operation: ArtifactsOperation) => ({
   attributes: { binding, operation },
 });
 
-const hasFunction = <Candidate>(value: Candidate, key: string): boolean =>
+const hasFunction = <Candidate, Key extends string>(
+  value: Candidate,
+  key: Key,
+): value is Candidate & Record<Key, (...args: ReadonlyArray<any>) => any> =>
   Predicate.hasProperty(value, key) && Predicate.isFunction(value[key]);
+
+const ArtifactsRepoInfoSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  description: Schema.NullOr(Schema.String),
+  defaultBranch: Schema.String,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+  lastPushAt: Schema.NullOr(Schema.String),
+  source: Schema.NullOr(Schema.String),
+  readOnly: Schema.Boolean,
+  remote: Schema.String,
+});
+
+const decodeRepoInfo = (
+  binding: string,
+  value: ArtifactsRepoInfo | ArtifactsRepoBinding,
+): Effect.Effect<ArtifactsRepoInfo, ArtifactsOperationError> =>
+  Schema.decodeUnknownEffect(ArtifactsRepoInfoSchema)(value).pipe(
+    Effect.mapError((cause) => artifactsError(binding, "info", cause)),
+  );
+
+const readRepoInfo = (
+  binding: string,
+  repo: ArtifactsRepoBinding,
+): Effect.Effect<ArtifactsRepoInfo, ArtifactsOperationError> => {
+  if (hasFunction(repo, "info")) {
+    return tryArtifactsPromise(binding, "info", () => repo.info()).pipe(
+      Effect.flatMap((info) => decodeRepoInfo(binding, info)),
+      Effect.withSpan("Artifacts.info", spanOptions(binding, "info")),
+    );
+  }
+
+  return decodeRepoInfo(binding, repo).pipe(
+    Effect.withSpan("Artifacts.info", spanOptions(binding, "info")),
+  );
+};
 
 /** Tests whether a value exposes the complete documented Artifacts repo handle API. */
 export const isArtifactsRepoBinding = <Candidate>(
@@ -403,17 +462,13 @@ export const isArtifactsBinding = <Candidate>(
   hasFunction(value, "list") &&
   hasFunction(value, "delete");
 
-const wrapRepo = (binding: string, repo: ArtifactsRepoBinding): ArtifactsRepoClient => ({
-  id: repo.id,
-  name: repo.name,
-  description: repo.description,
-  defaultBranch: repo.defaultBranch,
-  createdAt: repo.createdAt,
-  updatedAt: repo.updatedAt,
-  lastPushAt: repo.lastPushAt,
-  source: repo.source,
-  readOnly: repo.readOnly,
-  remote: repo.remote,
+const wrapRepo = (
+  binding: string,
+  repo: ArtifactsRepoBinding,
+  info: ArtifactsRepoInfo,
+): ArtifactsRepoClient => ({
+  ...info,
+  info: () => readRepoInfo(binding, repo),
   createToken: Effect.fn(
     "Artifacts.createToken",
     spanOptions(binding, "createToken"),
@@ -469,7 +524,9 @@ export const makeClient =
       tryArtifactsPromise(definition.binding, "get", () => artifacts.get(name)).pipe(
         Effect.flatMap((repo) =>
           isArtifactsRepoBinding(repo)
-            ? Effect.succeed(wrapRepo(definition.binding, repo))
+            ? readRepoInfo(definition.binding, repo).pipe(
+                Effect.map((info) => wrapRepo(definition.binding, repo, info)),
+              )
             : Effect.fail(
                 artifactsError(
                   definition.binding,

--- a/packages/effect-cf/src/Workflow.ts
+++ b/packages/effect-cf/src/Workflow.ts
@@ -12,7 +12,17 @@ import {
   type WorkflowStepEvent,
   type WorkflowTimeoutDuration,
 } from "cloudflare:workers";
-import { Context, Data, Effect, Layer, type ManagedRuntime, type Scope } from "effect";
+import { NonRetryableError as CloudflareNonRetryableError } from "cloudflare:workflows";
+import {
+  Cause,
+  Context,
+  Data,
+  Effect,
+  Layer,
+  type ManagedRuntime,
+  Option,
+  type Scope,
+} from "effect";
 
 import { WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { ExecutionContext, WorkerContext } from "./Worker";
@@ -46,6 +56,22 @@ export class WorkflowStepError extends Data.TaggedError("WorkflowStepError")<{
     const step = this.step === undefined ? "" : ` in step "${this.step}"`;
 
     return `Workflow ${this.operation} failed${step}: ${ErrorMessage.causeMessage(this.cause)}`;
+  }
+}
+
+/**
+ * Typed step failure that Cloudflare must treat as terminal instead of retrying.
+ *
+ * The workflow boundary converts this value into Cloudflare's native
+ * `NonRetryableError` while preserving the original cause and its message.
+ */
+export class WorkflowStepNonRetryableError extends Data.TaggedError(
+  "WorkflowStepNonRetryableError",
+)<{
+  readonly cause: unknown;
+}> {
+  override get message(): string {
+    return `Workflow step failed without retry: ${ErrorMessage.causeMessage(this.cause)}`;
   }
 }
 
@@ -93,6 +119,27 @@ const fromWorkflowEvent = <Payload>(
   workflowName: event.workflowName,
 });
 
+const toCloudflareNonRetryableError = (
+  error: WorkflowStepNonRetryableError,
+): CloudflareNonRetryableError => {
+  const cloudflareError = new CloudflareNonRetryableError(error.message);
+
+  cloudflareError.cause = error.cause;
+
+  return cloudflareError;
+};
+
+const exposeCloudflareNonRetryableError = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.catchCause(effect, (cause) => {
+    const error = Cause.findErrorOption(cause);
+
+    return Option.isSome(error) && error.value instanceof WorkflowStepNonRetryableError
+      ? Effect.die(toCloudflareNonRetryableError(error.value))
+      : Effect.failCause(cause);
+  });
+
 const fromWorkflowStep = (
   step: CloudflareWorkflowStep,
   runPromise: RunWorkflowStepEffect,
@@ -105,15 +152,17 @@ const fromWorkflowStep = (
           try: () => {
             const run = (stepContext: CloudflareWorkflowStepContext) =>
               runPromise(
-                Effect.scoped(
-                  Effect.provideService(
-                    Effect.provideContext(
-                      // SAFETY: WorkflowStepContext is provided immediately below; context supplies every other R service.
-                      effect as Effect.Effect<A, E, Exclude<R, WorkflowStepContext>>,
-                      context,
+                exposeCloudflareNonRetryableError(
+                  Effect.scoped(
+                    Effect.provideService(
+                      Effect.provideContext(
+                        // SAFETY: WorkflowStepContext is provided immediately below; context supplies every other R service.
+                        effect as Effect.Effect<A, E, Exclude<R, WorkflowStepContext>>,
+                        context,
+                      ),
+                      WorkflowStepContext,
+                      stepContext,
                     ),
-                    WorkflowStepContext,
-                    stepContext,
                   ),
                 ),
               );

--- a/packages/effect-cf/tests/Artifacts.test.ts
+++ b/packages/effect-cf/tests/Artifacts.test.ts
@@ -46,6 +46,7 @@ interface Calls {
   readonly listTokens: Array<true>;
   readonly revokeToken: Array<string>;
   readonly fork: Array<readonly [Artifacts.RepoName, Artifacts.ArtifactsForkOptions | undefined]>;
+  readonly info: Array<true>;
   readonly log: Array<Artifacts.ArtifactsLogOptions | undefined>;
   readonly readCommit: Array<string>;
   readonly readTree: Array<string>;
@@ -61,9 +62,21 @@ const makeCalls = (): Calls => ({
   listTokens: [],
   revokeToken: [],
   fork: [],
+  info: [],
   log: [],
   readCommit: [],
   readTree: [],
+});
+
+const commitInfo = (hash: string): Artifacts.ArtifactsCommit => ({
+  hash,
+  treeHash: "tree-1",
+  message: "Initial commit",
+  author: { name: "Ada", email: "ada@example.com" },
+  committer: { name: "Grace", email: "grace@example.com" },
+  parents: [],
+  authoredAt: 1_776_211_200,
+  committedAt: 1_776_211_260,
 });
 
 const makeRepo = (calls: Calls): Artifacts.ArtifactsRepoBinding => ({
@@ -107,12 +120,12 @@ const makeRepo = (calls: Calls): Artifacts.ArtifactsRepoBinding => ({
   log: async (options) => {
     calls.log.push(options);
 
-    return { commits: ["commit-1"] };
+    return [commitInfo("commit-1")];
   },
   readCommit: async (hash) => {
     calls.readCommit.push(hash);
 
-    return { hash, tree: "tree-1" };
+    return commitInfo(hash);
   },
   readTree: async (hash) => {
     calls.readTree.push(hash);
@@ -120,6 +133,25 @@ const makeRepo = (calls: Calls): Artifacts.ArtifactsRepoBinding => ({
     return { hash, entries: [{ name: "README.md", type: "blob" }] };
   },
 });
+
+const makeRemoteRepo = (calls: Calls): Artifacts.ArtifactsRepoBinding => {
+  const local = makeRepo(calls);
+
+  return {
+    info: async () => {
+      calls.info.push(true);
+
+      return repoInfo;
+    },
+    createToken: local.createToken,
+    listTokens: local.listTokens,
+    revokeToken: local.revokeToken,
+    fork: local.fork,
+    log: local.log,
+    readCommit: local.readCommit,
+    readTree: local.readTree,
+  };
+};
 
 const makeArtifacts = (calls: Calls): Artifacts.ArtifactsBinding => {
   const repo = makeRepo(calls);
@@ -245,6 +277,7 @@ const artifactsLayer = (artifacts: Artifacts.ArtifactsBinding) =>
       Effect.gen(function* () {
         const artifacts = yield* TestArtifacts;
         const repo = yield* artifacts.get("starter-repo");
+        const info = yield* repo.info();
         const token = yield* repo.createToken("read", 3600);
         const tokens = yield* repo.listTokens;
         const revoked = yield* repo.revokeToken("token-1");
@@ -258,6 +291,7 @@ const artifactsLayer = (artifacts: Artifacts.ArtifactsBinding) =>
         const tree = yield* repo.readTree("tree-1");
 
         assert.strictEqual(repo.raw.name, "starter-repo");
+        assert.deepStrictEqual(info, repoInfo);
         assert.deepStrictEqual(token, {
           id: "token-1",
           plaintext: "art_v1_token?expires=1786752000",
@@ -268,8 +302,17 @@ const artifactsLayer = (artifacts: Artifacts.ArtifactsBinding) =>
         assert.strictEqual(tokens.tokens[0]?.state, "active");
         assert.strictEqual(revoked, true);
         assert.strictEqual(forked.name, "starter-repo-copy");
-        assert.deepStrictEqual(history, { commits: ["commit-1"] });
-        assert.deepStrictEqual(commit, { hash: "commit-1", tree: "tree-1" });
+        assert.deepStrictEqual(history, [commitInfo("commit-1")]);
+        assert.deepStrictEqual(commit, {
+          hash: "commit-1",
+          treeHash: "tree-1",
+          message: "Initial commit",
+          author: { name: "Ada", email: "ada@example.com" },
+          committer: { name: "Grace", email: "grace@example.com" },
+          parents: [],
+          authoredAt: 1_776_211_200,
+          committedAt: 1_776_211_260,
+        });
         assert.deepStrictEqual(tree, {
           hash: "tree-1",
           entries: [{ name: "README.md", type: "blob" }],
@@ -294,6 +337,30 @@ const artifactsLayer = (artifacts: Artifacts.ArtifactsBinding) =>
     );
   });
 }
+
+test("Artifacts supports method-only remote repository handles", async () => {
+  const calls = makeCalls();
+  const artifacts = {
+    ...makeArtifacts(calls),
+    get: async () => makeRemoteRepo(calls),
+  } satisfies Artifacts.ArtifactsBinding;
+
+  const [repo, refreshed] = await Effect.runPromise(
+    Effect.gen(function* () {
+      const client = yield* TestArtifacts;
+      const repo = yield* client.get("starter-repo");
+      const refreshed = yield* repo.info();
+
+      return [repo, refreshed] as const;
+    }).pipe(Effect.provide(artifactsLayer(artifacts))),
+  );
+
+  assert.strictEqual(repo.name, "starter-repo");
+  assert.strictEqual(repo.remote, repoInfo.remote);
+  assert.deepStrictEqual(refreshed, repoInfo);
+  assert.deepStrictEqual(calls.info, [true, true]);
+  assert.notProperty(repo.raw, "name");
+});
 
 test("Artifacts layer validates the namespace binding shape", async () => {
   await expect(

--- a/packages/effect-cf/tests/Workflow.test.ts
+++ b/packages/effect-cf/tests/Workflow.test.ts
@@ -1,9 +1,12 @@
 import type {
   WorkflowEvent as CloudflareWorkflowEvent,
   WorkflowStep as CloudflareWorkflowStep,
+  WorkflowStepConfig,
+  WorkflowStepContext as CloudflareWorkflowStepContext,
 } from "cloudflare:workers";
+import { NonRetryableError } from "cloudflare:workflows";
 import { assert, test } from "@effect/vitest";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Predicate } from "effect";
 
 import { Workflow } from "../src/index";
 import { makePartialTestDouble } from "./TestDoubles";
@@ -20,17 +23,47 @@ const makeEvent = (): Readonly<CloudflareWorkflowEvent<undefined>> => ({
   workflowName: "TestWorkflow",
 });
 
-test("failing steps surface WorkflowStepError with step, operation, and cause", async () => {
-  const cause = new Error("step failed");
-  const step = makePartialTestDouble<CloudflareWorkflowStep>({
-    do: async () => {
-      throw cause;
+type FakeStepCallback = (context: CloudflareWorkflowStepContext) => Promise<never>;
+
+const makeExecutingStep = (onReject?: (cause: Error) => void): CloudflareWorkflowStep => {
+  const implementation = {
+    do: async (
+      name: string,
+      callbackOrConfig: WorkflowStepConfig | FakeStepCallback,
+      maybeCallback?: FakeStepCallback,
+    ) => {
+      const callback = maybeCallback ?? callbackOrConfig;
+
+      if (!Predicate.isFunction(callback)) {
+        throw new Error("Expected a workflow step callback");
+      }
+
+      try {
+        return await callback({
+          step: { name, count: 1 },
+          attempt: 1,
+          config: Predicate.isFunction(callbackOrConfig) ? {} : callbackOrConfig,
+        });
+      } catch (cause) {
+        if (cause instanceof Error) onReject?.(cause);
+
+        throw cause;
+      }
     },
     sleep: async () => undefined,
     sleepUntil: async () => undefined,
-  });
+  };
+
+  // SAFETY: This fixture implements the callback overloads exercised by these tests;
+  // Cloudflare's additional rollback arguments are not used by effect-cf.
+  return implementation as typeof implementation & CloudflareWorkflowStep;
+};
+
+test("failing steps surface WorkflowStepError with step, operation, and cause", async () => {
+  const cause = new Error("step failed");
+  const step = makeExecutingStep();
   const Live = Workflow.make(Layer.empty, {
-    run: () => Effect.flip(Workflow.step("explode", Effect.void)),
+    run: () => Effect.flip(Workflow.step("explode", Effect.fail(cause))),
   });
   const workflow = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
 
@@ -40,6 +73,34 @@ test("failing steps surface WorkflowStepError with step, operation, and cause", 
   assert.strictEqual(error.step, "explode");
   assert.strictEqual(error.operation, "do");
   assert.strictEqual(error.cause, cause);
+});
+
+test("non-retryable Effect failures reach Cloudflare as NonRetryableError", async () => {
+  const cause = new Error("repository source is invalid");
+  let boundaryError: Error | undefined;
+  const step = makeExecutingStep((error) => {
+    boundaryError = error;
+  });
+  const Live = Workflow.make(Layer.empty, {
+    run: () =>
+      Effect.flip(
+        Workflow.step(
+          "validate source",
+          Effect.fail(new Workflow.WorkflowStepNonRetryableError({ cause })),
+        ),
+      ),
+  });
+  const workflow = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+
+  const error = await workflow.run(makeEvent(), step);
+
+  assert.instanceOf(boundaryError, NonRetryableError);
+  assert.strictEqual(boundaryError.cause, cause);
+  assert.match(boundaryError.message, /repository source is invalid/);
+  assert.instanceOf(error, Workflow.WorkflowStepError);
+  assert.strictEqual(error.step, "validate source");
+  assert.strictEqual(error.operation, "do");
+  assert.strictEqual(error.cause, boundaryError);
 });
 
 test("failing sleeps surface WorkflowStepError with the sleep operation", async () => {

--- a/packages/effect-cf/tests/binding-ergonomics.test-d.ts
+++ b/packages/effect-cf/tests/binding-ergonomics.test-d.ts
@@ -125,6 +125,9 @@ const artifactsProgram = Effect.gen(function* () {
   const repo = yield* artifacts.get("agent-workspace");
 
   expectTypeOf(repo).toEqualTypeOf<Artifacts.ArtifactsRepoClient>();
+  expectTypeOf(repo.info()).toEqualTypeOf<
+    Effect.Effect<Artifacts.ArtifactsRepoInfo, Artifacts.ArtifactsOperationError>
+  >();
   expectTypeOf(repo.createToken("read", 3600)).toEqualTypeOf<
     Effect.Effect<Artifacts.ArtifactsCreateTokenResult, Artifacts.ArtifactsOperationError>
   >();

--- a/packages/effect-cf/tests/cloudflare-workflows.ts
+++ b/packages/effect-cf/tests/cloudflare-workflows.ts
@@ -1,0 +1,6 @@
+export class NonRetryableError extends Error {
+  constructor(message: string, name = "NonRetryableError") {
+    super(message);
+    this.name = name;
+  }
+}

--- a/packages/effect-cf/vite.config.ts
+++ b/packages/effect-cf/vite.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
         test: {
           name: "node",
           alias: {
+            "cloudflare:workflows": new URL("./tests/cloudflare-workflows.ts", import.meta.url)
+              .pathname,
             "cloudflare:workers": new URL("./tests/cloudflare-workers.ts", import.meta.url)
               .pathname,
           },
@@ -62,7 +64,7 @@ export default defineConfig({
       "src/Vitest.ts",
     ],
     deps: {
-      neverBundle: ["cloudflare:test", "cloudflare:workers"],
+      neverBundle: ["cloudflare:test", "cloudflare:workers", "cloudflare:workflows"],
     },
     dts: {
       tsgo: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,6 +53,10 @@ export default defineConfig({
         test: {
           name: "node",
           alias: {
+            "cloudflare:workflows": new URL(
+              "./packages/effect-cf/tests/cloudflare-workflows.ts",
+              import.meta.url,
+            ).pathname,
             "cloudflare:workers": new URL(
               "./packages/effect-cf/tests/cloudflare-workers.ts",
               import.meta.url,


### PR DESCRIPTION
## Summary

- Make [`ArtifactsRepoClient`](https://github.com/danieljvdm/effect-cf/blob/ac1ec9b/packages/effect-cf/src/Artifacts.ts#L277-L307) work with method-only remote RPC handles by resolving and validating metadata through `repo.info()`, while retaining a local plain-object fallback.
- Match the live Artifacts commit contract: `log()` returns a bare commit array and commits expose `treeHash` plus typed author, committer, parent, and Unix timestamp fields.
- Add [`WorkflowStepNonRetryableError`](https://github.com/danieljvdm/effect-cf/blob/69e66c1/packages/effect-cf/src/Workflow.ts#L62-L76) and convert it at the [`step.do` promise boundary](https://github.com/danieljvdm/effect-cf/blob/69e66c1/packages/effect-cf/src/Workflow.ts#L122-L168) into Cloudflare native `NonRetryableError`, preserving the original cause and message.

## What went wrong

Remote Artifacts repository handles are workerd RPC stubs with methods but no metadata data properties. The client copied fields such as `repo.name` eagerly, so the copied values were phantom RPC methods rather than strings. The real service instead exposes metadata through `repo.info()`. The published commit types also described unknown object shapes, while the service returns bare commit arrays and `treeHash`.

Workflow step Effects were executed through `runPromise`. A typed Effect failure therefore crossed into `step.do` as an Effect rejection rather than the native `NonRetryableError` instance that Cloudflare checks to stop retries. Consumers could not express terminal step failures without encoding them as successful values.

## Architecture

- `Artifacts.get()` now resolves one validated metadata snapshot before constructing the client. The existing synchronous metadata fields remain available for compatibility, and `client.info()` refreshes them through the remote method when present.
- The Workflow adapter inspects the typed failure cause immediately before promise interop. Only `WorkflowStepNonRetryableError` becomes a native Cloudflare terminal error; all other causes retain the existing `WorkflowStepError` path.

## Validation

- `vp run check`
- 45 test files passed; 320 tests passed and 3 skipped.
- Added a method-only Artifacts fake with no metadata properties and a Workflow fake that executes the callback and verifies the exact rejection observed by Cloudflare.