### PR TITLE
feat(effect-cf): add duration-based alarm scheduling

### DIFF
--- a/.changeset/calm-clocks-wake.md
+++ b/.changeset/calm-clocks-wake.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add `setAlarmAfter` to Durable Object storage and transaction wrappers for scheduling alarms with Effect `Duration.Input` values.

--- a/packages/effect-cf/src/DurableObjectStorage.ts
+++ b/packages/effect-cf/src/DurableObjectStorage.ts
@@ -1,4 +1,4 @@
-import { Data, Effect, Exit, Option, Predicate, Schema as S } from "effect";
+import { Clock, Data, Duration, Effect, Exit, Option, Predicate, Schema as S } from "effect";
 
 import * as ErrorMessage from "./internal/ErrorMessage";
 
@@ -99,6 +99,11 @@ export interface DurableObjectTransaction {
     scheduledTime: number | Date,
     options?: globalThis.DurableObjectSetAlarmOptions,
   ): StorageEffect<void>;
+  /** Schedules the alarm after a delay measured by the Effect clock. */
+  setAlarmAfter(
+    delay: Duration.Input,
+    options?: globalThis.DurableObjectSetAlarmOptions,
+  ): StorageEffect<void>;
   deleteAlarm(options?: globalThis.DurableObjectSetAlarmOptions): StorageEffect<void>;
 }
 
@@ -130,6 +135,11 @@ export interface DurableObjectStorage {
   getAlarm(options?: globalThis.DurableObjectGetAlarmOptions): StorageEffect<number | null>;
   setAlarm(
     scheduledTime: number | Date,
+    options?: globalThis.DurableObjectSetAlarmOptions,
+  ): StorageEffect<void>;
+  /** Schedules the alarm after a delay measured by the Effect clock. */
+  setAlarmAfter(
+    delay: Duration.Input,
     options?: globalThis.DurableObjectSetAlarmOptions,
   ): StorageEffect<void>;
   deleteAlarm(options?: globalThis.DurableObjectSetAlarmOptions): StorageEffect<void>;
@@ -173,6 +183,21 @@ const tryStoragePromise = <A>(operation: string, evaluate: () => Promise<A>): St
     try: evaluate,
     catch: (cause) => storageError(operation, cause),
   });
+
+const setAlarmAfter = Effect.fn("DurableObjectStorage.setAlarmAfter")(function* (
+  operation: string,
+  setAlarm: (
+    scheduledTime: number,
+    options?: globalThis.DurableObjectSetAlarmOptions,
+  ) => Promise<void>,
+  delay: Duration.Input,
+  options?: globalThis.DurableObjectSetAlarmOptions,
+) {
+  const now = yield* Clock.currentTimeMillis;
+  const delayMillis = Math.ceil(Duration.toMillis(delay));
+
+  yield* tryStoragePromise(operation, () => setAlarm(now + delayMillis, options));
+});
 
 const fromSqlCursor = <T extends Record<string, SqlStorageValue>>(
   cursor: globalThis.SqlStorageCursor<T>,
@@ -293,6 +318,13 @@ const fromDurableObjectTransaction = (
       tryStoragePromise("transaction.getAlarm", () => txn.getAlarm(options)),
     setAlarm: (scheduledTime: number | Date, options?: globalThis.DurableObjectSetAlarmOptions) =>
       tryStoragePromise("transaction.setAlarm", () => txn.setAlarm(scheduledTime, options)),
+    setAlarmAfter: (delay: Duration.Input, options?: globalThis.DurableObjectSetAlarmOptions) =>
+      setAlarmAfter(
+        "transaction.setAlarm",
+        (scheduledTime, options) => txn.setAlarm(scheduledTime, options),
+        delay,
+        options,
+      ),
     deleteAlarm: (options?: globalThis.DurableObjectSetAlarmOptions) =>
       tryStoragePromise("transaction.deleteAlarm", () => txn.deleteAlarm(options)),
   }) as DurableObjectTransaction;
@@ -315,6 +347,13 @@ export const fromDurableObjectStorage = (
     tryStoragePromise("getAlarm", () => storage.getAlarm(options)),
   setAlarm: (scheduledTime: number | Date, options?: globalThis.DurableObjectSetAlarmOptions) =>
     tryStoragePromise("setAlarm", () => storage.setAlarm(scheduledTime, options)),
+  setAlarmAfter: (delay: Duration.Input, options?: globalThis.DurableObjectSetAlarmOptions) =>
+    setAlarmAfter(
+      "setAlarm",
+      (scheduledTime, options) => storage.setAlarm(scheduledTime, options),
+      delay,
+      options,
+    ),
   deleteAlarm: (options?: globalThis.DurableObjectSetAlarmOptions) =>
     tryStoragePromise("deleteAlarm", () => storage.deleteAlarm(options)),
   transactionSync: <A, E, R>(closure: () => Effect.Effect<A, E, R>) =>

--- a/packages/effect-cf/tests/DurableObjectStorage.test.ts
+++ b/packages/effect-cf/tests/DurableObjectStorage.test.ts
@@ -1,5 +1,6 @@
 import { assert, it } from "@effect/vitest";
-import { Cause, Context, Effect } from "effect";
+import { Cause, Context, Duration, Effect } from "effect";
+import { TestClock } from "effect/testing";
 
 const TransactionMessage = Context.Service<{ readonly message: string }>(
   "effect-cf/test/TransactionMessage",
@@ -43,6 +44,30 @@ it.effect("wraps transaction with Effect-native callbacks", () =>
     assert.strictEqual(result, 42);
     assert.strictEqual(yield* storage.get("count"), 42);
     assert.strictEqual(tracker.transactionCalls, 1);
+  }),
+);
+
+it.effect("schedules alarms after Effect durations using the Effect clock", () =>
+  Effect.gen(function* () {
+    const { raw, tracker } = makeRawDurableObjectStorage();
+    const storage = DurableObjectStorage.fromDurableObjectStorage(raw);
+
+    yield* TestClock.setTime(1_700_000_000_000);
+    yield* storage.setAlarmAfter(Duration.seconds(10), { allowUnconfirmed: true });
+    yield* storage.transaction((txn) => txn.setAlarmAfter("20 seconds"));
+
+    assert.deepStrictEqual(tracker.alarms, [
+      {
+        options: { allowUnconfirmed: true },
+        scheduledTime: 1_700_000_010_000,
+      },
+    ]);
+    assert.deepStrictEqual(tracker.transactionAlarms, [
+      {
+        options: undefined,
+        scheduledTime: 1_700_000_020_000,
+      },
+    ]);
   }),
 );
 
