### PR TITLE
chore(deps): migrate to @cloudflare/vitest-plugin v1

### DIFF
--- a/.changeset/vitest-plugin-v1.md
+++ b/.changeset/vitest-plugin-v1.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Move the optional `effect-cf/vitest` peer from `@cloudflare/vitest-pool-workers` to `@cloudflare/vitest-plugin` `^1.0.0`. The package API is unchanged: keep using `cloudflareTest()` and `cloudflare:test`.

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.31.0",
-        "@cloudflare/vitest-pool-workers": "catalog:",
+        "@cloudflare/vitest-plugin": "catalog:",
         "@danieljvdm/dev-kit": "0.18.0",
         "@effect-cf/repo": "workspace:*",
         "@effect/tsgo": "0.36.4",
@@ -291,12 +291,12 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "devDependencies": {
         "@cloudflare/computer": "0.2.0",
         "@cloudflare/containers": "catalog:",
         "@cloudflare/sandbox": "0.13.0-next.738.2",
-        "@cloudflare/vitest-pool-workers": "catalog:",
+        "@cloudflare/vitest-plugin": "catalog:",
         "@cloudflare/workers-types": "catalog:",
         "@effect/platform-node": "^4.0.0-rc.110",
         "@effect/sql-d1": "catalog:",
@@ -312,7 +312,7 @@
       "peerDependencies": {
         "@cloudflare/computer": "^0.2.0",
         "@cloudflare/sandbox": "^0.13.0-next.738.2",
-        "@cloudflare/vitest-pool-workers": "^0.21.3",
+        "@cloudflare/vitest-plugin": "^1.0.0",
         "@cloudflare/workers-types": "^4.20260611.1",
         "@effect/sql-d1": "^4.0.0-rc.110",
         "@effect/sql-pg": "^4.0.0-rc.110",
@@ -322,7 +322,7 @@
       "optionalPeers": [
         "@cloudflare/computer",
         "@cloudflare/sandbox",
-        "@cloudflare/vitest-pool-workers",
+        "@cloudflare/vitest-plugin",
         "@cloudflare/workers-types",
         "@effect/sql-pg",
       ],
@@ -354,7 +354,7 @@
   },
   "catalog": {
     "@cloudflare/containers": "0.3.7",
-    "@cloudflare/vitest-pool-workers": "0.21.3",
+    "@cloudflare/vitest-plugin": "1.0.0",
     "@cloudflare/workers-types": "4.20260611.1",
     "@effect/sql-d1": "^4.0.0-rc.110",
     "@effect/sql-pg": "^4.0.0-rc.110",
@@ -425,7 +425,7 @@
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
-    "@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.21.3", "", { "dependencies": { "cjs-module-lexer": "1.2.3", "esbuild": "0.28.1", "miniflare": "5.20260811.1-alpha", "wrangler": "4.123.0", "zod": "4.4.3" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-jCoGRQ6FlsP5adp1GJISvITOGdTHTpsWOq3KkSGIfeDY/5RKjTUagDwaXjpqBXY5gAk6id/QbgnGuCTAg6lSTQ=="],
+    "@cloudflare/vitest-plugin": ["@cloudflare/vitest-plugin@1.0.0", "", { "dependencies": { "cjs-module-lexer": "1.2.3", "esbuild": "0.28.1", "miniflare": "5.20260820.0-alpha", "wrangler": "4.125.0", "zod": "4.4.3" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-AhOD/JysC15kYw25uwdkcpbsbN86jjiv0crHobViU3U/34ImWHXIiTnwqr3ZU0gXO+dIC30LUWS6bL/N+BaDbQ=="],
 
     "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260611.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA=="],
 
@@ -1221,7 +1221,7 @@
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
-    "miniflare": ["miniflare@5.20260811.1-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260811.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA=="],
+    "miniflare": ["miniflare@5.20260820.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260820.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ=="],
 
     "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
@@ -1559,7 +1559,7 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "@cloudflare/vitest-pool-workers/wrangler": ["wrangler@4.123.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260811.1-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260811.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260811.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q=="],
+    "@cloudflare/vitest-plugin/wrangler": ["wrangler@4.125.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260820.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260820.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260820.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg=="],
 
     "@danieljvdm/dev-kit/effect": ["effect@4.0.0-beta.107", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "uuid": "^14.0.1" } }, "sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ=="],
 
@@ -1593,7 +1593,7 @@
 
     "miniflare/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
-    "miniflare/workerd": ["workerd@1.20260811.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260811.1", "@cloudflare/workerd-darwin-arm64": "1.20260811.1", "@cloudflare/workerd-linux-64": "1.20260811.1", "@cloudflare/workerd-linux-arm64": "1.20260811.1", "@cloudflare/workerd-windows-64": "1.20260811.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw=="],
+    "miniflare/workerd": ["workerd@1.20260820.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260820.1", "@cloudflare/workerd-darwin-arm64": "1.20260820.1", "@cloudflare/workerd-linux-64": "1.20260820.1", "@cloudflare/workerd-linux-arm64": "1.20260820.1", "@cloudflare/workerd-windows-64": "1.20260820.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w=="],
 
     "pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
@@ -1613,19 +1613,19 @@
 
     "wrangler/miniflare": ["miniflare@4.20260611.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.24.8", "workerd": "1.20260611.1", "ws": "8.20.1", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg=="],
 
-    "@cloudflare/vitest-pool-workers/wrangler/workerd": ["workerd@1.20260811.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260811.1", "@cloudflare/workerd-darwin-arm64": "1.20260811.1", "@cloudflare/workerd-linux-64": "1.20260811.1", "@cloudflare/workerd-linux-arm64": "1.20260811.1", "@cloudflare/workerd-windows-64": "1.20260811.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw=="],
+    "@cloudflare/vitest-plugin/wrangler/workerd": ["workerd@1.20260820.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260820.1", "@cloudflare/workerd-darwin-arm64": "1.20260820.1", "@cloudflare/workerd-linux-64": "1.20260820.1", "@cloudflare/workerd-linux-arm64": "1.20260820.1", "@cloudflare/workerd-windows-64": "1.20260820.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w=="],
 
     "eslint/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260811.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ=="],
+    "miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260820.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg=="],
 
-    "miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260811.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ=="],
+    "miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260820.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw=="],
 
-    "miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260811.1", "", { "os": "linux", "cpu": "x64" }, "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg=="],
+    "miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260820.1", "", { "os": "linux", "cpu": "x64" }, "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg=="],
 
