### PR TITLE
ci: pin checkout by commit and keep changesets reviewable

### DIFF
--- a/.github/workflows/effect-agent-pr-review.yml
+++ b/.github/workflows/effect-agent-pr-review.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Check out the review profile
         if: env.HAS_OPENAI_KEY == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -89,10 +89,12 @@ jobs:
           guidance-file: .github/review-guidance.md
           # Generated or vendored surfaces the reviewer should never spend
           # budget on.
+          # .changeset/** stays REVIEWABLE so the guidance's changeset
+          # policy is enforceable on ordinary PRs; changeset-only release
+          # plumbing is already excluded by the trigger's paths-ignore.
           ignore: >-
             bun.lock,
             **/CHANGELOG.md,
-            .changeset/**,
             dev-kit.lock.json,
             .agents/skills/**,
             .repos/**


### PR DESCRIPTION
## Summary

- Applies the two valid findings from the review bot's own first run on #113 (its inaugural review of this repository, which reviewed the workflow that runs it):
  - `actions/checkout` is now pinned to the v7 commit SHA (`3d3c42e5`), matching the SHA-pinning already used for `create-github-app-token` in this privileged, key-holding workflow.
  - `.changeset/**` is no longer in the reviewer's `ignore` list, so the guidance's changeset policy (exactly one consumer-worded changeset for published-package changes, none for internal PRs, never empty) is actually enforceable on ordinary PRs. Changeset-only release plumbing stays excluded by the trigger's `paths-ignore`.
- The bot's other two findings (checking out the guidance profile from the base SHA) were rejected in the review threads: on same-repo `pull_request` events the workflow definition itself also comes from the merge ref, so the guidance file already has exactly the workflow file's trust level — the same-repo job guard excludes forks, and this design is documented in the effect-agent action README (which also forbids combining `guidance-file` with `pull_request_target`).

## Validation

- CI-only change; no repository commands run and no changeset added, per the changeset policy for internal-only PRs.
- This PR's own review run exercises the modified workflow (merge-ref semantics), including the un-ignored `.changeset/**` surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
