### PR TITLE
fix(effect-cf): bound scheduled telemetry flushes

### DIFF
--- a/.changeset/bound-scheduled-telemetry-flushes.md
+++ b/.changeset/bound-scheduled-telemetry-flushes.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": patch
+---
+
+Bound internally scheduled telemetry flushes so exporter retries cannot extend Worker or Durable Object event lifetimes indefinitely.

--- a/packages/effect-cf/src/internal/Telemetry.ts
+++ b/packages/effect-cf/src/internal/Telemetry.ts
@@ -1,7 +1,8 @@
 import { Effect, Option } from "effect";
 import { OtlpExporter } from "effect/unstable/observability";
 
-const logFlushFailure = Effect.logError("Telemetry flush failed").pipe(Effect.ignoreCause);
+/** Maximum event lifetime spent on an internally scheduled telemetry flush. */
+const scheduledFlushTimeout = "2 seconds";
 
 const logFlushSchedulingFailure = Effect.logError("Telemetry flush scheduling failed").pipe(
   Effect.ignoreCause,
@@ -20,8 +21,11 @@ export const scheduleTelemetryFlush = <R>(
       return;
     }
 
-    // Exporters and platform schedulers are foreign boundaries. Preserve a
-    // useful diagnostic without retaining their arbitrary failure causes in
-    // logs, where payloads, headers, or credentials could otherwise escape.
-    yield* waitUntil(flusher.value.flush.pipe(Effect.catchCause(() => logFlushFailure)));
+    yield* waitUntil(
+      flusher.value.flush.pipe(
+        Effect.timeoutOption(scheduledFlushTimeout),
+        Effect.ignoreCause,
+        Effect.asVoid,
+      ),
+    );
   }).pipe(Effect.catchCause(() => logFlushSchedulingFailure));

--- a/packages/effect-cf/tests/Telemetry.test.ts
+++ b/packages/effect-cf/tests/Telemetry.test.ts
@@ -1,0 +1,59 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { TestClock } from "effect/testing";
+import { OtlpExporter } from "effect/unstable/observability";
+
+import { scheduleTelemetryFlush } from "../src/internal/Telemetry";
+
+it.effect("releases a scheduled telemetry flush after its time budget", () =>
+  Effect.gen(function* () {
+    let scheduledFlush: Effect.Effect<void> | undefined;
+    const flusher = Layer.succeed(OtlpExporter.Flusher, {
+      flush: Effect.never,
+      register: () => Effect.void,
+    });
+
+    yield* scheduleTelemetryFlush((flush) =>
+      Effect.sync(() => {
+        scheduledFlush = flush;
+      }),
+    ).pipe(Effect.provide(flusher));
+
+    if (scheduledFlush === undefined) {
+      return yield* Effect.die("Expected telemetry flush to be scheduled");
+    }
+
+    const fiber = yield* Effect.forkChild(scheduledFlush);
+
+    yield* TestClock.adjust("2 seconds");
+
+    assert.isDefined(fiber.pollUnsafe());
+  }),
+);
+
+it.effect("runs a fast scheduled telemetry flush", () =>
+  Effect.gen(function* () {
+    let flushes = 0;
+    let scheduledFlush: Effect.Effect<void> | undefined;
+    const flusher = Layer.succeed(OtlpExporter.Flusher, {
+      flush: Effect.sync(() => {
+        flushes++;
+      }),
+      register: () => Effect.void,
+    });
+
+    yield* scheduleTelemetryFlush((flush) =>
+      Effect.sync(() => {
+        scheduledFlush = flush;
+      }),
+    ).pipe(Effect.provide(flusher));
+
+    if (scheduledFlush === undefined) {
+      return yield* Effect.die("Expected telemetry flush to be scheduled");
+    }
+
+    yield* scheduledFlush;
+
+    assert.strictEqual(flushes, 1);
+  }),
+);

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -253,7 +253,7 @@ test("WorkerDefinition RPC does not schedule background work without a flusher",
   expect(waitUntilPromises).toHaveLength(0);
 });
 
-test("WorkerDefinition RPC logs a bounded diagnostic for telemetry flush failure", async () => {
+test("WorkerDefinition RPC silently absorbs telemetry flush failure", async () => {
   const secret = "Bearer sensitive-exporter-credential";
   const flushFailure = Object.assign(new Error(`foreign exporter failure: ${secret}`), {
     headers: { authorization: secret },
@@ -281,7 +281,7 @@ test("WorkerDefinition RPC logs a bounded diagnostic for telemetry flush failure
   expect(waitUntilPromises).toHaveLength(1);
   await expect(Promise.all(waitUntilPromises)).resolves.toEqual([undefined]);
   expect(flushAttempts).toBe(1);
-  expectBoundedTelemetryLog(logs, "Telemetry flush failed", flushFailure);
+  expect(logs).toEqual([]);
 });
 
 test("WorkerDefinition RPC logs a bounded diagnostic for telemetry scheduling failure", async () => {


### PR DESCRIPTION
## Summary

- Bound [internally scheduled OTLP flushes](https://github.com/danieljvdm/effect-cf/blob/6a063d700022f76dfdf967882adcc57953917d40/packages/effect-cf/src/internal/Telemetry.ts#L4-L35) to two seconds before they enter Cloudflare `waitUntil`, then silently absorb timeouts and exporter failures so rate-limited telemetry cannot extend Worker or Durable Object event lifetimes.
- Added [deterministic scheduler coverage](https://github.com/danieljvdm/effect-cf/blob/6a063d700022f76dfdf967882adcc57953917d40/packages/effect-cf/tests/Telemetry.test.ts#L1-L59) for a never-ending flusher and a fast flusher, and changed the public Worker RPC boundary assertion to require silent failure handling.
- Added a patch changeset for the eventual `effect-cf` 0.28.1 release.

## What went wrong

The shared scheduler handed the raw `OtlpExporter.Flusher.flush` effect to `waitUntil`. The exporter honors OTLP `Retry-After` responses across retries, so a 429 storm could keep every alarm, RPC, or fetch event alive for roughly three minutes. Applying the budget once at the shared boundary makes all existing alarm/RPC/fetch callers inherit the cap without duplicating policy, while intentionally dropping telemetry when ingestion is slow or unavailable.

## Downstream boundary

kommunikasie separately bounds its explicit queue/scheduled flushes in PR #514 because `effect-cf` does not auto-flush queue events. This upstream change covers the alarm/RPC/fetch scheduled flushes that application code cannot reach.

## Validation

- `vp check`
- `vp pack` in `packages/effect-cf` and `packages/effect-webtransport`
- `vp test` — 46 files passed; 322 tests passed; 3 skipped
- `vp run --no-cache typecheck`

The combined cached `vp run check` path was not used as final local evidence because its cache restore removed this nested worktree; the same build, static-check, test, and typecheck stages passed individually above, and CI runs the combined workflow from a normal checkout.