### PR TITLE
fix(effect-cf): silence telemetry scheduling failures

### DIFF
--- a/.changeset/calm-ravens-flush.md
+++ b/.changeset/calm-ravens-flush.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": patch
+---
+
+Silently absorb failures raised while scheduling automatic OTLP telemetry flushes so platform boundary defects cannot feed back into the configured exporter. Document the two-second best-effort boundary and keep explicit queue flush policy application-owned.

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -357,6 +357,12 @@ Producers should usually use `const queue = yield* AvatarQueue` and then call `q
 
 Queue handlers run inline failures through Cloudflare's normal retry path. If background work scheduled with `WorkerContext.waitUntil(...)` should also make the batch retry, use `WorkerContext.waitUntilPropagating(...)` or `waitUntil(..., { mode: "propagate" })`; the default `waitUntil` mode observes and logs failures without rejecting the native `waitUntil` promise.
 
+effect-cf automatically schedules best-effort OTLP flushes only for Worker
+fetch/RPC and Durable Object alarm/RPC handlers. Those internal flushes are
+capped at two seconds. Queue handlers do not flush telemetry automatically;
+applications that explicitly flush in a queue handler own that flush's timeout
+and failure policy.
+
 ## Cache Example
 
 `Cache.layer` exposes Cloudflare's global Cache API as an Effect service. Cache misses are represented by `Option.none()`, and named caches are available through `open(...)`.

--- a/packages/effect-cf/src/CloudflareOtlp.ts
+++ b/packages/effect-cf/src/CloudflareOtlp.ts
@@ -5,16 +5,23 @@
  * telemetry on demand. Cloudflare isolates can freeze before the periodic
  * export interval fires. Effect-backed Worker fetch handlers, Worker or
  * Durable Object native RPC handlers, and Durable Object alarm handlers
- * schedule this flusher automatically.
- * Flush or scheduling failures do not replace the handler outcome and emit
- * only bounded framework diagnostics without attaching the foreign cause.
- * Other entrypoint lifecycles can flush explicitly or hand the flush to their
- * `waitUntil` mechanism:
+ * schedule this flusher automatically. These automatic flushes are capped at
+ * two seconds and silently discard timeouts and failures so telemetry cannot
+ * extend or fail the user event, or recursively log through an unhealthy
+ * exporter.
+ *
+ * Other entrypoint lifecycles, including queue handlers, do not flush
+ * automatically. Applications can flush explicitly or hand the flush to their
+ * `waitUntil` mechanism, and own the timeout and failure policy at that call
+ * site:
  *
  * ```ts
  * const flusher = yield* OtlpExporter.Flusher;
  *