-    "miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260811.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow=="],
+    "miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260820.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw=="],
 
-    "miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
+    "miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
 
     "pg/pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 
@@ -1733,15 +1733,15 @@
 
     "wrangler/miniflare/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
-    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260811.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ=="],
+    "@cloudflare/vitest-plugin/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260820.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg=="],
 
-    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260811.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ=="],
+    "@cloudflare/vitest-plugin/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260820.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw=="],
 
-    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260811.1", "", { "os": "linux", "cpu": "x64" }, "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg=="],
+    "@cloudflare/vitest-plugin/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260820.1", "", { "os": "linux", "cpu": "x64" }, "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg=="],
 
-    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260811.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow=="],
+    "@cloudflare/vitest-plugin/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260820.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw=="],
 
-    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
+    "@cloudflare/vitest-plugin/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
 
     "eslint/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
-    "@cloudflare/vitest-pool-workers": "catalog:",
+    "@cloudflare/vitest-plugin": "catalog:",
     "@danieljvdm/dev-kit": "0.18.0",
     "@effect-cf/repo": "workspace:*",
     "@effect/tsgo": "0.36.4",
@@ -65,7 +65,7 @@
   "catalog": {
     "@cloudflare/containers": "0.3.7",
     "@cloudflare/workers-types": "4.20260611.1",
-    "@cloudflare/vitest-pool-workers": "0.21.3",
+    "@cloudflare/vitest-plugin": "1.0.0",
     "@effect/sql-d1": "^4.0.0-rc.110",
     "@effect/sql-pg": "^4.0.0-rc.110",
     "@effect/sql-sqlite-do": "^4.0.0-rc.110",

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -72,12 +72,12 @@ Runtime creation belongs at Cloudflare entrypoints, not inside binding helpers.
 - `Rpc` - Cloudflare RPC type helpers and scoped disposal utilities
 - `WebTransport` - truthful WebTransport/HTTP-3 boundary: typed runtime capabilities and decoded inbound protocol metadata
 - `WorkerConfig` - Effect `Config` helpers backed by Cloudflare `env`
-- `effect-cf/vitest` - Effect-native runners and scoped test helpers for Cloudflare's Vitest Workers pool
+- `effect-cf/vitest` - Effect-native runners and scoped test helpers for Cloudflare's Workers Vitest plugin
 
-## Vitest Workers Pool
+## Vitest Workers Plugin
 
-Install and configure a `^0.21.3` release of
-[`@cloudflare/vitest-pool-workers`](https://github.com/cloudflare/workers-sdk/tree/main/packages/vitest-pool-workers#readme),
+Install and configure a `^1.0.0` release of
+[`@cloudflare/vitest-plugin`](https://github.com/cloudflare/workers-sdk/tree/main/packages/vitest-plugin#readme),
 then import the test-only helpers from `effect-cf/vitest`. The `fetch` runner
 constructs the Worker with the current test environment and waits for all
 `waitUntil` work before completing the Effect.
@@ -109,7 +109,7 @@ it.effect("reads Wrangler vars", () =>
 ```
 
 Queue consumers can be invoked with typed message bodies while retaining the
-pool's acknowledgement and retry result:
+plugin's acknowledgement and retry result:
 
 ```ts
 it.effect("acknowledges a job", () =>
@@ -130,7 +130,7 @@ it.effect("acknowledges a job", () =>
 
 Scheduled handlers and Pages Functions use the same lifecycle behavior: their
 Effects complete only after the event's `waitUntil` work has settled. Pages
-tests must configure the `ASSETS` binding required by Pool Workers.
+tests must configure the `ASSETS` binding required by the Workers Vitest plugin.
 
 ```ts
 it.effect("runs the cron handler", () =>

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -68,7 +68,7 @@
     "@cloudflare/computer": "0.2.0",
     "@cloudflare/containers": "catalog:",
     "@cloudflare/sandbox": "0.13.0-next.738.2",
-    "@cloudflare/vitest-pool-workers": "catalog:",
+    "@cloudflare/vitest-plugin": "catalog:",
     "@cloudflare/workers-types": "catalog:",
     "@effect/platform-node": "^4.0.0-rc.110",
     "@effect/sql-d1": "catalog:",
@@ -84,7 +84,7 @@
   "peerDependencies": {
     "@cloudflare/computer": "^0.2.0",
     "@cloudflare/sandbox": "^0.13.0-next.738.2",
-    "@cloudflare/vitest-pool-workers": "^0.21.3",
+    "@cloudflare/vitest-plugin": "^1.0.0",
     "@cloudflare/workers-types": "^4.20260611.1",
     "@effect/sql-d1": "^4.0.0-rc.110",
     "@effect/sql-pg": "^4.0.0-rc.110",
@@ -98,7 +98,7 @@
     "@cloudflare/sandbox": {
       "optional": true
     },
-    "@cloudflare/vitest-pool-workers": {
+    "@cloudflare/vitest-plugin": {
       "optional": true
     },
     "@cloudflare/workers-types": {

--- a/packages/effect-cf/src/Vitest.ts
+++ b/packages/effect-cf/src/Vitest.ts
@@ -1,5 +1,5 @@
 /**
- * Effect-native helpers for tests running in Cloudflare's Vitest Workers pool.
+ * Effect-native helpers for tests running in Cloudflare's Workers Vitest plugin.
  *
  * Import this module through the `effect-cf/vitest` subpath. It is intended to
  * run inside the Workers test runtime, where `cloudflare:test` is available.
@@ -37,7 +37,7 @@ import type { WorkflowInstanceStatusName } from "./WorkflowBinding";
 const currentEnv: WorkerEnv = env;
 
 /**
- * Provides the Workers pool environment as both {@link WorkerEnvironment} and
+ * Provides the Workers test environment as both {@link WorkerEnvironment} and
  * the active Effect `ConfigProvider`.
  */
 export const layer: Layer.Layer<WorkerEnvironment> = Layer.mergeAll(
@@ -134,7 +134,7 @@ type PagesEventContextInitData<Context> =
       : { readonly data: Data }
     : never;
 
-/** Initialization accepted by Pool Workers for a Pages Function. */
+/** Initialization accepted by the Workers Vitest plugin for a Pages Function. */
 export type PagesEventContextInit<Function extends AnyPagesFunction> = PagesEventContextInitBase &
   PagesEventContextInitParams<Parameters<Function>[0]> &
   PagesEventContextInitData<Parameters<Function>[0]>;
@@ -162,14 +162,14 @@ interface QueueWorker {
   queue(batch: globalThis.MessageBatch): Promise<void>;
 }
 
-/** Input message accepted by Pool Workers' `createMessageBatch` helper. */
+/** Input message accepted by the Workers Vitest plugin's `createMessageBatch` helper. */
 export type QueueMessage<Body> = {
   readonly id: string;
   readonly timestamp: Date;
   readonly attempts: number;
 } & ({ readonly body: Body } | { readonly serializedBody: ArrayBuffer | ArrayBufferView });
 
-/** Acknowledgement and retry result returned by Pool Workers. */
+/** Acknowledgement and retry result returned by the Workers Vitest plugin. */
 export type QueueResult = Awaited<ReturnType<typeof getQueueResult>>;
 
 /** Result of invoking a queue consumer through {@link queue}. */
@@ -180,7 +180,7 @@ export interface QueueRunResult<Body> {
 
 /**
  * Invokes an Effect-backed queue consumer, drains its `waitUntil` work, and
- * returns Pool Workers' acknowledgement and retry result.
+ * returns the Workers Vitest plugin's acknowledgement and retry result.
  */
 export const queue = Effect.fn("effect-cf/vitest/queue")(function* <
   Body,
@@ -280,7 +280,7 @@ export const evictAllDurableObjects = Effect.fn("effect-cf/vitest/evictAllDurabl
   },
 );
 
-/** A D1 migration accepted by Pool Workers. */
+/** A D1 migration accepted by the Workers Vitest plugin. */
 export interface D1Migration {
   readonly name: string;
   readonly queries: ReadonlyArray<string>;
@@ -310,7 +310,7 @@ export interface SecretsStoreSecret {
   readonly metadata?: { readonly uuid: string };
 }
 
-/** Effect-native wrapper around Pool Workers' Secrets Store admin API. */
+/** Effect-native wrapper around the Workers Vitest plugin's Secrets Store admin API. */
 export interface SecretsStoreAdmin {
   readonly raw: NativeSecretsStoreAdmin;
   readonly create: (value: string) => Effect.Effect<string>;
@@ -445,7 +445,7 @@ const runWorkflowModifier = Effect.fnUntraced(function* <A, E, R>(
     }
 
     if (callbackExit === undefined) {
-      throw new Error("Pool Workers did not invoke the Workflow modifier callback");
+      throw new Error("The Workers Vitest plugin did not invoke the Workflow modifier callback");
     }
 
     return callbackExit;

--- a/packages/effect-cf/tests/Cache.worker.test.ts
+++ b/packages/effect-cf/tests/Cache.worker.test.ts
@@ -1,4 +1,4 @@
-/// <reference types="@cloudflare/vitest-pool-workers/types" />
+/// <reference types="@cloudflare/vitest-plugin/types" />
 
 import { Effect } from "effect";
 import { expect, test } from "vite-plus/test";

--- a/packages/effect-cf/tests/CloudflareOtlp.worker.test.ts
+++ b/packages/effect-cf/tests/CloudflareOtlp.worker.test.ts
@@ -1,4 +1,4 @@
-/// <reference types="@cloudflare/vitest-pool-workers/types" />
+/// <reference types="@cloudflare/vitest-plugin/types" />
 
 import { createExecutionContext } from "cloudflare:test";
 import { expect, it } from "@effect/vitest";

--- a/packages/effect-cf/tests/ComputerWorkspace.worker.test.ts
+++ b/packages/effect-cf/tests/ComputerWorkspace.worker.test.ts
@@ -1,4 +1,4 @@
-/// <reference types="@cloudflare/vitest-pool-workers/types" />
+/// <reference types="@cloudflare/vitest-plugin/types" />
 
 import { env } from "cloudflare:test";
 import { expect, test } from "vite-plus/test";

--- a/packages/effect-cf/tests/env.d.ts
+++ b/packages/effect-cf/tests/env.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="@cloudflare/vitest-pool-workers/types" />
+/// <reference types="@cloudflare/vitest-plugin/types" />
 
 import type * as EffectArtifacts from "../src/Artifacts";
 import type * as TestWorkerModule from "./worker-fixture";

--- a/packages/effect-cf/tests/rpc-boundary.worker.test.ts
+++ b/packages/effect-cf/tests/rpc-boundary.worker.test.ts
@@ -1,4 +1,4 @@
-/// <reference types="@cloudflare/vitest-pool-workers/types" />
+/// <reference types="@cloudflare/vitest-plugin/types" />
 
 import { createExecutionContext, env } from "cloudflare:test";
 import { Effect, Layer, Predicate, Schema as S } from "effect";

--- a/packages/effect-cf/tests/worker-runtime.worker.test.ts
+++ b/packages/effect-cf/tests/worker-runtime.worker.test.ts
@@ -1,4 +1,4 @@
-/// <reference types="@cloudflare/vitest-pool-workers/types" />
+/// <reference types="@cloudflare/vitest-plugin/types" />
 
 import { createExecutionContext } from "cloudflare:test";
 import { Clock, Duration, Effect, Layer, Schema } from "effect";

--- a/packages/effect-cf/tsconfig.json
+++ b/packages/effect-cf/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ESNext"],
     "module": "esnext",
     "moduleResolution": "bundler",
-    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers/types"],
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-plugin/types"],
     "strict": true,
     "noUnusedLocals": true,
     "declaration": true,

--- a/packages/effect-cf/vite.config.ts
+++ b/packages/effect-cf/vite.config.ts
@@ -1,4 +1,4 @@
-import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { cloudflareTest } from "@cloudflare/vitest-plugin";
 import { defineConfig } from "vite-plus";
 
 const testExcludes = ["**/node_modules/**", "**/dist/**", "**/.git/**"];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { cloudflareTest } from "@cloudflare/vitest-plugin";
 import { createRecommendedVitePlusConfig } from "@danieljvdm/dev-kit/vite-plus";
 import { defineConfig } from "vite-plus";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Swap the optional Workers Vitest peer from [`@cloudflare/vitest-pool-workers`](https://www.npmjs.com/package/@cloudflare/vitest-pool-workers) to [`@cloudflare/vitest-plugin`](https://www.npmjs.com/package/@cloudflare/vitest-plugin) `^1.0.0`. Cloudflare's [migration guide](https://developers.cloudflare.com/workers/testing/vitest-integration/migration-guides/migrate-to-vitest-plugin/) says the package API and Vitest configuration are unchanged. This is a `minor` `effect-cf` bump, not a major.

This updates:

- catalog + lockfile
- the [optional `effect-cf` peer](https://github.com/danieljvdm/effect-cf/blob/cursor/migrate-vitest-plugin-4cd1/packages/effect-cf/package.json)
- [`cloudflareTest()` imports](https://github.com/danieljvdm/effect-cf/blob/cursor/migrate-vitest-plugin-4cd1/packages/effect-cf/vite.config.ts)
- `@cloudflare/vitest-plugin/types` references
- `effect-cf/vitest` docs

`effect-cf/vitest` still imports `cloudflare:test` helpers. Consumers need the renamed plugin package, not a test-source rewrite.

### API / runtime notes vs `0.21.3`

No `cloudflare:test` or `cloudflareTest()` signature changes. Diff of the published type files is a comment rename only.

Real deltas are bundled runtime versions:

- miniflare `5.20260811.1-alpha` → `5.20260820.0-alpha`
- nested wrangler `4.123.0` → `4.125.0`
- workerd `1.20260811.1` → `1.20260820.1`

Type-only: `cloudflareTest({ inject })` now infers keys from Vitest `ProvidedContext` when that augmentation is visible. `readD1Migrations` stays on the main export (the `/config` subpath was already gone in `0.21.3`; Cloudflare's types comment still mentions `/config` incorrectly). The v1 package dropped the `./codemods/vitest-v3-to-v4` export, which this repo never used.

This is not the Vitest 3→4 migration. That already landed here (`cloudflareTest()`, `fetchMock` removed, `env`/`SELF` from `cloudflare:test` deprecated in favor of `cloudflare:workers`). The new docs point outbound mocking at [`@msw/cloudflare`](https://github.com/mswjs/cloudflare); we do not use `fetchMock`.

Catalog `wrangler` stays `4.100.0` and `@cloudflare/workers-types` stays `4.20260611.1`. The plugin's nested wrangler optionally peers `@cloudflare/workers-types` `^5`, same pattern as `0.21.3`.

## Validation

- `vp run check` passed locally
- GitHub `Check / check` and `CI / PR Policy` are green
- Vitest: 47 files, 341 passed, 3 skipped, including all 9 `*.worker.test.ts` files under the new plugin pool
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-899244e3-5469-4fb4-8bfd-a848a8094cd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-899244e3-5469-4fb4-8bfd-a848a8094cd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

