### PR TITLE
ci: add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "effect-cf",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Cloud Agent install for the effect-cf monorepo.
+#
+# Idempotent bootstrap that mirrors CI (.github/workflows/check.yml):
+#   1. install the pinned Bun toolchain and expose it on PATH,
+#   2. restore workspace dependencies from the committed lockfile,
+#   3. run the locked Dev Kit setup (Effect source checkout + tsgo patch),
+#   4. expose the Vite+ CLI (`vp`) on PATH,
+#   5. build the publishable packages so examples consume their `dist` output.
+#
+# Safe to re-run: every step is a no-op when its result is already present.
+set -euo pipefail
+
+BUN_VERSION="1.3.14"
+
+# Prefer sudo for the shared /usr/local/bin symlinks, but tolerate running as
+# root (no sudo needed) or an image without sudo.
+SUDO=""
+if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+fi
+
+# 1. Install the pinned Bun (the repo's packageManager) if it is missing.
+if ! command -v bun >/dev/null 2>&1 && [ ! -x "${HOME}/.bun/bin/bun" ]; then
+  curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+fi
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+# Expose bun on the default PATH so non-login agent shells find it.
+if [ -n "$SUDO" ] || [ "$(id -u)" -eq 0 ]; then
+  $SUDO ln -sf "$BUN_INSTALL/bin/bun" /usr/local/bin/bun
+  $SUDO ln -sf "$BUN_INSTALL/bin/bunx" /usr/local/bin/bunx
+fi
+
+# 2. Install workspace dependencies from the lockfile. Lifecycle scripts are
+#    skipped here; the Dev Kit postinstall is run explicitly in --locked mode
+#    below (matching CI's `--frozen-lockfile --ignore-scripts`).
+bun install --frozen-lockfile --ignore-scripts
+
+# 3. Run the locked Dev Kit setup. Two Cloud-Agent-specific overrides:
+#    - VITE_GIT_HOOKS=0: Cursor owns core.hooksPath, so skip Vite+ git hooks
+#      (Dev Kit refuses to replace another hook manager and would fail here).
+#    - Filtered gitconfig: Cursor rewrites github.com URLs to an authenticated
+#      x-access-token form, but Dev Kit verifies the (public) Effect source
+#      checkout keeps its clean upstream origin. Drop the url.insteadOf rewrites
+#      for this step only; the Effect repo is public and needs no token.
+if [ -f "$HOME/.gitconfig" ]; then
+  GITCFG_CLEAN="$(mktemp)"
+  awk '
+    /^\[url /   { inurl=1; next }
+    /^\[/       { inurl=0; print; next }
+    inurl       { next }
+                { print }
+  ' "$HOME/.gitconfig" > "$GITCFG_CLEAN"
+  GIT_CONFIG_GLOBAL="$GITCFG_CLEAN" VITE_GIT_HOOKS=0 \
+    bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked
+  rm -f "$GITCFG_CLEAN"
+else
+  VITE_GIT_HOOKS=0 bun ./node_modules/@danieljvdm/dev-kit/bin/dev-kit.mjs apply --locked
+fi
+
+# 4. Expose the Vite+ CLI (`vp`), the repository's command authority, on PATH.
+if [ -n "$SUDO" ] || [ "$(id -u)" -eq 0 ]; then
+  $SUDO ln -sf "$PWD/node_modules/.bin/vp" /usr/local/bin/vp
+fi
+
+# 5. Build the publishable packages (mirrors CI's build step; warms vp cache).
+vp run effect-cf#build
+vp run effect-webtransport#build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repo-managed Cloud Agent environment so agents boot into a working `effect-cf` monorepo.

- `.cursor/environment.json` — default base image, `install` runs the bootstrap script.
- `.cursor/install.sh` — idempotent bootstrap that mirrors CI (`.github/workflows/check.yml`):
  1. installs the pinned Bun toolchain (`bun@1.3.14`) and exposes `bun`/`bunx` on `PATH`,
  2. `bun install --frozen-lockfile --ignore-scripts`,
  3. runs the locked Dev Kit setup (`dev-kit apply --locked`) for the Effect source checkout + TypeScript-Go patch,
  4. exposes the Vite+ CLI (`vp`) on `PATH`,
  5. builds the publishable packages (`effect-cf`, `effect-webtransport`).

Two Cloud-Agent-specific overrides are needed and documented inline in the script:
- `VITE_GIT_HOOKS=0` — Cursor owns `core.hooksPath`, and Dev Kit refuses to replace another Git hook manager, so the Vite+ hook install is skipped.
- A filtered `gitconfig` for the `dev-kit apply` step only — Cursor rewrites `github.com` URLs to an authenticated `x-access-token` form via `url.*.insteadOf`, but Dev Kit verifies the (public) Effect source checkout keeps its clean upstream origin. The rewrites are dropped just for that step; the Effect repo is public and needs no token.

No changeset: this is repository tooling only and does not touch a publishable package's `src` or `package.json`.

## Validation

All commands run from the repo root with the environment bootstrapped by `.cursor/install.sh`.

- `vp fmt --check` — pass (271 files)
- `vp lint` — pass (exit 0)
- `vp test` — 341 passed, 3 skipped (47 files)
- `vp run typecheck` — pass (24/24, Effect TypeScript-Go)
- `vp run effect-cf#build` and `vp run effect-webtransport#build` — pass
- `.cursor/install.sh` — idempotent (re-run is a clean no-op)

End-to-end product flows exercised on the bootstrapped VM:

- `todo-http` API Worker (`wrangler dev`, local D1): create → list → update (mark complete) → stats → clearCompleted, all returning correct JSON.
- `todos` full-stack demo (React SPA → web Worker → service binding → API Worker → local D1) driven through the browser UI:

[todos_fullstack_effect_cf_demo.mp4](https://cursor.com/agents/bc-99f010e1-89c8-4338-a656-51c0f693ad0a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftodos_fullstack_effect_cf_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99f010e1-89c8-4338-a656-51c0f693ad0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99f010e1-89c8-4338-a656-51c0f693ad0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