- * yield* flusher.flush;
+ * yield* flusher.flush.pipe(
+ *   Effect.timeoutOption("2 seconds"),
+ *   Effect.ignoreCause,
+ * );
  * ```
  */
 import { ConfigProvider, Effect, Layer, Option } from "effect";

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -108,7 +108,9 @@ export interface DurableObjectOptions<
    * Optional RPC methods exposed as Durable Object instance methods.
    *
    * After every invocation, the configured OTLP flusher is scheduled through
-   * `DurableObjectState.waitUntil`, including when the handler fails.
+   * `DurableObjectState.waitUntil`, including when the handler fails. The
+   * scheduled flush silently settles within two seconds even if the exporter
+   * does not.
    */
   readonly rpc?: Rpc;
   /** Optional fetch handler for HTTP/WebSocket requests. */
@@ -125,7 +127,9 @@ export interface DurableObjectOptions<
    * Optional raw alarm handler.
    *
    * After every invocation, the configured OTLP flusher is scheduled through
-   * `DurableObjectState.waitUntil`, including when the handler fails.
+   * `DurableObjectState.waitUntil`, including when the handler fails. The
+   * scheduled flush silently settles within two seconds even if the exporter
+   * does not.
    */
   readonly alarm?: (
     alarmInfo?: globalThis.AlarmInvocationInfo,

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -185,7 +185,8 @@ export interface WorkerOptions<
    *
    * The layer is built inside the event's Effect scope and finalized when the
    * event effect completes. Use this for event-scoped resources such as OTLP
-   * trace/log exporters that should flush at event completion.
+   * trace/log exporters. Worker fetch and RPC handlers schedule a best-effort
+   * flush capped at two seconds; queue handlers do not flush automatically.
    */
   readonly eventLayer?: Layer.Layer<REvent, EventLayerError, WorkerBaseContext<RRuntime>>;
   /** Main request handler. */
@@ -200,7 +201,8 @@ export interface WorkerOptions<
    * Optional RPC methods exposed as class instance methods.
    *
    * After every invocation, the configured OTLP flusher is scheduled through
-   * `WorkerContext.waitUntil`, including when the handler fails.
+   * `WorkerContext.waitUntil`, including when the handler fails. The scheduled
+   * flush silently settles within two seconds even if the exporter does not.
    */
   readonly rpc?: Rpc;
 }
@@ -300,7 +302,8 @@ const isWorkerOptions = <ROut, REvent, EventLayerError, Rpc extends WorkerRpc<RO
  *
  * The flush is handed to `ctx.waitUntil` so it never delays the response
  * (including streaming bodies still being consumed). It is a no-op when the
- * context does not contain an `OtlpExporter.Flusher`.
+ * context does not contain an `OtlpExporter.Flusher`. The handed-off effect is
+ * best-effort and silently settles within two seconds.
  */
 const scheduleTelemetryFlush: Effect.Effect<void, never, WorkerContext> =
   Telemetry.scheduleTelemetryFlush((flush) =>

--- a/packages/effect-cf/src/internal/Telemetry.ts
+++ b/packages/effect-cf/src/internal/Telemetry.ts
@@ -4,12 +4,12 @@ import { OtlpExporter } from "effect/unstable/observability";
 /** Maximum event lifetime spent on an internally scheduled telemetry flush. */
 const scheduledFlushTimeout = "2 seconds";
 
-const logFlushSchedulingFailure = Effect.logError("Telemetry flush scheduling failed").pipe(
-  Effect.ignoreCause,
-);
-
 /**
  * Schedules a configured OTLP flusher through the current Cloudflare event.
+ *
+ * The handed-off effect is best-effort: it settles within two seconds and
+ * silently absorbs every failure cause so telemetry cannot extend or fail the
+ * user event, or recursively log through an unhealthy exporter.
  */
 export const scheduleTelemetryFlush = <R>(
   waitUntil: (flush: Effect.Effect<void>) => Effect.Effect<void, never, R>,
@@ -21,6 +21,9 @@ export const scheduleTelemetryFlush = <R>(
       return;
     }
 
+    // Exporters and platform schedulers are foreign boundaries. Do not log
+    // their arbitrary failure causes: the configured logger may be the same
+    // unhealthy OTLP exporter and recursively increase its backlog.
     yield* waitUntil(
       flusher.value.flush.pipe(
         Effect.timeoutOption(scheduledFlushTimeout),
@@ -28,4 +31,4 @@ export const scheduleTelemetryFlush = <R>(
         Effect.asVoid,
       ),
     );
-  }).pipe(Effect.catchCause(() => logFlushSchedulingFailure));
+  }).pipe(Effect.ignoreCause);

--- a/packages/effect-cf/tests/Telemetry.test.ts
+++ b/packages/effect-cf/tests/Telemetry.test.ts
@@ -1,23 +1,55 @@
 import { assert, it } from "@effect/vitest";
-import { Effect, Layer } from "effect";
+import { Clock, Effect, Fiber, Layer } from "effect";
 import { TestClock } from "effect/testing";
 import { OtlpExporter } from "effect/unstable/observability";
 
+import { DurableObject, Worker } from "../src/index";
 import { scheduleTelemetryFlush } from "../src/internal/Telemetry";
+import { makePartialTestDouble } from "./TestDoubles";
+
+const NeverFlusher = Layer.succeed(OtlpExporter.Flusher, {
+  flush: Effect.never,
+  register: () => Effect.void,
+});
+
+const makeWaitUntilContext = () => {
+  const waitUntilPromises: Array<Promise<unknown>> = [];
+  const executionContext = makePartialTestDouble<globalThis.ExecutionContext>({
+    props: undefined,
+    waitUntil: (promise) => {
+      waitUntilPromises.push(promise);
+    },
+    passThroughOnException: () => undefined,
+  });
+
+  return { executionContext, waitUntilPromises };
+};
+
+const makeWaitUntilDurableObjectState = () => {
+  const waitUntilPromises: Array<Promise<unknown>> = [];
+  const state = makePartialTestDouble<globalThis.DurableObjectState>({
+    id: makePartialTestDouble<globalThis.DurableObjectId>({
+      toString: () => "durable-object:telemetry-test",
+    }),
+    storage: makePartialTestDouble<globalThis.DurableObjectStorage>({}),
+    waitUntil: (promise) => {
+      waitUntilPromises.push(promise);
+    },
+    blockConcurrencyWhile: async <A>(effect: () => Promise<A>) => effect(),
+  });
+
+  return { state, waitUntilPromises };
+};
 
 it.effect("releases a scheduled telemetry flush after its time budget", () =>
   Effect.gen(function* () {
     let scheduledFlush: Effect.Effect<void> | undefined;
-    const flusher = Layer.succeed(OtlpExporter.Flusher, {
-      flush: Effect.never,
-      register: () => Effect.void,
-    });
 
     yield* scheduleTelemetryFlush((flush) =>
       Effect.sync(() => {
         scheduledFlush = flush;
       }),
-    ).pipe(Effect.provide(flusher));
+    ).pipe(Effect.provide(NeverFlusher));
 
     if (scheduledFlush === undefined) {
       return yield* Effect.die("Expected telemetry flush to be scheduled");
@@ -25,9 +57,12 @@ it.effect("releases a scheduled telemetry flush after its time budget", () =>
 
     const fiber = yield* Effect.forkChild(scheduledFlush);
 
-    yield* TestClock.adjust("2 seconds");
+    yield* TestClock.adjust("1999 millis");
+    assert.isUndefined(fiber.pollUnsafe());
 
+    yield* TestClock.adjust("1 millis");
     assert.isDefined(fiber.pollUnsafe());
+    yield* Fiber.join(fiber);
   }),
 );
 
@@ -55,5 +90,95 @@ it.effect("runs a fast scheduled telemetry flush", () =>
     yield* scheduledFlush;
 
     assert.strictEqual(flushes, 1);
+  }),
+);
+
+it.effect("absorbs interruption from an internally scheduled telemetry flush", () =>
+  Effect.gen(function* () {
+    let scheduledFlush: Effect.Effect<void> | undefined;
+    const interruptedFlusher = Layer.succeed(OtlpExporter.Flusher, {
+      flush: Effect.interrupt,
+      register: () => Effect.void,
+    });
+
+    yield* scheduleTelemetryFlush((flush) =>
+      Effect.sync(() => {
+        scheduledFlush = flush;
+      }),
+    ).pipe(Effect.provide(interruptedFlusher));
+
+    if (scheduledFlush === undefined) {
+      return yield* Effect.die("Expected telemetry flush to be scheduled");
+    }
+
+    yield* scheduledFlush;
+  }),
+);
+
+it.effect("Worker fetch hands a bounded telemetry flush to waitUntil", () =>
+  Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const Live = Worker.make(Layer.mergeAll(NeverFlusher, Layer.succeed(Clock.Clock, clock)), {
+      fetch: Effect.succeed(new Response("ok")),
+    });
+    const { executionContext, waitUntilPromises } = makeWaitUntilContext();
+    const worker = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+
+    const response = yield* Effect.promise(() =>
+      Promise.resolve(worker.fetch(new Request("https://worker.test/telemetry"))),
+    );
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(waitUntilPromises.length, 1);
+
+    let outcome: "pending" | "resolved" | "rejected" = "pending";
+
+    void waitUntilPromises[0]?.then(
+      () => {
+        outcome = "resolved";
+      },
+      () => {
+        outcome = "rejected";
+      },
+    );
+
+    assert.strictEqual(outcome, "pending");
+    yield* TestClock.adjust("2 seconds");
+    yield* Effect.promise(() => Promise.resolve());
+
+    assert.strictEqual(outcome, "resolved");
+  }),
+);
+
+it.effect("Durable Object alarms hand a bounded telemetry flush to waitUntil", () =>
+  Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const Live = DurableObject.make(
+      Layer.mergeAll(NeverFlusher, Layer.succeed(Clock.Clock, clock)),
+      { alarm: () => Effect.void },
+    );
+    const { state, waitUntilPromises } = makeWaitUntilDurableObjectState();
+    const durableObject = new Live(state, makePartialTestDouble<Cloudflare.Env>({}));
+
+    yield* Effect.promise(() => Promise.resolve(durableObject.alarm?.()));
+
+    assert.strictEqual(waitUntilPromises.length, 1);
+
+    let outcome: "pending" | "resolved" | "rejected" = "pending";
+
+    void waitUntilPromises[0]?.then(
+      () => {
+        outcome = "resolved";
+      },
+      () => {
+        outcome = "rejected";
+      },
+    );
+
+    assert.strictEqual(outcome, "pending");
+    yield* TestClock.adjust("2 seconds");
+    yield* Effect.promise(() => Promise.resolve());
+
+    assert.strictEqual(outcome, "resolved");
   }),
 );

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -104,19 +104,6 @@ const makeCapturedLoggerLayer = (logs: Array<CapturedLog>) =>
     }),
   ]);
 
-const expectBoundedTelemetryLog = (
-  logs: Array<CapturedLog>,
-  message: string,
-  foreignFailure: Error,
-) => {
-  expect(logs).toHaveLength(1);
-  expect(logs[0]?.level).toBe("Error");
-  expect(logs[0]?.message).toEqual([message]);
-  expect(logs[0]?.message).not.toContain(foreignFailure);
-  expect(String(logs[0]?.message)).not.toContain(foreignFailure.message);
-  expect(logs[0]?.cause.reasons).toEqual([]);
-};
-
 test("Worker.makeFetchHandler returns an ExportedHandler-compatible fetch object", async () => {
   const handler = Worker.makeFetchHandler(Layer.empty, {
     fetch: Effect.succeed(new Response("ok")),
@@ -284,7 +271,7 @@ test("WorkerDefinition RPC silently absorbs telemetry flush failure", async () =
   expect(logs).toEqual([]);
 });
 
-test("WorkerDefinition RPC logs a bounded diagnostic for telemetry scheduling failure", async () => {
+test("WorkerDefinition RPC does not log telemetry scheduling failures", async () => {
   const handlerFailure = new BoomError();
   const secret = "Bearer sensitive-platform-credential";
   const schedulingFailure = Object.assign(new Error(`foreign waitUntil failure: ${secret}`), {
@@ -314,7 +301,7 @@ test("WorkerDefinition RPC logs a bounded diagnostic for telemetry scheduling fa
 
   await expect(worker.fail()).rejects.toBe(handlerFailure);
   expect(schedulingAttempts).toBe(1);
-  expectBoundedTelemetryLog(logs, "Telemetry flush scheduling failed", schedulingFailure);
+  expect(logs).toEqual([]);
 });
 
 test("DurableObjectDefinition RPC uses DurableObjectState.waitUntil for telemetry", async () => {


### PR DESCRIPTION
## Summary

- Build on the two-second automatic telemetry-flush bound merged in [#105](https://github.com/danieljvdm/effect-cf/pull/105) by making the [shared scheduler](https://github.com/danieljvdm/effect-cf/blob/6227b996c25db1facdc0e1d1608ad21437f989cc/packages/effect-cf/src/internal/Telemetry.ts#L14-L34) total and silent even when the Cloudflare `waitUntil` boundary itself raises a foreign cause.
- Prevent automatic telemetry cleanup from feeding a scheduler diagnostic back through the configured logger, which may be the same unhealthy OTLP exporter. Handler outcomes and the no-Flusher no-op remain unchanged.
- Strengthen deterministic deadline coverage at the [shared scheduler and public Worker/Durable Object boundaries](https://github.com/danieljvdm/effect-cf/blob/6227b996c25db1facdc0e1d1608ad21437f989cc/packages/effect-cf/tests/Telemetry.test.ts#L44-L184).
- Document the [automatic lifecycle boundary](https://github.com/danieljvdm/effect-cf/blob/6227b996c25db1facdc0e1d1608ad21437f989cc/packages/effect-cf/src/CloudflareOtlp.ts#L4-L25): Worker fetch/RPC and Durable Object alarm/RPC are automatic; queue handlers and other explicit flushes remain application-managed. Include a patch changeset for the additional published-package fix.

## What went wrong

#105 correctly capped exporter work at two seconds and silently absorbed exporter failures. Its remaining recovery path handled a defect raised while registering the flush with `waitUntil` by calling `Effect.logError("Telemetry flush scheduling failed")`.

The configured Effect logger can itself export through OTLP. Logging from this foreign scheduling-failure boundary can therefore add more telemetry to the same unhealthy exporter and retain sensitive platform-cause data indirectly. The handler result remained protected, but the path was not recursion-safe.

This follow-up replaces that logging recovery with `Effect.ignoreCause`. Timeout, exporter failure, interruption, and scheduling defects are now all deliberately lossy and cannot replace the user event outcome or create framework telemetry. The fixed two-second invariant and public API remain unchanged.

The motivating incident involved Sentry HTTP 429 responses with roughly 60-second retry cadence. Response headers were not preserved, so this PR does not claim a proven `Retry-After` value. A separate application-owned explicit queue flush produced much longer queue invocations; queue flushing remains outside this automatic lifecycle.

## Architecture

- `internal/Telemetry.scheduleTelemetryFlush` remains the single owner of the non-configurable two-second internal invariant and now absorbs causes from both the exporter effect and the scheduler handoff.
- Existing Worker fetch/RPC and Durable Object alarm/RPC adapters continue to delegate to the shared scheduler without API changes.
- Queue handlers still do not invoke the internal scheduler. Applications that explicitly flush there own their timeout, retry, and failure policy.

## Evidence

- The [virtual-time regression](https://github.com/danieljvdm/effect-cf/blob/6227b996c25db1facdc0e1d1608ad21437f989cc/packages/effect-cf/tests/Telemetry.test.ts#L44-L67) proves a never-settling Flusher is pending at 1,999 ms, settles at 2,000 ms, and can be joined successfully.
- [Public Worker and Durable Object integration tests](https://github.com/danieljvdm/effect-cf/blob/6227b996c25db1facdc0e1d1608ad21437f989cc/packages/effect-cf/tests/Telemetry.test.ts#L118-L184) inject Effect TestClock and prove the actual native `waitUntil` promises resolve at the deadline without wall-clock sleeps.
- The [foreign scheduling-defect regression](https://github.com/danieljvdm/effect-cf/blob/6227b996c25db1facdc0e1d1608ad21437f989cc/packages/effect-cf/tests/WorkerBoundary.test.ts#L274-L305) proves the original handler failure is preserved and no recursive framework log is emitted.

## Validation

- `vp test packages/effect-cf/tests/Telemetry.test.ts packages/effect-cf/tests/WorkerBoundary.test.ts packages/effect-cf/tests/CloudflareOtlp.test.ts` — 39 passed, 3 skipped.
- `vp run typecheck` — passed across all workspaces.
- `vp run check` — format and lint clean; all 46 test files passed with 325 tests passing and 3 skipped; workspace typechecks passed.
