### PR TITLE
feat: add effect-cf/sandbox for the Cloudflare Sandbox SDK 1.0 API

### DIFF
--- a/.changeset/sandbox-module.md
+++ b/.changeset/sandbox-module.md
@@ -1,0 +1,7 @@
+---
+"effect-cf": minor
+---
+
+Add `effect-cf/sandbox`: an Effect-native client for the Cloudflare Sandbox SDK 1.0 API (`@cloudflare/sandbox@next`, an optional peer dependency loaded lazily on first use).
+
+`Sandbox.Tag`/`Sandbox.make` create a typed service for a Sandbox Durable Object namespace binding, and `layer({ binding })` validates the binding from `WorkerEnvironment`. The instance client covers the complete `ISandbox` contract plus lifecycle, preview-port, tunnel, bucket-mount, and backup operations: `exec` returns a process handle with typed log `Stream`s and interruption-aware waits, `watch` decodes file-watch Server-Sent Events into an Effect `Stream`, `readFileStream` streams raw bytes, and terminals are wrapped as Effect handles. Failures are reported as a typed `SandboxOperationError` that preserves the SDK's error classes as `cause`, and `Sandbox.proxyToSandbox` routes preview-URL traffic as an `Option<Response>` Effect.

--- a/bun.lock
+++ b/bun.lock
@@ -291,10 +291,11 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.28.1",
+      "version": "0.29.0",
       "devDependencies": {
         "@cloudflare/computer": "0.2.0",
         "@cloudflare/containers": "catalog:",
+        "@cloudflare/sandbox": "0.13.0-next.738.2",
         "@cloudflare/vitest-pool-workers": "catalog:",
         "@cloudflare/workers-types": "catalog:",
         "@effect/platform-node": "^4.0.0-rc.110",
@@ -310,6 +311,7 @@
       },
       "peerDependencies": {
         "@cloudflare/computer": "^0.2.0",
+        "@cloudflare/sandbox": "^0.13.0-next.738.2",
         "@cloudflare/vitest-pool-workers": "^0.21.3",
         "@cloudflare/workers-types": "^4.20260611.1",
         "@effect/sql-d1": "^4.0.0-rc.110",
@@ -319,6 +321,7 @@
       },
       "optionalPeers": [
         "@cloudflare/computer",
+        "@cloudflare/sandbox",
         "@cloudflare/vitest-pool-workers",
         "@cloudflare/workers-types",
         "@effect/sql-pg",
@@ -326,7 +329,7 @@
     },
     "packages/effect-webtransport": {
       "name": "effect-webtransport",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "effect": "catalog:",
@@ -417,6 +420,8 @@
     "@cloudflare/containers": ["@cloudflare/containers@0.3.7", "", {}, "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/sandbox": ["@cloudflare/sandbox@0.13.0-next.738.2", "", { "dependencies": { "@cloudflare/containers": "^0.3.7", "aws4fetch": "^1.0.20", "capnweb": "^0.8.0", "hono": "^4.12.26" }, "peerDependencies": { "@openai/agents": "^0.3.3", "@opencode-ai/sdk": "^1.1.40", "@xterm/xterm": ">=5.0.0" }, "optionalPeers": ["@openai/agents", "@opencode-ai/sdk", "@xterm/xterm"] }, "sha512-fD5rANNn4L6rHHsxaOi4gME31VBSF9pdvyaeQv+4OBhYThfpgonHvqcLC1lUHmV4R6OXUDt+NVJOzK2d9CNMxw=="],
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
@@ -960,6 +965,8 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
+
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
@@ -1119,6 +1126,8 @@
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "hono": ["hono@4.13.3", "", {}, "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw=="],
 
     "human-id": ["human-id@4.2.0", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA=="],
 

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -33,6 +33,14 @@ Workspace Git operations additionally require `@platformatic/vfs`,
 bun add "@platformatic/vfs@^0.4.0"
 ```
 
+The Sandbox integration is an optional peer. Install the `@next` release line
+of `@cloudflare/sandbox` (the Sandbox SDK 1.0 API) only in applications that
+import `effect-cf/sandbox`:
+
+```bash
+bun add "@cloudflare/sandbox@next"
+```
+
 ## Goal
 
 Cloudflare APIs return promises and expose platform-specific bindings. `effect-cf` wraps those boundaries as `Context`, `Layer`, and `Effect` values so application code stays inside one managed Effect runtime.
@@ -54,6 +62,7 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `effect-cf/computer-workspace` - scoped Effect wrappers for the complete Cloudflare Computer filesystem, Git, runtime, Assets, Artifacts, and Think-compatible client surfaces
 - `effect-cf/computer-artifacts` - session-isolated Artifacts repositories backed by `@cloudflare/computer/artifacts`
 - `effect-cf/computer-workspace-host` - optional Durable Object host mixin, worker-shell backend wiring, and `WorkspaceServiceProxy`
+- `effect-cf/sandbox` - Effect-native client for Cloudflare Sandbox containers: processes with log streams, files and watches, preview URLs, tunnels, terminals, bucket mounts, and backups
 - `Hyperdrive` - typed Hyperdrive binding helper for connection strings and optional Postgres SQL integration
 - `Images` - typed Cloudflare Images binding helper with transformation APIs and optional hosted image operations
 - `Email` - typed Cloudflare Email Service binding helper for `send_email` bindings, with limit validation and typed error codes
@@ -321,6 +330,75 @@ const stub = Sandboxes.byName("codex").rawUnsafe;
 
 See [`examples/containers/README.md`](../../examples/containers/README.md) for
 the corresponding Wrangler configuration and entrypoint responsibilities.
+
+## Sandbox Example
+
+`effect-cf/sandbox` wraps the [Cloudflare Sandbox SDK](https://github.com/cloudflare/sandbox-sdk)
+1.0 API (`@cloudflare/sandbox@next`). The Sandbox Durable Object class remains
+owned by `@cloudflare/sandbox`; `effect-cf` wraps the namespace binding used by
+a calling Worker and loads the SDK lazily, so applications without the optional
+peer are unaffected.
+
+```ts
+import { Effect, Option } from "effect";
+import { Worker } from "effect-cf";
+import * as Sandbox from "effect-cf/sandbox";
+
+export { Sandbox as SandboxDurableObject } from "@cloudflare/sandbox";
+
+class Sandboxes extends Sandbox.Tag<Sandboxes>()("Sandboxes") {}
+
+const SandboxesLive = Sandboxes.layer({ binding: "Sandbox" });
+
+export default Worker.make(SandboxesLive, {
+  fetch: Effect.gen(function* () {
+    const request = yield* Worker.NativeRequest;
+
+    // Route preview-URL traffic before any other routing.
+    const proxied = yield* Sandbox.proxyToSandbox(request);
+    if (Option.isSome(proxied)) {
+      return proxied.value;
+    }
+
+    const sandbox = yield* Sandboxes.get("my-sandbox");
+    const handle = yield* sandbox.exec(["python3", "-c", "print(2 + 2)"]);
+    const output = yield* handle.outputText();
+
+    return new Response(output.stdout);
+  }),
+});
+```
+
+The instance client mirrors the complete `ISandbox` client contract plus the
+lifecycle, port, tunnel, and backup operations the SDK client proxies to the
+Sandbox Durable Object. `exec` returns a process handle whose `logs` is an
+Effect `Stream` of typed log events; `watch` decodes the SDK's Server-Sent
+Events into a `Stream` of file-watch events; `readFileStream` streams raw
+bytes. Interruptible waits (`waitForExit`, `waitForLog`, `output`,
+`waitForPort`) abort the underlying SDK call when the Effect is interrupted.
+Failures carry a typed `SandboxOperationError` whose `cause` preserves the
+SDK's rich error classes (`ProcessNotFoundError`, `PortNotExposedError`, and
+friends) for inspection.
+
+The corresponding `wrangler.jsonc` declares the container image and Durable
+Object binding; note the SDK requires the exported Durable Object class to be
+reachable under the configured `class_name`:
+
+```jsonc
+{
+  "containers": [
+    {
+      "class_name": "SandboxDurableObject",
+      "image": "./Dockerfile",
+      "instance_type": "lite",
+    },
+  ],
+  "durable_objects": {
+    "bindings": [{ "class_name": "SandboxDurableObject", "name": "Sandbox" }],
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["SandboxDurableObject"] }],
+}
+```
 
 ## Queue Example
 

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -42,6 +42,11 @@
       "import": "./dist/ComputerWorkspaceHost.mjs",
       "default": "./dist/ComputerWorkspaceHost.mjs"
     },
+    "./sandbox": {
+      "types": "./dist/Sandbox.d.mts",
+      "import": "./dist/Sandbox.mjs",
+      "default": "./dist/Sandbox.mjs"
+    },
     "./vitest": {
       "types": "./dist/Vitest.d.mts",
       "import": "./dist/Vitest.mjs",
@@ -62,6 +67,7 @@
   "devDependencies": {
     "@cloudflare/computer": "0.2.0",
     "@cloudflare/containers": "catalog:",
+    "@cloudflare/sandbox": "0.13.0-next.738.2",
     "@cloudflare/vitest-pool-workers": "catalog:",
     "@cloudflare/workers-types": "catalog:",
     "@effect/platform-node": "^4.0.0-rc.110",
@@ -77,6 +83,7 @@
   },
   "peerDependencies": {
     "@cloudflare/computer": "^0.2.0",
+    "@cloudflare/sandbox": "^0.13.0-next.738.2",
     "@cloudflare/vitest-pool-workers": "^0.21.3",
     "@cloudflare/workers-types": "^4.20260611.1",
     "@effect/sql-d1": "^4.0.0-rc.110",
@@ -86,6 +93,9 @@
   },
   "peerDependenciesMeta": {
     "@cloudflare/computer": {
+      "optional": true
+    },
+    "@cloudflare/sandbox": {
       "optional": true
     },
     "@cloudflare/vitest-pool-workers": {

--- a/packages/effect-cf/src/Sandbox.ts
+++ b/packages/effect-cf/src/Sandbox.ts
@@ -1,0 +1,1094 @@
+import type {
+  BackupOptions,
+  CheckChangesOptions,
+  CheckChangesResult,
+  CreateTerminalOptions,
+  DirectoryBackup,
+  ExecOptions,
+  FileWatchSSEEvent,
+  ISandbox,
+  ListFilesOptions,
+  MountBucketOptions,
+  ProcessExit,
+  ProcessLogEvent,
+  ProcessLogsOptions,
+  ProcessOutput,
+  ProcessOutputOptions,
+  ProcessStatus,
+  RestoreBackupResult,
+  SandboxCommand,
+  SandboxOptions,
+  SandboxProcess,
+  Terminal,
+  TerminalOutputCursor,
+  TerminalOutputEvent,
+  TerminalOutputOptions,
+  TerminalSnapshot,
+  TunnelInfo,
+  TunnelOptions,
+  WaitForExitOptions,
+  WaitForLogOptions,
+  WaitForLogResult,
+  WaitForPortOptions,
+  WatchOptions,
+} from "@cloudflare/sandbox";
+import { Context, Data, Effect, Option, Predicate, Stream, type Layer } from "effect";
+
+import * as Binding from "./Binding";
+import type { ContainerStartOptions, ContainerStopSignal } from "./ContainerNamespace";
+import { WorkerEnvironment } from "./Environment";
+import * as ErrorMessage from "./internal/ErrorMessage";
+
+export type {
+  BackupOptions,
+  CheckChangesOptions,
+  CheckChangesResult,
+  CreateTerminalOptions,
+  DirectoryBackup,
+  ExecOptions,
+  FileWatchSSEEvent,
+  ISandbox,
+  ListFilesOptions,
+  MountBucketOptions,
+  ProcessExit,
+  ProcessLogEvent,
+  ProcessLogsOptions,
+  ProcessOutput,
+  ProcessOutputOptions,
+  ProcessStatus,
+  RestoreBackupResult,
+  SandboxCommand,
+  SandboxOptions,
+  SandboxProcess,
+  Terminal,
+  TerminalOutputCursor,
+  TerminalOutputEvent,
+  TerminalOutputOptions,
+  TerminalSnapshot,
+  TunnelInfo,
+  TunnelOptions,
+  WaitForExitOptions,
+  WaitForLogOptions,
+  WaitForLogResult,
+  WaitForPortOptions,
+  WatchOptions,
+} from "@cloudflare/sandbox";
+
+const expectedSandboxNamespace =
+  "Sandbox Durable Object namespace binding with idFromName() and get()";
+
+/** Sandbox namespace binding metadata. */
+export interface SandboxDefinition {
+  /** Binding name as configured in `wrangler.jsonc`. */
+  readonly binding: string;
+}
+
+/** Failure raised when invoking a sandbox operation. */
+export class SandboxOperationError extends Data.TaggedError("SandboxOperationError")<{
+  readonly binding: string;
+  readonly instance: string;
+  readonly operation: string;
+  readonly cause: unknown;
+}> {
+  override get message(): string {
+    return `Sandbox ${this.operation} failed for binding "${this.binding}" instance "${this.instance}": ${ErrorMessage.causeMessage(this.cause)}`;
+  }
+}
+
+/**
+ * Structural Durable Object namespace shape required by `getSandbox()`.
+ *
+ * This is structural so importing this module does not require
+ * `@cloudflare/sandbox` at runtime; the package is loaded lazily when a
+ * sandbox instance is first requested.
+ */
+export interface SandboxNamespaceResource {
+  idFromName(name: string): globalThis.DurableObjectId;
+  get(
+    id: globalThis.DurableObjectId,
+    options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
+  ): globalThis.DurableObjectStub;
+}
+
+/** Result of `writeFile` as reported by the sandbox client. */
+export type WriteFileResult = Awaited<ReturnType<ISandbox["writeFile"]>>;
+
+/** Result of `readFile` as reported by the sandbox client. */
+export type ReadFileResult = Awaited<ReturnType<ISandbox["readFile"]>>;
+
+/** Result of `mkdir` as reported by the sandbox client. */
+export type MkdirResult = Awaited<ReturnType<ISandbox["mkdir"]>>;
+
+/** Result of `deleteFile` as reported by the sandbox client. */
+export type DeleteFileResult = Awaited<ReturnType<ISandbox["deleteFile"]>>;
+
+/** Result of `renameFile` as reported by the sandbox client. */
+export type RenameFileResult = Awaited<ReturnType<ISandbox["renameFile"]>>;
+
+/** Result of `moveFile` as reported by the sandbox client. */
+export type MoveFileResult = Awaited<ReturnType<ISandbox["moveFile"]>>;
+
+/** Result of `listFiles` as reported by the sandbox client. */
+export type ListFilesResult = Awaited<ReturnType<ISandbox["listFiles"]>>;
+
+/** Result of `exists` as reported by the sandbox client. */
+export type FileExistsResult = Awaited<ReturnType<ISandbox["exists"]>>;
+
+/** Text encodings accepted by `readFile`. */
+export type ReadFileEncoding = "utf-8" | "utf8" | "base64";
+
+/** Options accepted by `exposePort`. */
+export interface ExposePortOptions {
+  readonly name?: string;
+  readonly hostname: string;
+  readonly token?: string;
+}
+
+/** Preview URL information returned by `exposePort`. */
+export interface ExposedPort {
+  readonly url: string;
+  readonly port: number;
+  readonly name?: string;
+}
+
+/** Currently forwardable preview URL returned by `getExposedPorts`. */
+export interface ExposedPortStatus {
+  readonly url: string;
+  readonly port: number;
+  readonly status: "active";
+}
+
+/** Structural tunnel API surface exposed by a sandbox client. */
+export interface SandboxTunnelsResource {
+  get(port: number, options?: TunnelOptions): Promise<TunnelInfo>;
+  list(): Promise<Array<TunnelInfo>>;
+  destroy(portOrInfo: number | TunnelInfo): Promise<void>;
+}
+
+/**
+ * Structural surface of the client returned by `getSandbox()` that this
+ * module wraps: the `ISandbox` RPC contract plus the lifecycle, port, and
+ * tunnel methods the client proxy forwards to the Sandbox Durable Object.
+ */
+export interface SandboxClientResource extends ISandbox {
+  start(options?: ContainerStartOptions): Promise<void>;
+  stop(signal?: ContainerStopSignal): Promise<void>;
+  destroy(): Promise<void>;
+  containerFetch(requestOrUrl: Request | string | URL, port?: number): Promise<Response>;
+  exposePort(port: number, options: ExposePortOptions): Promise<ExposedPort>;
+  unexposePort(port: number): Promise<void>;
+  getExposedPorts(hostname: string): Promise<Array<ExposedPortStatus>>;
+  isPortExposed(port: number): Promise<boolean>;
+  validatePortToken(port: number, token: string): Promise<boolean>;
+  readonly tunnels: SandboxTunnelsResource;
+}
+
+/** Effect-wrapped handle for one process started inside a sandbox. */
+export interface SandboxProcessHandle {
+  readonly id: string;
+  readonly pid: number;
+  readonly rawUnsafe: Effect.Effect<SandboxProcess>;
+  readonly status: Effect.Effect<ProcessStatus, SandboxOperationError>;
+  readonly exitCode: Effect.Effect<number, SandboxOperationError>;
+  readonly logs: (
+    options?: Omit<ProcessLogsOptions, "signal">,
+  ) => Stream.Stream<ProcessLogEvent, SandboxOperationError>;
+  readonly waitForLog: (
+    pattern: string | RegExp,
+    options?: Omit<WaitForLogOptions, "signal">,
+  ) => Effect.Effect<WaitForLogResult, SandboxOperationError>;
+  readonly waitForExit: (
+    options?: Omit<WaitForExitOptions, "signal">,
+  ) => Effect.Effect<ProcessExit, SandboxOperationError>;
+  readonly output: (
+    options?: Omit<ProcessOutputOptions, "signal">,
+  ) => Effect.Effect<ProcessOutput<Uint8Array>, SandboxOperationError>;
+  readonly outputText: (
+    options?: Omit<ProcessOutputOptions, "signal">,
+  ) => Effect.Effect<ProcessOutput<string>, SandboxOperationError>;
+  readonly waitForPort: (
+    port: number,
+    options?: Omit<WaitForPortOptions, "signal">,
+  ) => Effect.Effect<void, SandboxOperationError>;
+  readonly kill: (signal?: number) => Effect.Effect<void, SandboxOperationError>;
+}
+
+/** Effect-wrapped handle for one interactive terminal inside a sandbox. */
+export interface SandboxTerminalHandle {
+  readonly id: string;
+  readonly rawUnsafe: Effect.Effect<Terminal>;
+  readonly snapshot: Effect.Effect<TerminalSnapshot, SandboxOperationError>;
+  readonly write: (data: Uint8Array) => Effect.Effect<void, SandboxOperationError>;
+  readonly resize: (cols: number, rows: number) => Effect.Effect<void, SandboxOperationError>;
+  readonly output: (
+    options?: Omit<TerminalOutputOptions, "signal">,
+  ) => Stream.Stream<TerminalOutputEvent, SandboxOperationError>;
+  readonly waitForExit: (
+    options?: Omit<WaitForExitOptions, "signal">,
+  ) => Effect.Effect<ProcessExit, SandboxOperationError>;
+  readonly interrupt: Effect.Effect<void, SandboxOperationError>;
+  readonly terminate: Effect.Effect<void, SandboxOperationError>;
+  readonly connect: (
+    request: Request,
+    options?: {
+      readonly cursor?: TerminalOutputCursor;
+      readonly cols?: number;
+      readonly rows?: number;
+    },
+  ) => Effect.Effect<Response, SandboxOperationError>;
+}
+
+/** Effect-wrapped tunnel operations for one sandbox instance. */
+export interface SandboxTunnelsClient {
+  readonly get: (
+    port: number,
+    options?: TunnelOptions,
+  ) => Effect.Effect<TunnelInfo, SandboxOperationError>;
+  readonly list: Effect.Effect<Array<TunnelInfo>, SandboxOperationError>;
+  readonly destroy: (portOrInfo: number | TunnelInfo) => Effect.Effect<void, SandboxOperationError>;
+}
+
+/** Effect-wrapped client for one named sandbox instance. */
+export interface SandboxInstanceClient {
+  readonly rawUnsafe: Effect.Effect<SandboxClientResource>;
+  readonly exec: (
+    command: SandboxCommand,
+    options?: ExecOptions,
+  ) => Effect.Effect<SandboxProcessHandle, SandboxOperationError>;
+  readonly getProcess: (
+    id: string,
+  ) => Effect.Effect<Option.Option<SandboxProcessHandle>, SandboxOperationError>;
+  readonly listProcesses: Effect.Effect<Array<ProcessStatus>, SandboxOperationError>;
+  readonly writeFile: (
+    path: string,
+    content: string | ReadableStream<Uint8Array>,
+    options?: { readonly encoding?: string },
+  ) => Effect.Effect<WriteFileResult, SandboxOperationError>;
+  readonly readFile: (
+    path: string,
+    options?: { readonly encoding?: ReadFileEncoding },
+  ) => Effect.Effect<ReadFileResult, SandboxOperationError>;
+  readonly readFileStream: (path: string) => Stream.Stream<Uint8Array, SandboxOperationError>;
+  readonly mkdir: (
+    path: string,
+    options?: { readonly recursive?: boolean },
+  ) => Effect.Effect<MkdirResult, SandboxOperationError>;
+  readonly deleteFile: (path: string) => Effect.Effect<DeleteFileResult, SandboxOperationError>;
+  readonly renameFile: (
+    oldPath: string,
+    newPath: string,
+  ) => Effect.Effect<RenameFileResult, SandboxOperationError>;
+  readonly moveFile: (
+    sourcePath: string,
+    destinationPath: string,
+  ) => Effect.Effect<MoveFileResult, SandboxOperationError>;
+  readonly listFiles: (
+    path: string,
+    options?: ListFilesOptions,
+  ) => Effect.Effect<ListFilesResult, SandboxOperationError>;
+  readonly exists: (path: string) => Effect.Effect<FileExistsResult, SandboxOperationError>;
+  readonly watch: (
+    path: string,
+    options?: WatchOptions,
+  ) => Stream.Stream<FileWatchSSEEvent, SandboxOperationError>;
+  readonly checkChanges: (
+    path: string,
+    options?: CheckChangesOptions,
+  ) => Effect.Effect<CheckChangesResult, SandboxOperationError>;
+  readonly setEnvVars: (
+    envVars: Record<string, string | undefined>,
+  ) => Effect.Effect<void, SandboxOperationError>;
+  readonly exposePort: (
+    port: number,
+    options: ExposePortOptions,
+  ) => Effect.Effect<ExposedPort, SandboxOperationError>;
+  readonly unexposePort: (port: number) => Effect.Effect<void, SandboxOperationError>;
+  readonly getExposedPorts: (
+    hostname: string,
+  ) => Effect.Effect<Array<ExposedPortStatus>, SandboxOperationError>;
+  readonly isPortExposed: (port: number) => Effect.Effect<boolean, SandboxOperationError>;
+  readonly validatePortToken: (
+    port: number,
+    token: string,
+  ) => Effect.Effect<boolean, SandboxOperationError>;
+  readonly containerFetch: (
+    requestOrUrl: Request | string | URL,
+    port?: number,
+  ) => Effect.Effect<Response, SandboxOperationError>;
+  readonly wsConnect: (
+    request: Request,
+    port: number,
+  ) => Effect.Effect<Response, SandboxOperationError>;
+  readonly mountBucket: (
+    bucket: string,
+    mountPath: string,
+    options: MountBucketOptions,
+  ) => Effect.Effect<void, SandboxOperationError>;
+  readonly unmountBucket: (mountPath: string) => Effect.Effect<void, SandboxOperationError>;
+  readonly createBackup: (
+    options: BackupOptions,
+  ) => Effect.Effect<DirectoryBackup, SandboxOperationError>;
+  readonly restoreBackup: (
+    backup: DirectoryBackup,
+  ) => Effect.Effect<RestoreBackupResult, SandboxOperationError>;
+  readonly createTerminal: (
+    options: CreateTerminalOptions,
+  ) => Effect.Effect<SandboxTerminalHandle, SandboxOperationError>;
+  readonly getTerminal: (
+    id: string,
+  ) => Effect.Effect<Option.Option<SandboxTerminalHandle>, SandboxOperationError>;
+  readonly listTerminals: Effect.Effect<Array<SandboxTerminalHandle>, SandboxOperationError>;
+  readonly tunnels: SandboxTunnelsClient;
+  readonly start: (options?: ContainerStartOptions) => Effect.Effect<void, SandboxOperationError>;
+  readonly stop: (signal?: ContainerStopSignal) => Effect.Effect<void, SandboxOperationError>;
+  readonly destroy: Effect.Effect<void, SandboxOperationError>;
+}
+
+/** Effect client for a Sandbox Durable Object namespace binding. */
+export interface SandboxNamespaceClient<
+  Namespace extends SandboxNamespaceResource = SandboxNamespaceResource,
+> {
+  readonly definition: SandboxDefinition;
+  readonly get: (
+    name: string,
+    options?: SandboxOptions,
+  ) => Effect.Effect<SandboxInstanceClient, SandboxOperationError>;
+  readonly rawUnsafe: Effect.Effect<Namespace>;
+}
+
+export type LayerOptions = {
+  readonly binding: string;
+};
+
+export interface TagClass<
+  Self,
+  Id extends string,
+  Namespace extends SandboxNamespaceResource = SandboxNamespaceResource,
+> extends Context.ServiceClass<Self, `effect-cf/Sandbox/${Id}`, SandboxNamespaceClient<Namespace>> {
+  readonly id: Id;
+  readonly layer: (
+    options: LayerOptions,
+  ) => Layer.Layer<
+    Self,
+    Binding.BindingNotFoundError | Binding.BindingValidationError,
+    WorkerEnvironment
+  >;
+  readonly get: (
+    name: string,
+    options?: SandboxOptions,
+  ) => Effect.Effect<SandboxInstanceClient, SandboxOperationError, Self>;
+  readonly rawUnsafe: Effect.Effect<Namespace, never, Self>;
+}
+
+const trySandboxPromise = <A>(
+  definition: SandboxDefinition,
+  instance: string,
+  operation: string,
+  evaluate: (signal: AbortSignal) => PromiseLike<A>,
+): Effect.Effect<A, SandboxOperationError> =>
+  Effect.tryPromise({
+    try: evaluate,
+    catch: (cause) =>
+      new SandboxOperationError({
+        binding: definition.binding,
+        instance,
+        operation,
+        cause,
+      }),
+  });
+
+const sandboxStream = <A>(
+  definition: SandboxDefinition,
+  instance: string,
+  operation: string,
+  acquire: (signal: AbortSignal) => PromiseLike<ReadableStream<A>>,
+): Stream.Stream<A, SandboxOperationError> =>
+  Stream.unwrap(
+    Effect.map(trySandboxPromise(definition, instance, operation, acquire), (readable) =>
+      Stream.fromReadableStream({
+        evaluate: () => readable,
+        onError: (cause) =>
+          new SandboxOperationError({
+            binding: definition.binding,
+            instance,
+            operation,
+            cause,
+          }),
+      }),
+    ),
+  );
+
+const decodeSseData = <A>(payload: string): ReadonlyArray<A> => {
+  if (payload === "[DONE]" || payload.trim() === "") {
+    return [];
+  }
+
+  try {
+    // SAFETY: sandbox watch frames are JSON-encoded event payloads produced by
+    // the sandbox runtime; the caller fixes A to the matching event type.
+    return [JSON.parse(payload) as A];
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Decodes the sandbox runtime's `data:`-framed Server-Sent Events byte stream
+ * into JSON event values, mirroring `parseSSEStream` from
+ * `@cloudflare/sandbox` without requiring the package at runtime.
+ */
+const decodeSseEvents = <A, E, R>(bytes: Stream.Stream<Uint8Array, E, R>): Stream.Stream<A, E, R> =>
+  bytes.pipe(
+    Stream.decodeText(),
+    Stream.splitLines,
+    Stream.mapAccum(
+      (): ReadonlyArray<string> => [],
+      (pending, line) => {
+        if (line === "") {
+          return pending.length > 0 ? [[], decodeSseData<A>(pending.join("\n"))] : [pending, []];
+        }
+
+        if (line.startsWith("data:")) {
+          const value = line.startsWith("data: ") ? line.slice(6) : line.slice(5);
+
+          return [[...pending, value], []];
+        }
+
+        return [pending, []];
+      },
+      {
+        onHalt: (pending) => (pending.length > 0 ? decodeSseData<A>(pending.join("\n")) : []),
+      },
+    ),
+  );
+
+const makeProcessHandle = (
+  definition: SandboxDefinition,
+  instance: string,
+  process: SandboxProcess,
+): SandboxProcessHandle => {
+  const spanOptions = (operation: string) => ({
+    attributes: {
+      binding: definition.binding,
+      instance,
+      processId: process.id,
+      operation,
+    },
+  });
+
+  return {
+    id: process.id,
+    pid: process.pid,
+    rawUnsafe: Effect.succeed(process),
+    status: trySandboxPromise(definition, instance, "process.status", () => process.status()).pipe(
+      Effect.withSpan("Sandbox.process.status", spanOptions("process.status")),
+    ),
+    exitCode: trySandboxPromise(
+      definition,
+      instance,
+      "process.exitCode",
+      () => process.exitCode,
+    ).pipe(Effect.withSpan("Sandbox.process.exitCode", spanOptions("process.exitCode"))),
+    logs: (options?: Omit<ProcessLogsOptions, "signal">) =>
+      sandboxStream(definition, instance, "process.logs", (signal) =>
+        process.logs({ ...options, signal }),
+      ),
+    waitForLog: Effect.fn(
+      "Sandbox.process.waitForLog",
+      spanOptions("process.waitForLog"),
+    )(function* (pattern: string | RegExp, options?: Omit<WaitForLogOptions, "signal">) {
+      return yield* trySandboxPromise(definition, instance, "process.waitForLog", (signal) =>
+        process.waitForLog(pattern, { ...options, signal }),
+      );
+    }),
+    waitForExit: Effect.fn(
+      "Sandbox.process.waitForExit",
+      spanOptions("process.waitForExit"),
+    )(function* (options?: Omit<WaitForExitOptions, "signal">) {
+      return yield* trySandboxPromise(definition, instance, "process.waitForExit", (signal) =>
+        process.waitForExit({ ...options, signal }),
+      );
+    }),
+    output: Effect.fn(
+      "Sandbox.process.output",
+      spanOptions("process.output"),
+    )(function* (options?: Omit<ProcessOutputOptions, "signal">) {
+      return yield* trySandboxPromise(definition, instance, "process.output", (signal) =>
+        process.output({ ...options, signal }),
+      );
+    }),
+    outputText: Effect.fn(
+      "Sandbox.process.outputText",
+      spanOptions("process.outputText"),
+    )(function* (options?: Omit<ProcessOutputOptions, "signal">) {
+      return yield* trySandboxPromise(definition, instance, "process.outputText", (signal) =>
+        process.output({ ...options, encoding: "utf8", signal }),
+      );
+    }),
+    waitForPort: Effect.fn(
+      "Sandbox.process.waitForPort",
+      spanOptions("process.waitForPort"),
+    )(function* (port: number, options?: Omit<WaitForPortOptions, "signal">) {
+      return yield* trySandboxPromise(definition, instance, "process.waitForPort", (signal) =>
+        process.waitForPort(port, { ...options, signal }),
+      );
+    }),
+    kill: Effect.fn(
+      "Sandbox.process.kill",
+      spanOptions("process.kill"),
+    )(function* (signal?: number) {
+      return yield* trySandboxPromise(definition, instance, "process.kill", () =>
+        process.kill(signal),
+      );
+    }),
+  };
+};
+
+const makeTerminalHandle = (
+  definition: SandboxDefinition,
+  instance: string,
+  terminal: Terminal,
+): SandboxTerminalHandle => {
+  const spanOptions = (operation: string) => ({
+    attributes: {
+      binding: definition.binding,
+      instance,
+      terminalId: terminal.id,
+      operation,
+    },
+  });
+
+  return {
+    id: terminal.id,
+    rawUnsafe: Effect.succeed(terminal),
+    snapshot: trySandboxPromise(definition, instance, "terminal.snapshot", () =>
+      terminal.getSnapshot(),
+    ).pipe(Effect.withSpan("Sandbox.terminal.snapshot", spanOptions("terminal.snapshot"))),
+    write: Effect.fn(
+      "Sandbox.terminal.write",
+      spanOptions("terminal.write"),
+    )(function* (data: Uint8Array) {
+      return yield* trySandboxPromise(definition, instance, "terminal.write", () =>
+        terminal.write(data),
+      );
+    }),
+    resize: Effect.fn(
+      "Sandbox.terminal.resize",
+      spanOptions("terminal.resize"),
+    )(function* (cols: number, rows: number) {
+      return yield* trySandboxPromise(definition, instance, "terminal.resize", () =>
+        terminal.resize(cols, rows),
+      );
+    }),
+    output: (options?: Omit<TerminalOutputOptions, "signal">) =>
+      sandboxStream(definition, instance, "terminal.output", (signal) =>
+        terminal.output({ ...options, signal }),
+      ),
+    waitForExit: Effect.fn(
+      "Sandbox.terminal.waitForExit",
+      spanOptions("terminal.waitForExit"),
+    )(function* (options?: Omit<WaitForExitOptions, "signal">) {
+      return yield* trySandboxPromise(definition, instance, "terminal.waitForExit", (signal) =>
+        terminal.waitForExit({ ...options, signal }),
+      );
+    }),
+    interrupt: trySandboxPromise(definition, instance, "terminal.interrupt", () =>
+      terminal.interrupt(),
+    ).pipe(Effect.withSpan("Sandbox.terminal.interrupt", spanOptions("terminal.interrupt"))),
+    terminate: trySandboxPromise(definition, instance, "terminal.terminate", () =>
+      terminal.terminate(),
+    ).pipe(Effect.withSpan("Sandbox.terminal.terminate", spanOptions("terminal.terminate"))),
+    connect: Effect.fn(
+      "Sandbox.terminal.connect",
+      spanOptions("terminal.connect"),
+    )(function* (
+      request: Request,
+      options?: {
+        readonly cursor?: TerminalOutputCursor;
+        readonly cols?: number;
+        readonly rows?: number;
+      },
+    ) {
+      return yield* trySandboxPromise(definition, instance, "terminal.connect", () =>
+        terminal.connect(request, options),
+      );
+    }),
+  };
+};
+
+/**
+ * Wraps an already-created sandbox client (the value returned by
+ * `getSandbox()` from `@cloudflare/sandbox`) into an Effect client.
+ *
+ * Prefer {@link Tag}/{@link make} with a layer for application code; this
+ * entry point exists for advanced composition and testing.
+ */
+export const fromSandboxClient = (
+  client: SandboxClientResource,
+  definition: SandboxDefinition,
+  instance: string,
+): SandboxInstanceClient => {
+  const spanOptions = (operation: string) => ({
+    attributes: { binding: definition.binding, instance, operation },
+  });
+
+  return {
+    rawUnsafe: Effect.succeed(client),
+    exec: Effect.fn(
+      "Sandbox.exec",
+      spanOptions("exec"),
+    )(function* (command: SandboxCommand, options?: ExecOptions) {
+      const process = yield* trySandboxPromise(definition, instance, "exec", () =>
+        client.exec(command, options),
+      );
+
+      return makeProcessHandle(definition, instance, process);
+    }),
+    getProcess: Effect.fn(
+      "Sandbox.getProcess",
+      spanOptions("getProcess"),
+    )(function* (id: string) {
+      const process = yield* trySandboxPromise(definition, instance, "getProcess", () =>
+        client.getProcess(id),
+      );
+
+      return Option.map(Option.fromNullishOr(process), (found) =>
+        makeProcessHandle(definition, instance, found),
+      );
+    }),
+    listProcesses: trySandboxPromise(definition, instance, "listProcesses", () =>
+      client.listProcesses(),
+    ).pipe(Effect.withSpan("Sandbox.listProcesses", spanOptions("listProcesses"))),
+    writeFile: Effect.fn(
+      "Sandbox.writeFile",
+      spanOptions("writeFile"),
+    )(function* (
+      path: string,
+      content: string | ReadableStream<Uint8Array>,
+      options?: { readonly encoding?: string },
+    ) {
+      yield* Effect.annotateCurrentSpan("path", path);
+
+      return yield* trySandboxPromise(definition, instance, "writeFile", () =>
+        client.writeFile(path, content, options),
+      );
+    }),
+    readFile: Effect.fn(
+      "Sandbox.readFile",
+      spanOptions("readFile"),
+    )(function* (path: string, options?: { readonly encoding?: ReadFileEncoding }) {
+      yield* Effect.annotateCurrentSpan("path", path);
+
+      return yield* trySandboxPromise(definition, instance, "readFile", () =>
+        client.readFile(path, options),
+      );
+    }),
+    readFileStream: (path: string) =>
+      sandboxStream(definition, instance, "readFileStream", () => client.readFileStream(path)),
+    mkdir: Effect.fn(
+      "Sandbox.mkdir",
+      spanOptions("mkdir"),
+    )(function* (path: string, options?: { readonly recursive?: boolean }) {
+      yield* Effect.annotateCurrentSpan("path", path);
+
+      return yield* trySandboxPromise(definition, instance, "mkdir", () =>
+        client.mkdir(path, options),
+      );
+    }),
+    deleteFile: Effect.fn(
+      "Sandbox.deleteFile",
+      spanOptions("deleteFile"),
+    )(function* (path: string) {
+      yield* Effect.annotateCurrentSpan("path", path);
+
+      return yield* trySandboxPromise(definition, instance, "deleteFile", () =>
+        client.deleteFile(path),
+      );
+    }),
+    renameFile: Effect.fn(
+      "Sandbox.renameFile",
+      spanOptions("renameFile"),
+    )(function* (oldPath: string, newPath: string) {
+      yield* Effect.annotateCurrentSpan({ oldPath, newPath });
+
+      return yield* trySandboxPromise(definition, instance, "renameFile", () =>
+        client.renameFile(oldPath, newPath),
+      );
+    }),
+    moveFile: Effect.fn(
+      "Sandbox.moveFile",
+      spanOptions("moveFile"),
+    )(function* (sourcePath: string, destinationPath: string) {
+      yield* Effect.annotateCurrentSpan({ sourcePath, destinationPath });
+
+      return yield* trySandboxPromise(definition, instance, "moveFile", () =>
+        client.moveFile(sourcePath, destinationPath),
+      );
+    }),
+    listFiles: Effect.fn(
+      "Sandbox.listFiles",
+      spanOptions("listFiles"),
+    )(function* (path: string, options?: ListFilesOptions) {
+      yield* Effect.annotateCurrentSpan("path", path);
+
+      return yield* trySandboxPromise(definition, instance, "listFiles", () =>
+        client.listFiles(path, options),
+      );
+    }),
+    exists: Effect.fn(
+      "Sandbox.exists",
+      spanOptions("exists"),
+    )(function* (path: string) {
+      yield* Effect.annotateCurrentSpan("path", path);
+
+      return yield* trySandboxPromise(definition, instance, "exists", () => client.exists(path));
+    }),
+    watch: (path: string, options?: WatchOptions) =>
+      decodeSseEvents<FileWatchSSEEvent, SandboxOperationError, never>(
+        sandboxStream(definition, instance, "watch", () => client.watch(path, options)),
+      ),
+    checkChanges: Effect.fn(
+      "Sandbox.checkChanges",
+      spanOptions("checkChanges"),
+    )(function* (path: string, options?: CheckChangesOptions) {
+      yield* Effect.annotateCurrentSpan("path", path);
+
+      return yield* trySandboxPromise(definition, instance, "checkChanges", () =>
+        client.checkChanges(path, options),
+      );
+    }),
+    setEnvVars: Effect.fn(
+      "Sandbox.setEnvVars",
+      spanOptions("setEnvVars"),
+    )(function* (envVars: Record<string, string | undefined>) {
+      return yield* trySandboxPromise(definition, instance, "setEnvVars", () =>
+        client.setEnvVars(envVars),
+      );
+    }),
+    exposePort: Effect.fn(
+      "Sandbox.exposePort",
+      spanOptions("exposePort"),
+    )(function* (port: number, options: ExposePortOptions) {
+      yield* Effect.annotateCurrentSpan("port", port);
+
+      return yield* trySandboxPromise(definition, instance, "exposePort", () =>
+        client.exposePort(port, options),
+      );
+    }),
+    unexposePort: Effect.fn(
+      "Sandbox.unexposePort",
+      spanOptions("unexposePort"),
+    )(function* (port: number) {
+      yield* Effect.annotateCurrentSpan("port", port);
+
+      return yield* trySandboxPromise(definition, instance, "unexposePort", () =>
+        client.unexposePort(port),
+      );
+    }),
+    getExposedPorts: Effect.fn(
+      "Sandbox.getExposedPorts",
+      spanOptions("getExposedPorts"),
+    )(function* (hostname: string) {
+      return yield* trySandboxPromise(definition, instance, "getExposedPorts", () =>
+        client.getExposedPorts(hostname),
+      );
+    }),
+    isPortExposed: Effect.fn(
+      "Sandbox.isPortExposed",
+      spanOptions("isPortExposed"),
+    )(function* (port: number) {
+      yield* Effect.annotateCurrentSpan("port", port);
+
+      return yield* trySandboxPromise(definition, instance, "isPortExposed", () =>
+        client.isPortExposed(port),
+      );
+    }),
+    validatePortToken: Effect.fn(
+      "Sandbox.validatePortToken",
+      spanOptions("validatePortToken"),
+    )(function* (port: number, token: string) {
+      yield* Effect.annotateCurrentSpan("port", port);
+
+      return yield* trySandboxPromise(definition, instance, "validatePortToken", () =>
+        client.validatePortToken(port, token),
+      );
+    }),
+    containerFetch: Effect.fn(
+      "Sandbox.containerFetch",
+      spanOptions("containerFetch"),
+    )(function* (requestOrUrl: Request | string | URL, port?: number) {
+      return yield* trySandboxPromise(definition, instance, "containerFetch", () =>
+        client.containerFetch(requestOrUrl, port),
+      );
+    }),
+    wsConnect: Effect.fn(
+      "Sandbox.wsConnect",
+      spanOptions("wsConnect"),
+    )(function* (request: Request, port: number) {
+      yield* Effect.annotateCurrentSpan("port", port);
+
+      return yield* trySandboxPromise(definition, instance, "wsConnect", () =>
+        client.wsConnect(request, port),
+      );
+    }),
+    mountBucket: Effect.fn(
+      "Sandbox.mountBucket",
+      spanOptions("mountBucket"),
+    )(function* (bucket: string, mountPath: string, options: MountBucketOptions) {
+      yield* Effect.annotateCurrentSpan({ bucket, mountPath });
+
+      return yield* trySandboxPromise(definition, instance, "mountBucket", () =>
+        client.mountBucket(bucket, mountPath, options),
+      );
+    }),
+    unmountBucket: Effect.fn(
+      "Sandbox.unmountBucket",
+      spanOptions("unmountBucket"),
+    )(function* (mountPath: string) {
+      yield* Effect.annotateCurrentSpan("mountPath", mountPath);
+
+      return yield* trySandboxPromise(definition, instance, "unmountBucket", () =>
+        client.unmountBucket(mountPath),
+      );
+    }),
+    createBackup: Effect.fn(
+      "Sandbox.createBackup",
+      spanOptions("createBackup"),
+    )(function* (options: BackupOptions) {
+      yield* Effect.annotateCurrentSpan("dir", options.dir);
+
+      return yield* trySandboxPromise(definition, instance, "createBackup", () =>
+        client.createBackup(options),
+      );
+    }),
+    restoreBackup: Effect.fn(
+      "Sandbox.restoreBackup",
+      spanOptions("restoreBackup"),
+    )(function* (backup: DirectoryBackup) {
+      yield* Effect.annotateCurrentSpan({ backupId: backup.id, dir: backup.dir });
+
+      return yield* trySandboxPromise(definition, instance, "restoreBackup", () =>
+        client.restoreBackup(backup),
+      );
+    }),
+    createTerminal: Effect.fn(
+      "Sandbox.createTerminal",
+      spanOptions("createTerminal"),
+    )(function* (options: CreateTerminalOptions) {
+      const terminal = yield* trySandboxPromise(definition, instance, "createTerminal", () =>
+        client.createTerminal(options),
+      );
+
+      return makeTerminalHandle(definition, instance, terminal);
+    }),
+    getTerminal: Effect.fn(
+      "Sandbox.getTerminal",
+      spanOptions("getTerminal"),
+    )(function* (id: string) {
+      const terminal = yield* trySandboxPromise(definition, instance, "getTerminal", () =>
+        client.getTerminal(id),
+      );
+
+      return Option.map(Option.fromNullishOr(terminal), (found) =>
+        makeTerminalHandle(definition, instance, found),
+      );
+    }),
+    listTerminals: trySandboxPromise(definition, instance, "listTerminals", () =>
+      client.listTerminals(),
+    ).pipe(
+      Effect.map((terminals) =>
+        terminals.map((terminal) => makeTerminalHandle(definition, instance, terminal)),
+      ),
+      Effect.withSpan("Sandbox.listTerminals", spanOptions("listTerminals")),
+    ),
+    tunnels: {
+      get: Effect.fn(
+        "Sandbox.tunnels.get",
+        spanOptions("tunnels.get"),
+      )(function* (port: number, options?: TunnelOptions) {
+        yield* Effect.annotateCurrentSpan("port", port);
+
+        return yield* trySandboxPromise(definition, instance, "tunnels.get", () =>
+          client.tunnels.get(port, options),
+        );
+      }),
+      list: trySandboxPromise(definition, instance, "tunnels.list", () =>
+        client.tunnels.list(),
+      ).pipe(Effect.withSpan("Sandbox.tunnels.list", spanOptions("tunnels.list"))),
+      destroy: Effect.fn(
+        "Sandbox.tunnels.destroy",
+        spanOptions("tunnels.destroy"),
+      )(function* (portOrInfo: number | TunnelInfo) {
+        return yield* trySandboxPromise(definition, instance, "tunnels.destroy", () =>
+          client.tunnels.destroy(portOrInfo),
+        );
+      }),
+    },
+    start: Effect.fn(
+      "Sandbox.start",
+      spanOptions("start"),
+    )(function* (options?: ContainerStartOptions) {
+      return yield* trySandboxPromise(definition, instance, "start", () => client.start(options));
+    }),
+    stop: Effect.fn(
+      "Sandbox.stop",
+      spanOptions("stop"),
+    )(function* (signal?: ContainerStopSignal) {
+      return yield* trySandboxPromise(definition, instance, "stop", () => client.stop(signal));
+    }),
+    destroy: trySandboxPromise(definition, instance, "destroy", () => client.destroy()).pipe(
+      Effect.withSpan("Sandbox.destroy", spanOptions("destroy")),
+    ),
+  };
+};
+
+/**
+ * Lazily imports `@cloudflare/sandbox`.
+ *
+ * The package is an optional peer dependency: loading it on first use keeps
+ * this module importable (and the rest of `effect-cf` bundleable) in
+ * applications that never touch sandboxes.
+ */
+const importSandboxModule = (definition: SandboxDefinition, instance: string) =>
+  Effect.tryPromise({
+    try: () => import("@cloudflare/sandbox"),
+    catch: (cause) =>
+      new SandboxOperationError({
+        binding: definition.binding,
+        instance,
+        operation: "import",
+        cause,
+      }),
+  });
+
+export const isSandboxNamespaceResource = <Candidate>(
+  value: Candidate,
+): value is Candidate & SandboxNamespaceResource =>
+  Predicate.hasProperty(value, "idFromName") &&
+  Predicate.isFunction(value.idFromName) &&
+  Predicate.hasProperty(value, "get") &&
+  Predicate.isFunction(value.get);
+
+export const makeClient =
+  (definition: SandboxDefinition) =>
+  <Namespace extends SandboxNamespaceResource>(
+    namespace: Namespace,
+  ): SandboxNamespaceClient<Namespace> => {
+    const get = Effect.fn("Sandbox.get", {
+      attributes: { binding: definition.binding, operation: "get" },
+    })(function* (name: string, options?: SandboxOptions) {
+      yield* Effect.annotateCurrentSpan("instance", name);
+
+      const sandboxModule = yield* importSandboxModule(definition, name);
+      const nativeNamespace: unknown = namespace;
+      const client = yield* Effect.try({
+        try: () =>
+          sandboxModule.getSandbox(
+            // SAFETY: the layer validated the binding as a Durable Object
+            // namespace, and getSandbox only requires idFromName() and get();
+            // the structural namespace type is narrower than the SDK's nominal
+            // one, so the conversion goes through unknown.
+            nativeNamespace as Parameters<typeof sandboxModule.getSandbox>[0],
+            name,
+            options,
+          ),
+        catch: (cause) =>
+          new SandboxOperationError({
+            binding: definition.binding,
+            instance: name,
+            operation: "get",
+            cause,
+          }),
+      });
+
+      return fromSandboxClient(client, definition, name);
+    });
+
+    return {
+      definition,
+      get,
+      rawUnsafe: Effect.succeed(namespace),
+    };
+  };
+
+export const layer = <Self, Namespace extends SandboxNamespaceResource>(
+  tag: Context.Service<Self, SandboxNamespaceClient<Namespace>>,
+  definition: SandboxDefinition,
+) =>
+  Binding.layer(
+    tag,
+    definition.binding,
+    (value): value is Namespace => isSandboxNamespaceResource(value),
+    makeClient(definition),
+    {
+      expected: expectedSandboxNamespace,
+    },
+  );
+
+export const make = <Id extends string>(id: Id) => Tag<SandboxNamespaceService<Id>>()<Id>(id);
+
+declare const SandboxNamespaceServiceTypeId: unique symbol;
+
+/** Nominal service marker for Sandbox namespaces created with {@link make}. */
+export interface SandboxNamespaceService<Id extends string> {
+  readonly [SandboxNamespaceServiceTypeId]: {
+    readonly id: Id;
+  };
+}
+
+/** Creates a typed Effect service for a Cloudflare Sandbox namespace. */
+export const Tag =
+  <Self, Namespace extends SandboxNamespaceResource = SandboxNamespaceResource>() =>
+  <Id extends string>(id: Id) => {
+    const tag = Context.Service<Self, SandboxNamespaceClient<Namespace>>()(
+      `effect-cf/Sandbox/${id}` as const,
+    );
+    const makeLayer = (definition: LayerOptions) => layer(tag, definition);
+
+    const get = Effect.fnUntraced(function* (name: string, options?: SandboxOptions) {
+      const namespace = yield* tag;
+
+      return yield* namespace.get(name, options);
+    });
+
+    const rawUnsafe = Effect.flatMap(tag, (namespace) => namespace.rawUnsafe);
+
+    // SAFETY: the assigned namespace helpers exactly implement TagClass for this service tag.
+    return Object.assign(tag, {
+      id,
+      layer: makeLayer,
+      get,
+      rawUnsafe,
+    }) as TagClass<Self, Id, Namespace>;
+  };
+
+export const Sandbox = Tag;
+
+/**
+ * Routes sandbox preview-URL requests (`https://<port>-<sandbox-id>-<token>.<host>`)
+ * to the owning sandbox, mirroring `proxyToSandbox` from `@cloudflare/sandbox`.
+ *
+ * Call this before any other routing in a Worker `fetch` handler; it resolves
+ * to `Option.none()` for requests that are not preview-URL traffic.
+ */
+export const proxyToSandbox = Effect.fn("Sandbox.proxyToSandbox")(function* (
+  request: Request,
+  options?: { readonly binding?: string },
+) {
+  const binding = options?.binding ?? "Sandbox";
+  const definition: SandboxDefinition = { binding };
+  const env = yield* WorkerEnvironment;
+  const resource = Predicate.hasProperty(env, binding) ? env[binding] : undefined;
+  const sandboxModule = yield* importSandboxModule(definition, "preview");
+  const response = yield* trySandboxPromise(definition, "preview", "proxyToSandbox", () =>
+    sandboxModule.proxyToSandbox(
+      request,
+      // SAFETY: proxyToSandbox reads exactly one binding, hardcoded as
+      // env.Sandbox; this adapts the configured binding name to that shape,
+      // and getSandbox validates the binding value when a preview route hits it.
+      { Sandbox: resource } as Parameters<typeof sandboxModule.proxyToSandbox>[1],
+    ),
+  );
+
+  return Option.fromNullishOr(response);
+});

--- a/packages/effect-cf/tests/Packaging.test.ts
+++ b/packages/effect-cf/tests/Packaging.test.ts
@@ -1,23 +1,23 @@
 import { build, type Plugin } from "esbuild";
 import { expect, test } from "vitest";
 
-const rejectCloudflareComputer: Plugin = {
-  name: "reject-cloudflare-computer",
+const rejectOptionalPeers: Plugin = {
+  name: "reject-optional-peers",
   setup(build) {
-    build.onResolve({ filter: /^@cloudflare\/computer(?:\/.*)?$/ }, (args) => ({
+    build.onResolve({ filter: /^@cloudflare\/(?:computer|sandbox)(?:\/.*)?$/ }, (args) => ({
       errors: [{ text: `unexpected optional peer import: ${args.path}` }],
     }));
   },
 };
 
-test("the root package bundles Durable Object consumers without Cloudflare Computer", async () => {
+test("the root package bundles Durable Object consumers without optional peers", async () => {
   const result = await build({
     entryPoints: [new URL("./fixtures/durable-object-consumer.ts", import.meta.url).pathname],
     bundle: true,
     external: ["cloudflare:*"],
     format: "esm",
     platform: "browser",
-    plugins: [rejectCloudflareComputer],
+    plugins: [rejectOptionalPeers],
     write: false,
   });
 

--- a/packages/effect-cf/tests/Sandbox.test.ts
+++ b/packages/effect-cf/tests/Sandbox.test.ts
@@ -1,0 +1,712 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer, Option, Stream } from "effect";
+import { expectTypeOf } from "vitest";
+
+import { Binding, WorkerEnvironment, type WorkerEnv } from "../src/index";
+import * as Sandbox from "../src/Sandbox";
+import { makePartialTestDouble } from "./TestDoubles";
+
+class TestSandboxes extends Sandbox.Tag<TestSandboxes>()("TestSandboxes") {}
+
+const definition: Sandbox.SandboxDefinition = { binding: "SANDBOX" };
+
+interface Call {
+  readonly operation: string;
+  readonly args: ReadonlyArray<unknown>;
+}
+
+const readableFromArray = <A>(items: ReadonlyArray<A>): ReadableStream<A> =>
+  new ReadableStream<A>({
+    start(controller) {
+      for (const item of items) {
+        controller.enqueue(item);
+      }
+      controller.close();
+    },
+  });
+
+const processExit: Sandbox.ProcessExit = { code: 0, timedOut: false };
+
+const runningStatus: Sandbox.ProcessStatus = {
+  id: "proc-1",
+  pid: 42,
+  command: ["echo", "hi"],
+  startedAt: "2026-08-18T00:00:00.000Z",
+  state: "running",
+};
+
+const logEvents: ReadonlyArray<Sandbox.ProcessLogEvent> = [
+  {
+    type: "stdout",
+    cursor: "c1",
+    timestamp: "2026-08-18T00:00:00.000Z",
+    data: new TextEncoder().encode("hello\n"),
+  },
+  {
+    type: "terminal",
+    state: "exited",
+    cursor: "c2",
+    timestamp: "2026-08-18T00:00:01.000Z",
+    exit: processExit,
+  },
+];
+
+const makeFakeProcess = (calls: Array<Call>): Sandbox.SandboxProcess =>
+  makePartialTestDouble<Sandbox.SandboxProcess>({
+    id: "proc-1",
+    pid: 42,
+    exitCode: Promise.resolve(0),
+    status: async () => {
+      calls.push({ operation: "process.status", args: [] });
+
+      return runningStatus;
+    },
+    logs: async (options) => {
+      calls.push({
+        operation: "process.logs",
+        args: [options?.replay ?? null, options?.signal instanceof AbortSignal],
+      });
+
+      return readableFromArray(logEvents);
+    },
+    waitForLog: async (pattern, options) => {
+      calls.push({ operation: "process.waitForLog", args: [pattern, options] });
+
+      return { stream: "stdout", text: "ready", match: "ready" };
+    },
+    waitForExit: async (options) => {
+      calls.push({
+        operation: "process.waitForExit",
+        args: [options?.timeout ?? null, options?.signal instanceof AbortSignal],
+      });
+
+      return processExit;
+    },
+    // SAFETY: a single test implementation stands in for both output()
+    // overloads; the encoding option only selects the payload type.
+    output: (async (options?: Sandbox.ProcessOutputOptions & { encoding?: string }) => {
+      calls.push({
+        operation: "process.output",
+        args: [options?.encoding ?? null, options?.maxBytes ?? null],
+      });
+
+      return {
+        stdout: options?.encoding === "utf8" ? "out" : new TextEncoder().encode("out"),
+        stderr: options?.encoding === "utf8" ? "" : new Uint8Array(),
+        exitCode: 0,
+        timedOut: false,
+        truncated: false,
+      };
+    }) as Sandbox.SandboxProcess["output"],
+    waitForPort: async (port, options) => {
+      calls.push({ operation: "process.waitForPort", args: [port, options] });
+    },
+    kill: async (signal) => {
+      calls.push({ operation: "process.kill", args: [signal] });
+    },
+  });
+
+const terminalSnapshot: Sandbox.TerminalSnapshot = {
+  id: "term-1",
+  command: ["bash"],
+  status: "running",
+};
+
+const terminalEvents: ReadonlyArray<Sandbox.TerminalOutputEvent> = [
+  {
+    type: "data",
+    terminalId: "term-1",
+    cursor: "t1",
+    timestamp: "2026-08-18T00:00:00.000Z",
+    data: new TextEncoder().encode("$ "),
+  },
+];
+
+const makeFakeTerminal = (calls: Array<Call>): Sandbox.Terminal =>
+  makePartialTestDouble<Sandbox.Terminal>({
+    id: "term-1",
+    getSnapshot: async () => {
+      calls.push({ operation: "terminal.getSnapshot", args: [] });
+
+      return terminalSnapshot;
+    },
+    write: async (data) => {
+      calls.push({ operation: "terminal.write", args: [data] });
+    },
+    resize: async (cols, rows) => {
+      calls.push({ operation: "terminal.resize", args: [cols, rows] });
+    },
+    output: async (options) => {
+      calls.push({ operation: "terminal.output", args: [options] });
+
+      return readableFromArray(terminalEvents);
+    },
+    waitForExit: async (options) => {
+      calls.push({ operation: "terminal.waitForExit", args: [options] });
+
+      return processExit;
+    },
+    interrupt: async () => {
+      calls.push({ operation: "terminal.interrupt", args: [] });
+    },
+    terminate: async () => {
+      calls.push({ operation: "terminal.terminate", args: [] });
+    },
+  });
+
+const makeFakeClient = (options?: {
+  readonly calls?: Array<Call>;
+  readonly readFileFailure?: unknown;
+  readonly watchChunks?: ReadonlyArray<string>;
+}) => {
+  const calls = options?.calls ?? [];
+  const process = makeFakeProcess(calls);
+  const terminal = makeFakeTerminal(calls);
+  const response = new Response("sandbox", { status: 200 });
+  const tunnelInfo = {
+    id: "tunnel-1",
+    port: 8080,
+    url: "https://example.trycloudflare.com",
+    hostname: "example.trycloudflare.com",
+    createdAt: "2026-08-18T00:00:00.000Z",
+  };
+  const encoder = new TextEncoder();
+  const client = makePartialTestDouble<Sandbox.SandboxClientResource>({
+    exec: async (command, execOptions) => {
+      calls.push({ operation: "exec", args: [command, execOptions] });
+
+      return process;
+    },
+    getProcess: async (id) => {
+      calls.push({ operation: "getProcess", args: [id] });
+
+      return id === "proc-1" ? process : null;
+    },
+    listProcesses: async () => {
+      calls.push({ operation: "listProcesses", args: [] });
+
+      return [runningStatus];
+    },
+    writeFile: async (path, content, writeOptions) => {
+      calls.push({ operation: "writeFile", args: [path, content, writeOptions] });
+
+      return { success: true, path, timestamp: "t" };
+    },
+    // SAFETY: a single test implementation stands in for both readFile()
+    // overloads; this suite never requests the `encoding: "none"` variant.
+    readFile: (async (path: string, readOptions?: { encoding?: string }) => {
+      calls.push({ operation: "readFile", args: [path, readOptions] });
+      if (options?.readFileFailure !== undefined) {
+        throw options.readFileFailure;
+      }
+
+      return { success: true, path, content: "file-content", timestamp: "t" };
+    }) as Sandbox.SandboxClientResource["readFile"],
+    readFileStream: async (path) => {
+      calls.push({ operation: "readFileStream", args: [path] });
+
+      return readableFromArray([encoder.encode("chunk-1;"), encoder.encode("chunk-2")]);
+    },
+    watch: async (path, watchOptions) => {
+      calls.push({ operation: "watch", args: [path, watchOptions] });
+
+      return readableFromArray((options?.watchChunks ?? []).map((chunk) => encoder.encode(chunk)));
+    },
+    checkChanges: async (path, checkOptions) => {
+      calls.push({ operation: "checkChanges", args: [path, checkOptions] });
+
+      return { success: true, status: "unchanged", version: "v1", timestamp: "t" };
+    },
+    mkdir: async (path, mkdirOptions) => {
+      calls.push({ operation: "mkdir", args: [path, mkdirOptions] });
+
+      return { success: true, path, recursive: mkdirOptions?.recursive ?? false, timestamp: "t" };
+    },
+    deleteFile: async (path) => {
+      calls.push({ operation: "deleteFile", args: [path] });
+
+      return { success: true, path, timestamp: "t" };
+    },
+    renameFile: async (oldPath, newPath) => {
+      calls.push({ operation: "renameFile", args: [oldPath, newPath] });
+
+      return { success: true, path: oldPath, newPath, timestamp: "t" };
+    },
+    moveFile: async (sourcePath, destinationPath) => {
+      calls.push({ operation: "moveFile", args: [sourcePath, destinationPath] });
+
+      return { success: true, path: sourcePath, newPath: destinationPath, timestamp: "t" };
+    },
+    listFiles: async (path, listOptions) => {
+      calls.push({ operation: "listFiles", args: [path, listOptions] });
+
+      return { success: true, path, files: [], count: 0, timestamp: "t" };
+    },
+    exists: async (path) => {
+      calls.push({ operation: "exists", args: [path] });
+
+      return { success: true, path, exists: true, timestamp: "t" };
+    },
+    setEnvVars: async (envVars) => {
+      calls.push({ operation: "setEnvVars", args: [envVars] });
+    },
+    exposePort: async (port, exposeOptions) => {
+      calls.push({ operation: "exposePort", args: [port, exposeOptions] });
+
+      return { url: `https://${port}-sandbox.example.com`, port };
+    },
+    unexposePort: async (port) => {
+      calls.push({ operation: "unexposePort", args: [port] });
+    },
+    getExposedPorts: async (hostname) => {
+      calls.push({ operation: "getExposedPorts", args: [hostname] });
+
+      return [{ url: `https://8080-sandbox.${hostname}`, port: 8080, status: "active" as const }];
+    },
+    isPortExposed: async (port) => {
+      calls.push({ operation: "isPortExposed", args: [port] });
+
+      return true;
+    },
+    validatePortToken: async (port, token) => {
+      calls.push({ operation: "validatePortToken", args: [port, token] });
+
+      return token === "valid";
+    },
+    containerFetch: async (requestOrUrl, port) => {
+      calls.push({ operation: "containerFetch", args: [requestOrUrl, port] });
+
+      return response;
+    },
+    wsConnect: async (request, port) => {
+      calls.push({ operation: "wsConnect", args: [request, port] });
+
+      return response;
+    },
+    mountBucket: async (bucket, mountPath, mountOptions) => {
+      calls.push({ operation: "mountBucket", args: [bucket, mountPath, mountOptions] });
+    },
+    unmountBucket: async (mountPath) => {
+      calls.push({ operation: "unmountBucket", args: [mountPath] });
+    },
+    createBackup: async (backupOptions) => {
+      calls.push({ operation: "createBackup", args: [backupOptions] });
+
+      return { id: "backup-1", dir: backupOptions.dir };
+    },
+    restoreBackup: async (backup) => {
+      calls.push({ operation: "restoreBackup", args: [backup] });
+
+      return { success: true, dir: backup.dir, id: backup.id };
+    },
+    createTerminal: async (terminalOptions) => {
+      calls.push({ operation: "createTerminal", args: [terminalOptions] });
+
+      return terminal;
+    },
+    getTerminal: async (id) => {
+      calls.push({ operation: "getTerminal", args: [id] });
+
+      return id === "term-1" ? terminal : null;
+    },
+    listTerminals: async () => {
+      calls.push({ operation: "listTerminals", args: [] });
+
+      return [terminal];
+    },
+    tunnels: {
+      get: async (port, tunnelOptions) => {
+        calls.push({ operation: "tunnels.get", args: [port, tunnelOptions] });
+
+        return tunnelInfo;
+      },
+      list: async () => {
+        calls.push({ operation: "tunnels.list", args: [] });
+
+        return [tunnelInfo];
+      },
+      destroy: async (portOrInfo) => {
+        calls.push({ operation: "tunnels.destroy", args: [portOrInfo] });
+      },
+    },
+    start: async (startOptions) => {
+      calls.push({ operation: "start", args: [startOptions] });
+    },
+    stop: async (signal) => {
+      calls.push({ operation: "stop", args: [signal] });
+    },
+    destroy: async () => {
+      calls.push({ operation: "destroy", args: [] });
+    },
+  });
+  const instance = Sandbox.fromSandboxClient(client, definition, "test-sandbox");
+
+  return { calls, client, instance, process, response, terminal, tunnelInfo };
+};
+
+it.effect("executes commands and wraps process handles", () => {
+  const fake = makeFakeClient();
+
+  return Effect.gen(function* () {
+    const handle = yield* fake.instance.exec(["echo", "hi"], { cwd: "/workspace" });
+
+    assert.strictEqual(handle.id, "proc-1");
+    assert.strictEqual(handle.pid, 42);
+    assert.deepStrictEqual(yield* handle.status, runningStatus);
+    assert.strictEqual(yield* handle.exitCode, 0);
+
+    const exit = yield* handle.waitForExit({ timeout: 5000 });
+
+    assert.deepStrictEqual(exit, processExit);
+
+    const output = yield* handle.outputText({ maxBytes: 1024 });
+
+    assert.strictEqual(output.stdout, "out");
+
+    const logMatch = yield* handle.waitForLog("ready");
+
+    assert.strictEqual(logMatch.match, "ready");
+    yield* handle.waitForPort(8080, { mode: "tcp" });
+    yield* handle.kill(15);
+
+    assert.deepStrictEqual(
+      fake.calls.map((call) => call.operation),
+      [
+        "exec",
+        "process.status",
+        "process.waitForExit",
+        "process.output",
+        "process.waitForLog",
+        "process.waitForPort",
+        "process.kill",
+      ],
+    );
+    assert.deepStrictEqual(fake.calls[0]?.args, [["echo", "hi"], { cwd: "/workspace" }]);
+    assert.deepStrictEqual(fake.calls[2], {
+      operation: "process.waitForExit",
+      args: [5000, true],
+    });
+    assert.deepStrictEqual(fake.calls[3], {
+      operation: "process.output",
+      args: ["utf8", 1024],
+    });
+    assert.deepStrictEqual(fake.calls[6]?.args, [15]);
+  });
+});
+
+it.effect("streams process logs as typed events", () => {
+  const fake = makeFakeClient();
+
+  return Effect.gen(function* () {
+    const handle = yield* fake.instance.exec(["sleep", "1"]);
+    const events = yield* Stream.runCollect(handle.logs({ replay: true }));
+
+    assert.deepStrictEqual(events, [...logEvents]);
+    assert.deepStrictEqual(fake.calls[1], {
+      operation: "process.logs",
+      args: [true, true],
+    });
+  });
+});
+
+it.effect("returns Option for process lookups", () => {
+  const fake = makeFakeClient();
+
+  return Effect.gen(function* () {
+    const found = yield* fake.instance.getProcess("proc-1");
+    const missing = yield* fake.instance.getProcess("proc-9");
+
+    assert.isTrue(Option.isSome(found));
+    assert.isTrue(Option.isNone(missing));
+    assert.strictEqual(Option.map(found, (handle) => handle.id).pipe(Option.getOrNull), "proc-1");
+  });
+});
+
+it.effect("wraps filesystem operations", () => {
+  const fake = makeFakeClient();
+
+  return Effect.gen(function* () {
+    const written = yield* fake.instance.writeFile("/workspace/a.txt", "hello");
+    const read = yield* fake.instance.readFile("/workspace/a.txt", { encoding: "utf-8" });
+    const made = yield* fake.instance.mkdir("/workspace/dir", { recursive: true });
+    const listed = yield* fake.instance.listFiles("/workspace");
+    const exists = yield* fake.instance.exists("/workspace/a.txt");
+    const renamed = yield* fake.instance.renameFile("/workspace/a.txt", "/workspace/b.txt");
+    const moved = yield* fake.instance.moveFile("/workspace/b.txt", "/tmp/b.txt");
+    const deleted = yield* fake.instance.deleteFile("/tmp/b.txt");
+    const changes = yield* fake.instance.checkChanges("/workspace", { since: "v0" });
+
+    yield* fake.instance.setEnvVars({ TOKEN: "secret", UNSET: undefined });
+
+    assert.isTrue(written.success);
+    assert.strictEqual(read.content, "file-content");
+    assert.isTrue(made.recursive);
+    assert.strictEqual(listed.count, 0);
+    assert.isTrue(exists.exists);
+    assert.strictEqual(renamed.newPath, "/workspace/b.txt");
+    assert.strictEqual(moved.newPath, "/tmp/b.txt");
+    assert.isTrue(deleted.success);
+    assert.strictEqual(changes.status, "unchanged");
+    assert.deepStrictEqual(
+      fake.calls.map((call) => call.operation),
+      [
+        "writeFile",
+        "readFile",
+        "mkdir",
+        "listFiles",
+        "exists",
+        "renameFile",
+        "moveFile",
+        "deleteFile",
+        "checkChanges",
+        "setEnvVars",
+      ],
+    );
+  });
+});
+
+it.effect("streams file contents as bytes", () => {
+  const fake = makeFakeClient();
+
+  return Effect.gen(function* () {
+    const chunks = yield* Stream.runCollect(fake.instance.readFileStream("/workspace/large.bin"));
+    const text = chunks.map((chunk) => new TextDecoder().decode(chunk)).join("");
+
+    assert.strictEqual(text, "chunk-1;chunk-2");
+    assert.deepStrictEqual(fake.calls, [
+      { operation: "readFileStream", args: ["/workspace/large.bin"] },
+    ]);
+  });
+});
+
+it.effect("decodes watch SSE frames across chunk boundaries", () => {
+  const watchingEvent: Sandbox.FileWatchSSEEvent = {
+    type: "watching",
+    path: "/workspace",
+    watchId: "w1",
+  };
+  const createEvent: Sandbox.FileWatchSSEEvent = {
+    type: "event",
+    eventType: "create",
+    path: "/workspace/a.txt",
+    isDirectory: false,
+    timestamp: "t",
+  };
+  const fake = makeFakeClient({
+    watchChunks: [
+      'data: {"type":"watching","path":"/works',
+      'pace","watchId":"w1"}\n\ndata: [DONE]\n\ndata: not-json\n\n',
+      `data: ${JSON.stringify(createEvent)}\n\n`,
+      'data: {"type":"stopped","reason":"shutdown"}',
+    ],
+  });
+
+  return Effect.gen(function* () {
+    const events = yield* Stream.runCollect(fake.instance.watch("/workspace", { recursive: true }));
+
+    assert.deepStrictEqual(events, [
+      watchingEvent,
+      createEvent,
+      { type: "stopped", reason: "shutdown" },
+    ]);
+    assert.deepStrictEqual(fake.calls[0]?.args, ["/workspace", { recursive: true }]);
+  });
+});
+
+it.effect("wraps port, preview, and proxy operations", () => {
+  const fake = makeFakeClient();
+
+  return Effect.gen(function* () {
+    const exposed = yield* fake.instance.exposePort(8080, { hostname: "example.com" });
+    const ports = yield* fake.instance.getExposedPorts("example.com");
+    const isExposed = yield* fake.instance.isPortExposed(8080);
+    const valid = yield* fake.instance.validatePortToken(8080, "valid");
+
+    yield* fake.instance.unexposePort(8080);
+
+    const fetched = yield* fake.instance.containerFetch("https://sandbox.test/health", 8080);
+    const upgraded = yield* fake.instance.wsConnect(new Request("https://sandbox.test/ws"), 8080);
+
+    assert.strictEqual(exposed.url, "https://8080-sandbox.example.com");
+    assert.strictEqual(ports.length, 1);
+    assert.isTrue(isExposed);
+    assert.isTrue(valid);
+    assert.strictEqual(fetched, fake.response);
+    assert.strictEqual(upgraded, fake.response);
+    assert.deepStrictEqual(
+      fake.calls.map((call) => call.operation),
+      [
+        "exposePort",
+        "getExposedPorts",
+        "isPortExposed",
+        "validatePortToken",
+        "unexposePort",
+        "containerFetch",
+        "wsConnect",
+      ],
+    );
+  });
+});
+
+it.effect("wraps bucket, backup, tunnel, and lifecycle operations", () => {
+  const fake = makeFakeClient();
+
+  return Effect.gen(function* () {
+    yield* fake.instance.mountBucket("artifacts", "/workspace/artifacts", { readOnly: true });
+
+    const backup = yield* fake.instance.createBackup({ dir: "/workspace" });
+    const restored = yield* fake.instance.restoreBackup(backup);
+
+    yield* fake.instance.unmountBucket("/workspace/artifacts");
+
+    const tunnel = yield* fake.instance.tunnels.get(8080);
+    const tunnels = yield* fake.instance.tunnels.list;
+
+    yield* fake.instance.tunnels.destroy(8080);
+    yield* fake.instance.start({ envVars: { MODE: "test" } });
+    yield* fake.instance.stop("SIGTERM");
+    yield* fake.instance.destroy;
+
+    assert.strictEqual(backup.id, "backup-1");
+    assert.isTrue(restored.success);
+    assert.strictEqual(tunnel, fake.tunnelInfo);
+    assert.deepStrictEqual(tunnels, [fake.tunnelInfo]);
+    assert.deepStrictEqual(
+      fake.calls.map((call) => call.operation),
+      [
+        "mountBucket",
+        "createBackup",
+        "restoreBackup",
+        "unmountBucket",
+        "tunnels.get",
+        "tunnels.list",
+        "tunnels.destroy",
+        "start",
+        "stop",
+        "destroy",
+      ],
+    );
+  });
+});
+
+it.effect("wraps interactive terminals", () => {
+  const fake = makeFakeClient();
+
+  return Effect.gen(function* () {
+    const created = yield* fake.instance.createTerminal({ command: ["bash"] });
+
+    assert.strictEqual(created.id, "term-1");
+    assert.deepStrictEqual(yield* created.snapshot, terminalSnapshot);
+    yield* created.write(new TextEncoder().encode("ls\n"));
+    yield* created.resize(120, 40);
+
+    const events = yield* Stream.runCollect(created.output({ replay: true }));
+
+    assert.deepStrictEqual(events, [...terminalEvents]);
+    assert.deepStrictEqual(yield* created.waitForExit(), processExit);
+    yield* created.interrupt;
+    yield* created.terminate;
+
+    const found = yield* fake.instance.getTerminal("term-1");
+    const missing = yield* fake.instance.getTerminal("term-9");
+    const listed = yield* fake.instance.listTerminals;
+
+    assert.isTrue(Option.isSome(found));
+    assert.isTrue(Option.isNone(missing));
+    assert.strictEqual(listed.length, 1);
+    assert.deepStrictEqual(
+      fake.calls.map((call) => call.operation),
+      [
+        "createTerminal",
+        "terminal.getSnapshot",
+        "terminal.write",
+        "terminal.resize",
+        "terminal.output",
+        "terminal.waitForExit",
+        "terminal.interrupt",
+        "terminal.terminate",
+        "getTerminal",
+        "getTerminal",
+        "listTerminals",
+      ],
+    );
+  });
+});
+
+it.effect("maps rejected operations to SandboxOperationError", () => {
+  const cause = new Error("file missing");
+  const fake = makeFakeClient({ readFileFailure: cause });
+
+  return Effect.gen(function* () {
+    const error = yield* Effect.flip(fake.instance.readFile("/workspace/missing.txt"));
+
+    assert.instanceOf(error, Sandbox.SandboxOperationError);
+    assert.strictEqual(error.binding, "SANDBOX");
+    assert.strictEqual(error.instance, "test-sandbox");
+    assert.strictEqual(error.operation, "readFile");
+    assert.strictEqual(error.cause, cause);
+    assert.include(error.message, 'binding "SANDBOX"');
+  });
+});
+
+it.effect("resolves the namespace client from the binding", () => {
+  const namespace = makePartialTestDouble<Sandbox.SandboxNamespaceResource>({
+    idFromName: (name) => makePartialTestDouble<globalThis.DurableObjectId>({ name }),
+    get: () => makePartialTestDouble<globalThis.DurableObjectStub>({}),
+  });
+  const env = makePartialTestDouble<WorkerEnv & { readonly SANDBOX: typeof namespace }>({
+    SANDBOX: namespace,
+  });
+  const live = TestSandboxes.layer({ binding: "SANDBOX" }).pipe(
+    Layer.provide(Layer.succeed(WorkerEnvironment, env)),
+  );
+
+  return Effect.gen(function* () {
+    const sandboxes = yield* TestSandboxes;
+
+    assert.strictEqual(sandboxes.definition.binding, "SANDBOX");
+    assert.strictEqual(yield* TestSandboxes.rawUnsafe, namespace);
+  }).pipe(Effect.provide(live));
+});
+
+it.effect("reports missing and malformed bindings", () =>
+  Effect.gen(function* () {
+    const missing = yield* TestSandboxes.pipe(
+      Effect.provide(
+        TestSandboxes.layer({ binding: "SANDBOX" }).pipe(
+          Layer.provide(Layer.succeed(WorkerEnvironment, {})),
+        ),
+      ),
+      Effect.flip,
+    );
+
+    assert.instanceOf(missing, Binding.BindingNotFoundError);
+
+    const invalid = yield* TestSandboxes.pipe(
+      Effect.provide(
+        TestSandboxes.layer({ binding: "SANDBOX" }).pipe(
+          Layer.provide(
+            Layer.succeed(
+              WorkerEnvironment,
+              makePartialTestDouble<WorkerEnv & { readonly SANDBOX: object }>({ SANDBOX: {} }),
+            ),
+          ),
+        ),
+      ),
+      Effect.flip,
+    );
+
+    if (invalid._tag === "BindingValidationError") {
+      assert.strictEqual(invalid.binding, "SANDBOX");
+      assert.include(invalid.expected, "idFromName()");
+    } else {
+      assert.fail(`expected BindingValidationError, got ${invalid._tag}`);
+    }
+  }),
+);
+
+it("covers the complete ISandbox client surface", () => {
+  expectTypeOf<
+    Exclude<keyof Sandbox.ISandbox, keyof Sandbox.SandboxInstanceClient>
+  >().toEqualTypeOf<never>();
+});

--- a/packages/effect-cf/tests/sandbox.test-d.ts
+++ b/packages/effect-cf/tests/sandbox.test-d.ts
@@ -1,0 +1,39 @@
+import type { ISandbox } from "@cloudflare/sandbox";
+import { expectTypeOf } from "vitest";
+import { Effect, type Option, type Stream } from "effect";
+
+import * as Sandbox from "effect-cf/sandbox";
+
+type MissingClientMethods = Exclude<keyof ISandbox, keyof Sandbox.SandboxInstanceClient>;
+
+expectTypeOf<MissingClientMethods>().toEqualTypeOf<never>();
+
+class TestSandboxes extends Sandbox.Tag<TestSandboxes>()("TestSandboxes") {}
+
+const program = Effect.gen(function* () {
+  const sandbox = yield* TestSandboxes.get("my-sandbox");
+
+  expectTypeOf(sandbox.exec(["echo", "hi"])).toEqualTypeOf<
+    Effect.Effect<Sandbox.SandboxProcessHandle, Sandbox.SandboxOperationError>
+  >();
+  expectTypeOf(sandbox.getProcess("proc-1")).toEqualTypeOf<
+    Effect.Effect<Option.Option<Sandbox.SandboxProcessHandle>, Sandbox.SandboxOperationError>
+  >();
+  expectTypeOf(sandbox.readFileStream("/workspace/a.bin")).toEqualTypeOf<
+    Stream.Stream<Uint8Array, Sandbox.SandboxOperationError>
+  >();
+  expectTypeOf(sandbox.watch("/workspace")).toEqualTypeOf<
+    Stream.Stream<Sandbox.FileWatchSSEEvent, Sandbox.SandboxOperationError>
+  >();
+
+  const handle = yield* sandbox.exec(["sleep", "1"]);
+
+  expectTypeOf(handle.logs()).toEqualTypeOf<
+    Stream.Stream<Sandbox.ProcessLogEvent, Sandbox.SandboxOperationError>
+  >();
+  expectTypeOf(handle.waitForExit()).toEqualTypeOf<
+    Effect.Effect<Sandbox.ProcessExit, Sandbox.SandboxOperationError>
+  >();
+});
+
+void program;

--- a/packages/effect-cf/vite.config.ts
+++ b/packages/effect-cf/vite.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
       "src/ComputerWorkspace.ts",
       "src/ComputerWorkspaceHost.ts",
       "src/HyperdrivePg.ts",
+      "src/Sandbox.ts",
       "src/Vitest.ts",
     ],
     deps: {


### PR DESCRIPTION
## Summary

Adds a new optional-peer subpath export, `effect-cf/sandbox`, wrapping the Cloudflare Sandbox SDK 1.0 API line (`@cloudflare/sandbox@next`, currently `0.13.0-next.738.2`) as an Effect-native client.

- **Service**: `Sandbox.Tag<Self>()("Id")` / `Sandbox.make("Id")` create a typed tag keyed `effect-cf/Sandbox/<Id>`; `layer({ binding })` validates the Sandbox Durable Object namespace binding from `WorkerEnvironment` with the shared `Binding` machinery ([Sandbox.ts tag/layer](packages/effect-cf/src/Sandbox.ts)).
- **Optional peer, loaded lazily**: `@cloudflare/sandbox` is a `peerDependenciesMeta`-optional peer and is dynamically imported on first `get()`/`proxyToSandbox` use, mirroring the `@cloudflare/computer` pattern. The packaging test now bundles the root entry with an esbuild plugin that rejects both optional peers, proving neither leaks into `effect-cf`'s root export.
- **Instance client**: covers the complete `ISandbox` client contract plus the lifecycle, preview-port, tunnel, bucket-mount, backup, and terminal operations the SDK client proxies to the Durable Object. A type-level test asserts `Exclude<keyof ISandbox, keyof SandboxInstanceClient>` is `never`, so upstream surface drift fails typecheck.
- **Streams**: process `logs` and terminal `output` are Effect `Stream`s of typed events, `readFileStream` streams raw bytes, and `watch` decodes the SDK's Server-Sent Events framing into `Stream<FileWatchSSEEvent>` via a pure decoder mirroring the SDK's parser (no runtime import needed in the node test pool).
- **Interruption**: `waitForExit`, `waitForLog`, `output`, and `waitForPort` thread Effect's `AbortSignal` into the SDK so interrupting the Effect aborts the remote wait.
- **Errors**: one tagged `SandboxOperationError` (`binding`/`instance`/`operation`) whose `cause` preserves the SDK's rich error classes; every operation carries a tracing span.
- **`Sandbox.proxyToSandbox(request)`**: routes preview-URL traffic as `Effect<Option<Response>>`, adapting any configured binding name to the SDK's hardcoded `env.Sandbox` shape.
- README gains an install note, exports bullet, and a full `## Sandbox Example` with the matching `wrangler.jsonc`; a `minor` changeset is included.

Unit tests exercise the wrapper through the exported `fromSandboxClient` adapter against structural fakes (including SSE decoding across chunk boundaries and error-cause passthrough); the live `getSandbox` path cannot run under vitest since miniflare has no container runtime, matching how `ComputerWorkspace.layer` is treated.

## Validation

- `vp run check` (repo root): pass — build, format, type-aware lint, typecheck.
- `vp test` (repo root): 47 files passed, 341 tests passed / 3 skipped, including 13 new `Sandbox.test.ts` tests and the vitest typecheck project covering `sandbox.test-d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)