@@ -170,8 +195,16 @@ it.effect("maps platform transactionSync failures to StorageOperationError", () 
 );
 
 interface StorageTracker {
+  readonly alarms: Array<{
+    readonly options: globalThis.DurableObjectSetAlarmOptions | undefined;
+    readonly scheduledTime: number | Date;
+  }>;
   readonly deleteAllOptions: Array<globalThis.DurableObjectPutOptions | undefined>;
   syncCalls: number;
+  readonly transactionAlarms: Array<{
+    readonly options: globalThis.DurableObjectSetAlarmOptions | undefined;
+    readonly scheduledTime: number | Date;
+  }>;
   transactionCalls: number;
   transactionRollbacks: number;
   transactionSyncCalls: number;
@@ -193,8 +226,10 @@ type StorageFixtureValue = number | string;
 function makeRawDurableObjectStorage(options: StorageOptions = {}): RawStorageFixture {
   const values = new Map<string, StorageFixtureValue>();
   const tracker: StorageTracker = {
+    alarms: [],
     deleteAllOptions: [],
     syncCalls: 0,
+    transactionAlarms: [],
     transactionCalls: 0,
     transactionRollbacks: 0,
     transactionSyncCalls: 0,
@@ -220,7 +255,7 @@ function makeRawDurableObjectStorage(options: StorageOptions = {}): RawStorageFi
       }
 
       try {
-        return await closure(makeRawDurableObjectTransaction(values));
+        return await closure(makeRawDurableObjectTransaction(values, tracker));
       } catch (error) {
         tracker.transactionRollbacks += 1;
         restore(values, snapshot);
@@ -228,7 +263,12 @@ function makeRawDurableObjectStorage(options: StorageOptions = {}): RawStorageFi
       }
     },
     getAlarm: async () => null,
-    setAlarm: async () => undefined,
+    setAlarm: async (
+      scheduledTime: number | Date,
+      alarmOptions?: globalThis.DurableObjectSetAlarmOptions,
+    ) => {
+      tracker.alarms.push({ options: alarmOptions, scheduledTime });
+    },
     deleteAlarm: async () => undefined,
     sync: async () => {
       tracker.syncCalls += 1;
@@ -279,6 +319,7 @@ function makeRawDurableObjectStorage(options: StorageOptions = {}): RawStorageFi
 
 function makeRawDurableObjectTransaction(
   values: Map<string, StorageFixtureValue>,
+  tracker: StorageTracker,
 ): globalThis.DurableObjectTransaction {
   const implementation = {
     get: async (key: string) => values.get(key),
@@ -291,7 +332,12 @@ function makeRawDurableObjectTransaction(
       throw new Error("rollback not used");
     },
     getAlarm: async () => null,
-    setAlarm: async () => undefined,
+    setAlarm: async (
+      scheduledTime: number | Date,
+      options?: globalThis.DurableObjectSetAlarmOptions,
+    ) => {
+      tracker.transactionAlarms.push({ options, scheduledTime });
+    },
     deleteAlarm: async () => undefined,
   };
 


### PR DESCRIPTION
## Summary

- Add [`setAlarmAfter`](https://github.com/danieljvdm/effect-cf/blob/4f894267e62666cddb47fab15571c6aad8c80cee/packages/effect-cf/src/DurableObjectStorage.ts#L99-L149) to Durable Object storage and transaction wrappers while preserving `setAlarm` as the absolute-time Cloudflare primitive.
- Convert Effect `Duration.Input` delays against the Effect [`Clock`](https://github.com/danieljvdm/effect-cf/blob/4f894267e62666cddb47fab15571c6aad8c80cee/packages/effect-cf/src/DurableObjectStorage.ts#L184-L201), making relative alarm scheduling testable without wall-clock access.
- Cover storage and transaction scheduling, alarm options, and virtual time through a [deterministic regression test](https://github.com/danieljvdm/effect-cf/blob/4f894267e62666cddb47fab15571c6aad8c80cee/packages/effect-cf/tests/DurableObjectStorage.test.ts#L50-L72).

## Validation

- `vp test run packages/effect-cf/tests/DurableObjectStorage.test.ts`
- `vp check`
- `vp test`
- `vp run check`