### PR TITLE
feat(effect-cf): pin workerd 1.20260820.1 and wrap new APIs

### DIFF
--- a/.changeset/workerd-20260820.md
+++ b/.changeset/workerd-20260820.md
@@ -4,4 +4,4 @@
 
 Pin the Cloudflare Workers runtime stack to workerd `1.20260820.1` (`@cloudflare/workers-types@^5.20260820.1`, wrangler `4.125.0`, recommended `compatibility_date` `2026-08-20`).
 
-Images gains text rasterization (`text` / `process` text input), hosted `createDirectUpload` and `signedUrl`, and `response(options?)` for extra headers. Workflow instances gain `delete`, optional `terminate({ rollback })`, and `create`/`createBatch` `locationHint` via the updated types.
+Images gains text rasterization (`text` / `process` text input), hosted `createDirectUpload` and `signedUrl`, and `response(options?)` for extra headers. Workflow instances gain `delete`, optional `terminate({ rollback })`, and `create`/`createBatch` `locationHint` via the updated types. `Worker.WorkerContext` now wraps the non-experimental `ExecutionContext.abort`.

--- a/.changeset/workerd-20260820.md
+++ b/.changeset/workerd-20260820.md
@@ -1,0 +1,7 @@
+---
+"effect-cf": minor
+---
+
+Pin the Cloudflare Workers runtime stack to workerd `1.20260820.1` (`@cloudflare/workers-types@^5.20260820.1`, wrangler `4.125.0`, recommended `compatibility_date` `2026-08-20`).
+
+Images gains text rasterization (`text` / `process` text input), hosted `createDirectUpload` and `signedUrl`, and `response(options?)` for extra headers. Workflow instances gain `delete`, optional `terminate({ rollback })`, and `create`/`createBatch` `locationHint` via the updated types.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Do not use `bun run`, `npm run`, `pnpm run`, or `yarn run` in this repository. D
 
 - `packages/effect-cf` and `packages/effect-webtransport` are the publishable packages.
 - `packages/effect-cf` holds Cloudflare-specific primitives; `packages/effect-webtransport` is a platform-generic Effect WebTransport library with no Cloudflare dependency.
+- `effect-cf` pins Cloudflare workerd `1.20260820.1` via the root catalog (`@cloudflare/workers-types@5.20260820.1`, `wrangler@4.125.0`) and recommends `compatibility_date` `2026-08-20`. Keep those three in lockstep when bumping the runtime.
 - `examples/` contains consumer and example applications.
 - Reusable package code belongs under a package's `src/` and must be exported from that package's `src/index.ts`.
 - Worker projects use `@cloudflare/workers-types` directly for Cloudflare runtime types.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This monorepo also publishes [`effect-webtransport`](packages/effect-webtranspor
 
 ## Install
 
-`effect-cf` targets Effect `^4.0.0-beta.105`.
+`effect-cf` targets Effect `^4.0.0-beta.105` and Cloudflare workerd `1.20260820.1`
+(`@cloudflare/workers-types@5.20260820.1`, recommended `compatibility_date` `2026-08-20`).
 
 ```bash
 bun add effect-cf "effect@^4.0.0-beta.105"

--- a/bun.lock
+++ b/bun.lock
@@ -313,7 +313,7 @@
         "@cloudflare/computer": "^0.2.0",
         "@cloudflare/sandbox": "^0.13.0-next.738.2",
         "@cloudflare/vitest-plugin": "^1.0.0",
-        "@cloudflare/workers-types": "^4.20260611.1",
+        "@cloudflare/workers-types": "^5.20260820.1",
         "@effect/sql-d1": "^4.0.0-rc.110",
         "@effect/sql-pg": "^4.0.0-rc.110",
         "@effect/sql-sqlite-do": "^4.0.0-rc.110",
@@ -355,7 +355,7 @@
   "catalog": {
     "@cloudflare/containers": "0.3.7",
     "@cloudflare/vitest-plugin": "1.0.0",
-    "@cloudflare/workers-types": "4.20260611.1",
+    "@cloudflare/workers-types": "5.20260820.1",
     "@effect/sql-d1": "^4.0.0-rc.110",
     "@effect/sql-pg": "^4.0.0-rc.110",
     "@effect/sql-sqlite-do": "^4.0.0-rc.110",
@@ -364,7 +364,7 @@
     "vite": "npm:@voidzero-dev/vite-plus-core@0.2.6",
     "vite-plus": "0.2.6",
     "vitest": "4.1.10",
-    "wrangler": "4.100.0",
+    "wrangler": "4.125.0",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -427,17 +427,17 @@
 
     "@cloudflare/vitest-plugin": ["@cloudflare/vitest-plugin@1.0.0", "", { "dependencies": { "cjs-module-lexer": "1.2.3", "esbuild": "0.28.1", "miniflare": "5.20260820.0-alpha", "wrangler": "4.125.0", "zod": "4.4.3" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-AhOD/JysC15kYw25uwdkcpbsbN86jjiv0crHobViU3U/34ImWHXIiTnwqr3ZU0gXO+dIC30LUWS6bL/N+BaDbQ=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260611.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260820.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260611.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yBbVXvbZyltR3I7NJdC4C4ItkItjZSiabcA/3HzEWOUQjLVKFqRh4so6ToHr70VCYh8VGeR8EDZL23igLhXqFQ=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260820.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260611.1", "", { "os": "linux", "cpu": "x64" }, "sha512-PfNjpxOlaIgZFYuhD7+neEEewCN2Ud993wEEN0fmbtSOax1AK53LGqmXUDvFhnbkHxJLFAxYCSNISW8QbzaAIg=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260820.1", "", { "os": "linux", "cpu": "x64" }, "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260611.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-GEp4XbuIKjlF8pakqXcUDJfKiJosD/Q7S83J0d+r+z9XIlYGfF3ntm08e2aiF5TFTwp3fnG4yMoPUAKNhNJpvQ=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260820.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260611.1", "", { "os": "win32", "cpu": "x64" }, "sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260611.1", "", {}, "sha512-DLiz8Ol1OIWLigJ+dGvuQ5Nm66D/CHNPasl8YnPiz6fGo10ggYSIVuEDMlFk6oho+piAHstNmZMl088w8xqW6g=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260820.1", "", {}, "sha512-KFRmtV4toMf1LL2yXylFTIs7YAS1IYo6jrJCneBG8I1VXHcKCIdqPROH6lGum+gZ+ZgdcNZqxDgjM1yEMgma2w=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -607,7 +607,7 @@
 
     "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
 
     "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "cpu": "none" }, "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g=="],
 
@@ -1533,9 +1533,9 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "workerd": ["workerd@1.20260611.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260611.1", "@cloudflare/workerd-darwin-arm64": "1.20260611.1", "@cloudflare/workerd-linux-64": "1.20260611.1", "@cloudflare/workerd-linux-arm64": "1.20260611.1", "@cloudflare/workerd-windows-64": "1.20260611.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w=="],
+    "workerd": ["workerd@1.20260820.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260820.1", "@cloudflare/workerd-darwin-arm64": "1.20260820.1", "@cloudflare/workerd-linux-64": "1.20260820.1", "@cloudflare/workerd-linux-arm64": "1.20260820.1", "@cloudflare/workerd-windows-64": "1.20260820.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w=="],
 
-    "wrangler": ["wrangler@4.100.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260611.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260611.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260611.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg=="],
+    "wrangler": ["wrangler@4.125.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260820.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260820.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260820.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -1559,17 +1559,13 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "@cloudflare/vitest-plugin/wrangler": ["wrangler@4.125.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260820.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260820.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260820.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg=="],
-
     "@danieljvdm/dev-kit/effect": ["effect@4.0.0-beta.107", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "uuid": "^14.0.1" } }, "sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ=="],
 
     "@danieljvdm/dev-kit/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "@effect/sql-d1/@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260611.1", "", {}, "sha512-DLiz8Ol1OIWLigJ+dGvuQ5Nm66D/CHNPasl8YnPiz6fGo10ggYSIVuEDMlFk6oho+piAHstNmZMl088w8xqW6g=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
-
-    "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -1593,8 +1589,6 @@
 
     "miniflare/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
-    "miniflare/workerd": ["workerd@1.20260820.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260820.1", "@cloudflare/workerd-darwin-arm64": "1.20260820.1", "@cloudflare/workerd-linux-64": "1.20260820.1", "@cloudflare/workerd-linux-arm64": "1.20260820.1", "@cloudflare/workerd-windows-64": "1.20260820.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w=="],
-
     "pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
@@ -1609,23 +1603,7 @@
 
     "vite-plus/oxlint": ["oxlint@1.75.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.75.0", "@oxlint/binding-android-arm64": "1.75.0", "@oxlint/binding-darwin-arm64": "1.75.0", "@oxlint/binding-darwin-x64": "1.75.0", "@oxlint/binding-freebsd-x64": "1.75.0", "@oxlint/binding-linux-arm-gnueabihf": "1.75.0", "@oxlint/binding-linux-arm-musleabihf": "1.75.0", "@oxlint/binding-linux-arm64-gnu": "1.75.0", "@oxlint/binding-linux-arm64-musl": "1.75.0", "@oxlint/binding-linux-ppc64-gnu": "1.75.0", "@oxlint/binding-linux-riscv64-gnu": "1.75.0", "@oxlint/binding-linux-riscv64-musl": "1.75.0", "@oxlint/binding-linux-s390x-gnu": "1.75.0", "@oxlint/binding-linux-x64-gnu": "1.75.0", "@oxlint/binding-linux-x64-musl": "1.75.0", "@oxlint/binding-openharmony-arm64": "1.75.0", "@oxlint/binding-win32-arm64-msvc": "1.75.0", "@oxlint/binding-win32-ia32-msvc": "1.75.0", "@oxlint/binding-win32-x64-msvc": "1.75.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g=="],
 
-    "wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
-
-    "wrangler/miniflare": ["miniflare@4.20260611.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.24.8", "workerd": "1.20260611.1", "ws": "8.20.1", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg=="],
-
-    "@cloudflare/vitest-plugin/wrangler/workerd": ["workerd@1.20260820.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260820.1", "@cloudflare/workerd-darwin-arm64": "1.20260820.1", "@cloudflare/workerd-linux-64": "1.20260820.1", "@cloudflare/workerd-linux-arm64": "1.20260820.1", "@cloudflare/workerd-windows-64": "1.20260820.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w=="],
-
     "eslint/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
-
-    "miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260820.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg=="],
-
-    "miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260820.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw=="],
-
-    "miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260820.1", "", { "os": "linux", "cpu": "x64" }, "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg=="],
-
-    "miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260820.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw=="],
-
-    "miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
 
     "pg/pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 
@@ -1675,123 +1653,9 @@
 
     "vite-plus/oxlint/@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.75.0", "", { "os": "win32", "cpu": "x64" }, "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA=="],
 
-    "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
-
-    "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
-
-    "wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
-
-    "wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
-
-    "wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
-
-    "wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
-
-    "wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
-
-    "wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
-
-    "wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
-
-    "wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
-
-    "wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
-
-    "wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
-
-    "wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
-
-    "wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
-
-    "wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
-
-    "wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
-
-    "wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
-
-    "wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
-
-    "wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
-
-    "wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
-
-    "wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
-
-    "wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
-
-    "wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
-
-    "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
-
-    "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
-
-    "wrangler/miniflare/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
-
-    "wrangler/miniflare/undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
-
-    "wrangler/miniflare/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
-
-    "@cloudflare/vitest-plugin/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260820.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg=="],
-
-    "@cloudflare/vitest-plugin/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260820.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw=="],
-
-    "@cloudflare/vitest-plugin/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260820.1", "", { "os": "linux", "cpu": "x64" }, "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg=="],
-
-    "@cloudflare/vitest-plugin/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260820.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw=="],
-
-    "@cloudflare/vitest-plugin/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
-
     "eslint/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
     "read-yaml-file/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
-
-    "wrangler/miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "eslint/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
   }

--- a/examples/chat/durable-objects/chat-room/wrangler.jsonc
+++ b/examples/chat/durable-objects/chat-room/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-chat-room",
   "main": "src/index.ts",
-  "compatibility_date": "2026-04-24",
+  "compatibility_date": "2026-08-20",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,

--- a/examples/chat/workers/analytics/wrangler.jsonc
+++ b/examples/chat/workers/analytics/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-chat-analytics",
   "main": "src/index.ts",
-  "compatibility_date": "2026-04-24",
+  "compatibility_date": "2026-08-20",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,

--- a/examples/chat/workers/api/wrangler.jsonc
+++ b/examples/chat/workers/api/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-chat-api",
   "main": "src/index.ts",
-  "compatibility_date": "2026-04-24",
+  "compatibility_date": "2026-08-20",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,

--- a/examples/containers/README.md
+++ b/examples/containers/README.md
@@ -45,7 +45,7 @@ Durable Object namespace:
 {
   "name": "container-example",
   "main": "src/index.ts",
-  "compatibility_date": "2026-06-11",
+  "compatibility_date": "2026-08-20",
   "containers": [
     {
       "class_name": "RendererContainer",

--- a/examples/email/README.md
+++ b/examples/email/README.md
@@ -62,7 +62,7 @@ locally:
 {
   "name": "email-example",
   "main": "src/index.ts",
-  "compatibility_date": "2026-06-11",
+  "compatibility_date": "2026-08-20",
   "send_email": [
     {
       "name": "EMAIL",

--- a/examples/queue-workflow/workers/app/tests/examples.test.ts
+++ b/examples/queue-workflow/workers/app/tests/examples.test.ts
@@ -25,6 +25,8 @@ import {
   startReportWorkflow,
 } from "../src/workflow.ts";
 
+// SAFETY: This fixture only implements the ExecutionContext methods the queue/workflow
+// examples exercise; workers-types v5 also requires exports/tracing which stay unused here.
 const executionContext = {
   waitUntil(_promise: Promise<unknown>) {},
   passThroughOnException() {},
@@ -185,8 +187,10 @@ interface ReportInstanceStatus extends Omit<InstanceStatus, "output"> {
   readonly output?: ReportResult;
 }
 
-const makeWorkflowInstance = (id: string, status: ReportInstanceStatus): WorkflowInstance =>
-  ({
+const makeWorkflowInstance = (id: string, status: ReportInstanceStatus): WorkflowInstance => {
+  // SAFETY: This fixture implements the WorkflowInstance methods exercised by the example
+  // binding tests; platform-only fields beyond that surface are unused.
+  return {
     id,
     pause: async () => undefined,
     resume: async () => undefined,
@@ -195,7 +199,8 @@ const makeWorkflowInstance = (id: string, status: ReportInstanceStatus): Workflo
     delete: async () => undefined,
     status: async () => status,
     sendEvent: async () => undefined,
-  }) as WorkflowInstance;
+  } as WorkflowInstance;
+};
 
 class TestWorkflowStep {
   constructor(private readonly calls: Array<string>) {}
@@ -234,5 +239,8 @@ class TestWorkflowStep {
   }
 }
 
-const makeWorkflowStep = (calls: Array<string>): WorkflowStep =>
-  new TestWorkflowStep(calls) as unknown as WorkflowStep;
+const makeWorkflowStep = (calls: Array<string>): WorkflowStep => {
+  // SAFETY: This fixture owns the do/sleep/sleepUntil callbacks the example workflow
+  // invokes; Cloudflare's newer delay-function overloads are unused here.
+  return new TestWorkflowStep(calls) as WorkflowStep;
+};

--- a/examples/queue-workflow/workers/app/tests/examples.test.ts
+++ b/examples/queue-workflow/workers/app/tests/examples.test.ts
@@ -29,7 +29,8 @@ const executionContext = {
   waitUntil(_promise: Promise<unknown>) {},
   passThroughOnException() {},
   props: undefined,
-} satisfies ExecutionContext;
+  abort() {},
+} as ExecutionContext;
 
 test("Queue example sends typed jobs through a producer binding", async () => {
   await Effect.runPromise(
@@ -184,30 +185,21 @@ interface ReportInstanceStatus extends Omit<InstanceStatus, "output"> {
   readonly output?: ReportResult;
 }
 
-const makeWorkflowInstance = (id: string, status: ReportInstanceStatus): WorkflowInstance => ({
-  id,
-  pause: async () => undefined,
-  resume: async () => undefined,
-  terminate: async () => undefined,
-  restart: async () => undefined,
-  status: async () => status,
-  sendEvent: async () => undefined,
-});
+const makeWorkflowInstance = (id: string, status: ReportInstanceStatus): WorkflowInstance =>
+  ({
+    id,
+    pause: async () => undefined,
+    resume: async () => undefined,
+    terminate: async () => undefined,
+    restart: async () => undefined,
+    delete: async () => undefined,
+    status: async () => status,
+    sendEvent: async () => undefined,
+  }) as WorkflowInstance;
 
-class TestWorkflowStep implements WorkflowStep {
+class TestWorkflowStep {
   constructor(private readonly calls: Array<string>) {}
 
-  do<T>(
-    name: string,
-    callback: (context: WorkflowStepContext) => Promise<T>,
-    rollbackOptions?: WorkflowStepRollbackOptions<T>,
-  ): Promise<T>;
-  do<T>(
-    name: string,
-    config: WorkflowStepConfig,
-    callback: (context: WorkflowStepContext) => Promise<T>,
-    rollbackOptions?: WorkflowStepRollbackOptions<T>,
-  ): Promise<T>;
   async do<T>(
     name: string,
     configOrCallback: WorkflowStepConfig | ((context: WorkflowStepContext) => Promise<T>),
@@ -242,4 +234,5 @@ class TestWorkflowStep implements WorkflowStep {
   }
 }
 
-const makeWorkflowStep = (calls: Array<string>): WorkflowStep => new TestWorkflowStep(calls);
+const makeWorkflowStep = (calls: Array<string>): WorkflowStep =>
+  new TestWorkflowStep(calls) as unknown as WorkflowStep;

--- a/examples/todo-http/workers/api/wrangler.jsonc
+++ b/examples/todo-http/workers/api/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todo-http-api",
   "main": "src/index.ts",
-  "compatibility_date": "2026-04-25",
+  "compatibility_date": "2026-08-20",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "d1_databases": [

--- a/examples/todo-rpc-http/workers/api/wrangler.jsonc
+++ b/examples/todo-rpc-http/workers/api/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todo-rpc-http-api",
   "main": "src/index.ts",
-  "compatibility_date": "2026-04-25",
+  "compatibility_date": "2026-08-20",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "d1_databases": [

--- a/examples/todo-rpc-ws/durable-objects/todo-store/wrangler.jsonc
+++ b/examples/todo-rpc-ws/durable-objects/todo-store/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todo-rpc-ws-store",
   "main": "src/index.ts",
-  "compatibility_date": "2026-04-25",
+  "compatibility_date": "2026-08-20",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "durable_objects": {

--- a/examples/todo-rpc-ws/workers/api/wrangler.jsonc
+++ b/examples/todo-rpc-ws/workers/api/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todo-rpc-ws-api",
   "main": "src/index.ts",
-  "compatibility_date": "2026-04-25",
+  "compatibility_date": "2026-08-20",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "durable_objects": {

--- a/examples/todos/workers/api/wrangler.jsonc
+++ b/examples/todos/workers/api/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todos-api",
   "main": "src/index.ts",
-  "compatibility_date": "2026-04-24",
+  "compatibility_date": "2026-08-20",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,

--- a/examples/todos/workers/web/wrangler.jsonc
+++ b/examples/todos/workers/web/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todos-web",
   "main": "src/index.ts",
-  "compatibility_date": "2026-04-24",
+  "compatibility_date": "2026-08-20",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "packageManager": "bun@1.3.14",
   "catalog": {
     "@cloudflare/containers": "0.3.7",
-    "@cloudflare/workers-types": "4.20260611.1",
+    "@cloudflare/workers-types": "5.20260820.1",
     "@cloudflare/vitest-plugin": "1.0.0",
     "@effect/sql-d1": "^4.0.0-rc.110",
     "@effect/sql-pg": "^4.0.0-rc.110",
@@ -74,6 +74,6 @@
     "vite": "npm:@voidzero-dev/vite-plus-core@0.2.6",
     "vitest": "4.1.10",
     "vite-plus": "0.2.6",
-    "wrangler": "4.100.0"
+    "wrangler": "4.125.0"
   }
 }

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -729,12 +729,12 @@ export const resizeAvatar = (image: Images.ImageInputValue) =>
 `effect-cf` develops and tests against a fixed Cloudflare Workers runtime stack. Keep consumer
 `compatibility_date` and optional `@cloudflare/workers-types` peers at or above this pin:
 
-| Pin | Version |
-| --- | --- |
-| workerd | `1.20260820.1` |
+| Pin                                         | Version        |
+| ------------------------------------------- | -------------- |
+| workerd                                     | `1.20260820.1` |
 | `@cloudflare/workers-types` (optional peer) | `5.20260820.1` |
-| wrangler (repo catalog / examples) | `4.125.0` |
-| Recommended `compatibility_date` | `2026-08-20` |
+| wrangler (repo catalog / examples)          | `4.125.0`      |
+| Recommended `compatibility_date`            | `2026-08-20`   |
 
 The date in the `workerd` / `@cloudflare/workers-types` version is the API surface this package wraps.
 Repo catalog pins live in the root `package.json` `catalog` field (`@cloudflare/workers-types`, `wrangler`).

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -4,7 +4,8 @@ Effect-native Cloudflare primitives for Workers, Durable Objects, Containers, bi
 
 ## Install
 
-`effect-cf` targets Effect `^4.0.0-beta.105`.
+`effect-cf` targets Effect `^4.0.0-beta.105` and Cloudflare workerd `1.20260820.1`
+(`@cloudflare/workers-types@5.20260820.1`, recommended `compatibility_date` `2026-08-20`).
 
 ```bash
 bun add effect-cf "effect@^4.0.0-beta.105"
@@ -719,9 +720,25 @@ export const resizeAvatar = (image: Images.ImageInputValue) =>
       },
     );
 
-    return yield* result.response;
+    return yield* result.response();
   });
 ```
+
+## Cloudflare runtime pin
+
+`effect-cf` develops and tests against a fixed Cloudflare Workers runtime stack. Keep consumer
+`compatibility_date` and optional `@cloudflare/workers-types` peers at or above this pin:
+
+| Pin | Version |
+| --- | --- |
+| workerd | `1.20260820.1` |
+| `@cloudflare/workers-types` (optional peer) | `5.20260820.1` |
+| wrangler (repo catalog / examples) | `4.125.0` |
+| Recommended `compatibility_date` | `2026-08-20` |
+
+The date in the `workerd` / `@cloudflare/workers-types` version is the API surface this package wraps.
+Repo catalog pins live in the root `package.json` `catalog` field (`@cloudflare/workers-types`, `wrangler`).
+`wrangler@4.125.0` pulls `workerd@1.20260820.1` and peers `@cloudflare/workers-types@^5.20260820.1`.
 
 ## Email Example
 

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -85,7 +85,7 @@
     "@cloudflare/computer": "^0.2.0",
     "@cloudflare/sandbox": "^0.13.0-next.738.2",
     "@cloudflare/vitest-plugin": "^1.0.0",
-    "@cloudflare/workers-types": "^4.20260611.1",
+    "@cloudflare/workers-types": "^5.20260820.1",
     "@effect/sql-d1": "^4.0.0-rc.110",
     "@effect/sql-pg": "^4.0.0-rc.110",
     "@effect/sql-sqlite-do": "^4.0.0-rc.110",

--- a/packages/effect-cf/src/Images.ts
+++ b/packages/effect-cf/src/Images.ts
@@ -1,5 +1,7 @@
 import type {
   HostedImagesBinding as CloudflareHostedImagesBinding,
+  ImageDirectUploadOptions as CloudflareImageDirectUploadOptions,
+  ImageDirectUploadResult as CloudflareImageDirectUploadResult,
   ImageDrawOptions as CloudflareImageDrawOptions,
   ImageHandle as CloudflareImageHandle,
   ImageInfoResponse as CloudflareImageInfoResponse,
@@ -8,13 +10,16 @@ import type {
   ImageListOptions as CloudflareImageListOptions,
   ImageMetadata as CloudflareImageMetadata,
   ImageOutputOptions as CloudflareImageOutputOptions,
+  ImageSignedUrlOptions as CloudflareImageSignedUrlOptions,
   ImageTransform as CloudflareImageTransform,
   ImageTransformationOutputOptions as CloudflareImageTransformationOutputOptions,
+  ImageTransformationResponseOptions as CloudflareImageTransformationResponseOptions,
   ImageTransformationResult as CloudflareImageTransformationResult,
   ImageTransformer as CloudflareImageTransformer,
   ImageUpdateOptions as CloudflareImageUpdateOptions,
   ImageUploadOptions as CloudflareImageUploadOptions,
   Response as CloudflareResponse,
+  TextOptions as CloudflareTextOptions,
 } from "@cloudflare/workers-types";
 import { Context, Data, Effect, Function, Option, Predicate, type Layer } from "effect";
 
@@ -51,12 +56,17 @@ export type ImageDrawOptions = CloudflareImageDrawOptions;
 export type ImageInputOptions = CloudflareImageInputOptions;
 export type ImageOutputOptions = CloudflareImageOutputOptions;
 export type ImageTransformationOutputOptions = CloudflareImageTransformationOutputOptions;
+export type ImageTransformationResponseOptions = CloudflareImageTransformationResponseOptions;
 export type ImageTransformationResult = CloudflareImageTransformationResult;
 export type ImageUploadOptions = CloudflareImageUploadOptions;
 export type ImageUpdateOptions = CloudflareImageUpdateOptions;
 export type ImageListOptions = CloudflareImageListOptions;
 export type ImageList = CloudflareImageList;
 export type ImageMetadata = CloudflareImageMetadata;
+export type ImageSignedUrlOptions = CloudflareImageSignedUrlOptions;
+export type ImageDirectUploadOptions = CloudflareImageDirectUploadOptions;
+export type ImageDirectUploadResult = CloudflareImageDirectUploadResult;
+export type TextOptions = CloudflareTextOptions;
 export type ImageInputValue = ReadableStream<Uint8Array> | ArrayBuffer;
 export type ImageUploadValue = ReadableStream<Uint8Array> | ArrayBuffer;
 
@@ -79,15 +89,23 @@ export interface Steps {
   readonly steps: ReadonlyArray<Step>;
 }
 
-export interface ProcessOptions {
-  readonly stream: ImageInputValue;
-  readonly inputOptions?: ImageInputOptions;
-  readonly outputOptions: ImageOutputOptions;
-}
+export type ProcessOptions =
+  | {
+      readonly stream: ImageInputValue;
+      readonly inputOptions?: ImageInputOptions;
+      readonly outputOptions: ImageOutputOptions;
+    }
+  | {
+      readonly text: string;
+      readonly textOptions: TextOptions;
+      readonly outputOptions: ImageOutputOptions;
+    };
 
 export interface ImagesTransformationResultClient {
   readonly raw: CloudflareImageTransformationResult;
-  readonly response: Effect.Effect<CloudflareResponse, ImagesOperationError>;
+  readonly response: (
+    options?: ImageTransformationResponseOptions,
+  ) => Effect.Effect<CloudflareResponse, ImagesOperationError>;
   readonly contentType: Effect.Effect<string, ImagesOperationError>;
   readonly image: (
     options?: ImageTransformationOutputOptions,
@@ -98,6 +116,9 @@ export interface ImageHandleClient {
   readonly raw: CloudflareImageHandle;
   readonly details: Effect.Effect<Option.Option<ImageMetadata>, ImagesOperationError>;
   readonly bytes: Effect.Effect<Option.Option<ReadableStream<Uint8Array>>, ImagesOperationError>;
+  readonly signedUrl: (
+    options: ImageSignedUrlOptions,
+  ) => Effect.Effect<string, ImagesOperationError>;
   readonly update: (
     options: ImageUpdateOptions,
   ) => Effect.Effect<ImageMetadata, ImagesOperationError>;
@@ -111,6 +132,9 @@ export interface HostedImagesClient {
     options?: ImageUploadOptions,
   ) => Effect.Effect<ImageMetadata, ImagesOperationError>;
   readonly list: (options?: ImageListOptions) => Effect.Effect<ImageList, ImagesOperationError>;
+  readonly createDirectUpload: (
+    options?: ImageDirectUploadOptions,
+  ) => Effect.Effect<ImageDirectUploadResult, ImagesOperationError>;
   readonly rawUnsafe: Effect.Effect<CloudflareHostedImagesBinding>;
 }
 
@@ -123,6 +147,7 @@ export interface ImagesRuntimeBinding {
     image: ImageInputValue,
     options?: ImageInputOptions,
   ) => CloudflareImageTransformer;
+  readonly text?: (content: string, options: TextOptions) => CloudflareImageTransformer;
   readonly hosted?: CloudflareHostedImagesBinding;
 }
 
@@ -134,6 +159,10 @@ export interface ImagesClient {
   readonly input: (
     image: ImageInputValue,
     options?: ImageInputOptions,
+  ) => Effect.Effect<CloudflareImageTransformer, ImagesOperationError>;
+  readonly text: (
+    content: string,
+    options: TextOptions,
   ) => Effect.Effect<CloudflareImageTransformer, ImagesOperationError>;
   readonly process: (
     steps: Steps,
@@ -230,7 +259,10 @@ const hasFunction = <Candidate>(value: Candidate, key: string): boolean =>
 const isHostedImagesBinding = <Candidate>(
   value: Candidate,
 ): value is Candidate & CloudflareHostedImagesBinding =>
-  hasFunction(value, "image") && hasFunction(value, "upload") && hasFunction(value, "list");
+  hasFunction(value, "image") &&
+  hasFunction(value, "upload") &&
+  hasFunction(value, "list") &&
+  hasFunction(value, "createDirectUpload");
 
 export const isImagesBinding = <Candidate>(
   value: Candidate,
@@ -242,7 +274,7 @@ const wrapResult = (
   result: CloudflareImageTransformationResult,
 ): ImagesTransformationResultClient => ({
   raw: result,
-  response: tryImagesSync(binding, "response", () => result.response()),
+  response: (options) => tryImagesSync(binding, "response", () => result.response(options)),
   contentType: tryImagesSync(binding, "contentType", () => result.contentType()),
   image: (options) => tryImagesSync(binding, "image", () => result.image(options)),
 });
@@ -256,6 +288,9 @@ const wrapHandle = (binding: string, handle: CloudflareImageHandle): ImageHandle
   bytes: tryImagesPromise(binding, "bytes", () => handle.bytes()).pipe(
     Effect.map(maybe),
     Effect.withSpan("Images.bytes"),
+  ),
+  signedUrl: Effect.fn("Images.signedUrl")((options: ImageSignedUrlOptions) =>
+    tryImagesPromise(binding, "signedUrl", () => handle.signedUrl(options)),
   ),
   update: Effect.fn("Images.update")((options: ImageUpdateOptions) =>
     tryImagesPromise(binding, "update", () => handle.update(options)),
@@ -276,6 +311,10 @@ const wrapHosted = (
   list: Effect.fn("Images.list")((options?: ImageListOptions) =>
     tryImagesPromise(binding, "list", () => hosted.list(options)),
   ),
+  createDirectUpload: Effect.fn("Images.createDirectUpload")(
+    (options?: ImageDirectUploadOptions) =>
+      tryImagesPromise(binding, "createDirectUpload", () => hosted.createDirectUpload(options)),
+  ),
   rawUnsafe: Effect.succeed(hosted),
 });
 
@@ -285,8 +324,20 @@ export const makeClient =
     const input = (image: ImageInputValue, options?: ImageInputOptions) =>
       tryImagesSync(definition.binding, "input", () => images.input(image, options));
 
+    const text = (content: string, options: TextOptions) =>
+      tryImagesSync(definition.binding, "text", () => {
+        if (!hasFunction(images, "text")) {
+          throw new Error("Images binding is missing text()");
+        }
+
+        return images.text!(content, options);
+      });
+
     const process = Effect.fn("Images.process")(function* (steps: Steps, options: ProcessOptions) {
-      let transformer = yield* input(options.stream, options.inputOptions);
+      let transformer =
+        "text" in options
+          ? yield* text(options.text, options.textOptions)
+          : yield* input(options.stream, options.inputOptions);
 
       for (const step of steps.steps) {
         transformer = yield* Step.$match(step, {
@@ -314,6 +365,7 @@ export const makeClient =
         tryImagesPromise(definition.binding, "info", () => images.info(image, options)),
       ),
       input,
+      text,
       process,
       hosted: isHostedImagesBinding(images.hosted)
         ? Option.some(wrapHosted(definition.binding, images.hosted))

--- a/packages/effect-cf/src/Images.ts
+++ b/packages/effect-cf/src/Images.ts
@@ -311,9 +311,8 @@ const wrapHosted = (
   list: Effect.fn("Images.list")((options?: ImageListOptions) =>
     tryImagesPromise(binding, "list", () => hosted.list(options)),
   ),
-  createDirectUpload: Effect.fn("Images.createDirectUpload")(
-    (options?: ImageDirectUploadOptions) =>
-      tryImagesPromise(binding, "createDirectUpload", () => hosted.createDirectUpload(options)),
+  createDirectUpload: Effect.fn("Images.createDirectUpload")((options?: ImageDirectUploadOptions) =>
+    tryImagesPromise(binding, "createDirectUpload", () => hosted.createDirectUpload(options)),
   ),
   rawUnsafe: Effect.succeed(hosted),
 });

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -46,6 +46,8 @@ export interface WorkerContextService {
     options?: Omit<WorkerContextWaitUntilOptions<E, R2>, "mode">,
   ): Effect.Effect<void, never, R | R2>;
   readonly passThroughOnException: Effect.Effect<void>;
+  /** Abort the current stateless Worker invocation (`ExecutionContext.abort`). */
+  abort(reason?: unknown): Effect.Effect<void>;
 }
 
 /**

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -47,7 +47,7 @@ export interface WorkerContextService {
   ): Effect.Effect<void, never, R | R2>;
   readonly passThroughOnException: Effect.Effect<void>;
   /** Abort the current stateless Worker invocation (`ExecutionContext.abort`). */
-  abort(reason?: unknown): Effect.Effect<void>;
+  abort(reason?: string): Effect.Effect<void>;
 }
 
 /**

--- a/packages/effect-cf/src/WorkflowBinding.ts
+++ b/packages/effect-cf/src/WorkflowBinding.ts
@@ -3,7 +3,9 @@ import type {
   Workflow as CloudflareWorkflow,
   WorkflowInstance as CloudflareWorkflowInstance,
   WorkflowInstanceCreateOptions as CloudflareWorkflowInstanceCreateOptions,
+  WorkflowInstanceLocationHint as CloudflareWorkflowInstanceLocationHint,
   WorkflowInstanceRestartOptions as CloudflareWorkflowInstanceRestartOptions,
+  WorkflowInstanceTerminateOptions as CloudflareWorkflowInstanceTerminateOptions,
 } from "@cloudflare/workers-types";
 import { type Context, Data, Effect, Option, Predicate, Schema as S } from "effect";
 
@@ -23,6 +25,8 @@ export type WorkflowInstanceCreateBatchOptions<Payload, EncodedPayload = unknown
 >;
 
 export type WorkflowInstanceRestartOptions = CloudflareWorkflowInstanceRestartOptions;
+export type WorkflowInstanceTerminateOptions = CloudflareWorkflowInstanceTerminateOptions;
+export type WorkflowInstanceLocationHint = CloudflareWorkflowInstanceLocationHint;
 
 export type WorkflowInstanceStatusName = CloudflareInstanceStatus["status"];
 
@@ -40,10 +44,13 @@ export interface WorkflowInstance<Result> {
   readonly id: string;
   readonly pause: Effect.Effect<void, WorkflowOperationError>;
   readonly resume: Effect.Effect<void, WorkflowOperationError>;
-  readonly terminate: Effect.Effect<void, WorkflowOperationError>;
+  readonly terminate: (
+    options?: WorkflowInstanceTerminateOptions,
+  ) => Effect.Effect<void, WorkflowOperationError>;
   readonly restart: (
     options?: WorkflowInstanceRestartOptions,
   ) => Effect.Effect<void, WorkflowOperationError>;
+  readonly delete: Effect.Effect<void, WorkflowOperationError>;
   readonly status: Effect.Effect<
     WorkflowInstanceStatus<Result>,
     WorkflowOperationError | WorkflowResultDecodeError
@@ -165,8 +172,9 @@ export const makeClient = <
       id: raw.id,
       pause: operation("pause", () => raw.pause()),
       resume: operation("resume", () => raw.resume()),
-      terminate: operation("terminate", () => raw.terminate()),
+      terminate: (options) => operation("terminate", () => raw.terminate(options)),
       restart: (options) => operation("restart", () => raw.restart(options)),
+      delete: operation("delete", () => raw.delete()),
       status: operation("status", () => raw.status()).pipe(
         Effect.flatMap((status) =>
           Effect.gen(function* () {

--- a/packages/effect-cf/src/internal/WorkerContext.ts
+++ b/packages/effect-cf/src/internal/WorkerContext.ts
@@ -101,6 +101,6 @@ export const fromExecutionContext = (
       options?: Omit<WorkerContextWaitUntilOptions<E, R2>, "mode">,
     ) => schedule(effect, options, "propagate"),
     passThroughOnException: Effect.sync(() => ctx.passThroughOnException()),
-    abort: (reason?: unknown) => Effect.sync(() => ctx.abort(reason)),
+    abort: (reason?: string) => Effect.sync(() => ctx.abort(reason)),
   };
 };

--- a/packages/effect-cf/src/internal/WorkerContext.ts
+++ b/packages/effect-cf/src/internal/WorkerContext.ts
@@ -101,5 +101,6 @@ export const fromExecutionContext = (
       options?: Omit<WorkerContextWaitUntilOptions<E, R2>, "mode">,
     ) => schedule(effect, options, "propagate"),
     passThroughOnException: Effect.sync(() => ctx.passThroughOnException()),
+    abort: (reason?: unknown) => Effect.sync(() => ctx.abort(reason)),
   };
 };

--- a/packages/effect-cf/tests/CloudflareOtlp.test.ts
+++ b/packages/effect-cf/tests/CloudflareOtlp.test.ts
@@ -12,11 +12,13 @@ const TelemetryWorker = WorkerDefinition.make("CloudflareOtlpTelemetryWorker", {
   run: WorkerDefinition.method({ success: S.String }),
 });
 
-const makeExecutionContext = (): globalThis.ExecutionContext => ({
-  props: undefined,
-  waitUntil: () => undefined,
-  passThroughOnException: () => undefined,
-});
+const makeExecutionContext = (): globalThis.ExecutionContext =>
+  makePartialTestDouble<globalThis.ExecutionContext>({
+    props: undefined,
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+    abort: () => undefined,
+  });
 
 const makeWaitUntilExecutionContext = () => {
   const waitUntilPromises: Array<Promise<unknown>> = [];
@@ -26,6 +28,7 @@ const makeWaitUntilExecutionContext = () => {
       waitUntilPromises.push(promise);
     },
     passThroughOnException: () => undefined,
+    abort: () => undefined,
   });
 
   return { executionContext, waitUntilPromises };

--- a/packages/effect-cf/tests/Images.test.ts
+++ b/packages/effect-cf/tests/Images.test.ts
@@ -48,6 +48,7 @@ const makeHandle = (id: string) =>
   makePartialTestDouble<ImageHandle>({
     details: async () => metadata(id),
     bytes: async () => stream(),
+    signedUrl: async () => `https://imagedelivery.test/${id}`,
     update: async (options: ImageUpdateOptions) => ({
       ...metadata(id),
       requireSignedURLs: options.requireSignedURLs ?? false,
@@ -63,6 +64,7 @@ interface FakeImagesOptions {
     options: ImageInputOptions | undefined,
   ) => Promise<ImageInfoResponse>;
   readonly input?: (image: Images.ImageInputValue, options: ImageInputOptions | undefined) => void;
+  readonly text?: (content: string, options: TextOptions) => void;
   readonly image?: (imageId: string) => ImageHandle;
   readonly hosted?: HostedImagesBinding;
   readonly includeHosted?: boolean;
@@ -75,6 +77,11 @@ const makeFakeImages = (options: FakeImagesOptions = {}) => {
     info: options.info ?? (async () => ({ format: "image/png", fileSize: 4, width: 1, height: 1 })),
     input: (image: Images.ImageInputValue, inputOptions: ImageInputOptions | undefined) => {
       options.input?.(image, inputOptions);
+
+      return makeTransformer(state);
+    },
+    text: (content: string, textOptions: TextOptions) => {
+      options.text?.(content, textOptions);
 
       return makeTransformer(state);
     },
@@ -93,6 +100,10 @@ const makeFakeImages = (options: FakeImagesOptions = {}) => {
           list: async () => ({
             images: [metadata("image-1")],
             listComplete: true,
+          }),
+          createDirectUpload: async () => ({
+            id: "direct-1",
+            uploadURL: "https://upload.imagedelivery.test/direct-1",
           }),
         } satisfies HostedImagesBinding),
     });
@@ -155,13 +166,47 @@ const imagesLayer = (images: ImagesBinding) =>
           outputOptions: { format: "image/webp" },
         });
         const contentType = yield* result.contentType;
-        const response = yield* result.response;
+        const response = yield* result.response();
 
         assert.strictEqual(seen[0], bytes);
         assert.deepStrictEqual(state.transforms, [{ width: 128 }]);
         assert.deepStrictEqual(state.draws, [{ opacity: 0.5 }]);
         assert.strictEqual(contentType, "image/webp");
         assert.strictEqual(response.headers.get("content-type"), "image/webp");
+      }),
+    );
+  });
+}
+
+{
+  const state: FakeTransformerState = { transforms: [], draws: [] };
+  const seenText: Array<{ content: string; options: TextOptions }> = [];
+  const images = makeFakeImages({
+    state,
+    text: (content, options) => {
+      seenText.push({ content, options });
+    },
+  });
+
+  layer(imagesLayer(images))("Images text rasterization", (it) => {
+    it.effect("runs process from text rasterization input", () =>
+      Effect.gen(function* () {
+        const images = yield* TestImages;
+        const result = yield* images.process(Images.transform(Images.empty, { width: 256 }), {
+          text: "hello",
+          textOptions: { font: { url: "https://fonts.test/Inter.ttf" }, size: 32 },
+          outputOptions: { format: "image/png" },
+        });
+        const contentType = yield* result.contentType;
+
+        assert.strictEqual(contentType, "image/webp");
+        assert.deepStrictEqual(seenText, [
+          {
+            content: "hello",
+            options: { font: { url: "https://fonts.test/Inter.ttf" }, size: 32 },
+          },
+        ]);
+        assert.deepStrictEqual(state.transforms, [{ width: 256 }]);
       }),
     );
   });
@@ -184,15 +229,20 @@ const imagesLayer = (images: ImagesBinding) =>
         const hosted = Option.getOrThrow(images.hosted);
         const uploaded = yield* hosted.upload(new ArrayBuffer(0), { id: "avatar-1" });
         const listed = yield* hosted.list();
+        const direct = yield* hosted.createDirectUpload({ expiresIn: 60 });
         const handle = hosted.image("missing");
         const details = yield* handle.details;
         const bytes = yield* handle.bytes;
+        const signedUrl = yield* handle.signedUrl({ variant: "public" });
         const deleted = yield* handle.delete;
 
         assert.strictEqual(uploaded.id, "avatar-1");
         assert.strictEqual(listed.images[0]?.id, "image-1");
+        assert.strictEqual(direct.id, "direct-1");
+        assert.strictEqual(direct.uploadURL, "https://upload.imagedelivery.test/direct-1");
         assert.strictEqual(Option.isNone(details), true);
         assert.strictEqual(Option.isNone(bytes), true);
+        assert.strictEqual(signedUrl, "https://imagedelivery.test/missing");
         assert.strictEqual(deleted, true);
       }),
     );

--- a/packages/effect-cf/tests/WorkerContext.test.ts
+++ b/packages/effect-cf/tests/WorkerContext.test.ts
@@ -15,6 +15,7 @@ class TestService extends Context.Service<
 const makeExecutionContext = () => {
   const waitUntilPromises: Array<Promise<unknown>> = [];
   let passThroughCalls = 0;
+  const abortReasons: Array<unknown> = [];
 
   const executionContext = makePartialTestDouble<globalThis.ExecutionContext>({
     props: undefined,
@@ -24,6 +25,9 @@ const makeExecutionContext = () => {
     passThroughOnException: () => {
       passThroughCalls++;
     },
+    abort: (reason?: unknown) => {
+      abortReasons.push(reason);
+    },
   });
 
   return {
@@ -31,6 +35,9 @@ const makeExecutionContext = () => {
     waitUntilPromises,
     get passThroughCalls() {
       return passThroughCalls;
+    },
+    get abortReasons() {
+      return abortReasons;
     },
   };
 };
@@ -159,6 +166,24 @@ test("WorkerContext.passThroughOnException delegates to the raw ExecutionContext
   await worker.fetch!(new Request("https://example.com/"));
 
   expect(context.passThroughCalls).toBe(1);
+});
+
+test("WorkerContext.abort delegates to the raw ExecutionContext", async () => {
+  const Live = Worker.make(Layer.empty, {
+    fetch: Effect.gen(function* () {
+      const ctx = yield* Worker.WorkerContext;
+
+      yield* ctx.abort("shutdown");
+
+      return new Response("ok");
+    }),
+  });
+  const context = makeExecutionContext();
+  const worker = new Live(context.executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+
+  await worker.fetch!(new Request("https://example.com/"));
+
+  expect(context.abortReasons).toEqual(["shutdown"]);
 });
 
 const makeMessageBatch = (queue: string): globalThis.MessageBatch<unknown> =>

--- a/packages/effect-cf/tests/WorkerContext.test.ts
+++ b/packages/effect-cf/tests/WorkerContext.test.ts
@@ -25,7 +25,7 @@ const makeExecutionContext = () => {
     passThroughOnException: () => {
       passThroughCalls++;
     },
-    abort: (reason?: unknown) => {
+    abort: (reason?: string) => {
       abortReasons.push(reason);
     },
   });

--- a/packages/effect-cf/tests/Workflow.test.ts
+++ b/packages/effect-cf/tests/Workflow.test.ts
@@ -42,7 +42,11 @@ const makeExecutingStep = (onReject?: (cause: Error) => void): CloudflareWorkflo
         return await callback({
           step: { name, count: 1 },
           attempt: 1,
-          config: Predicate.isFunction(callbackOrConfig) ? {} : callbackOrConfig,
+          // Cloudflare now specializes WorkflowStepContext.config by delay kind;
+          // these fixtures only exercise the callback path, not delay typing.
+          config: (Predicate.isFunction(callbackOrConfig)
+            ? {}
+            : callbackOrConfig) as CloudflareWorkflowStepContext["config"],
         });
       } catch (cause) {
         if (cause instanceof Error) onReject?.(cause);

--- a/packages/effect-cf/tests/Workflow.test.ts
+++ b/packages/effect-cf/tests/Workflow.test.ts
@@ -42,8 +42,10 @@ const makeExecutingStep = (onReject?: (cause: Error) => void): CloudflareWorkflo
         return await callback({
           step: { name, count: 1 },
           attempt: 1,
-          // Cloudflare now specializes WorkflowStepContext.config by delay kind;
+          // Cloudflare specializes WorkflowStepContext.config by delay kind;
           // these fixtures only exercise the callback path, not delay typing.
+          // SAFETY: callbackOrConfig is either empty or the WorkflowStepConfig already
+          // accepted by step.do; the specialized context config is a structural subset.
           config: (Predicate.isFunction(callbackOrConfig)
             ? {}
             : callbackOrConfig) as CloudflareWorkflowStepContext["config"],

--- a/packages/effect-cf/tests/wrangler.jsonc
+++ b/packages/effect-cf/tests/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-tests",
   "main": "./worker-fixture.ts",
-  "compatibility_date": "2026-04-24",
+  "compatibility_date": "2026-08-20",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "directory": "./assets",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Pin the Cloudflare Workers stack to **workerd `1.20260820.1`** (was `1.20260611.1`): catalog [`@cloudflare/workers-types@5.20260820.1`](package.json), [`wrangler@4.125.0`](package.json), examples/tests `compatibility_date` `2026-08-20`.
- Make the pin explicit in [`packages/effect-cf/README.md`](packages/effect-cf/README.md) (runtime table + install blurb), root [`README.md`](README.md), and [`AGENTS.md`](AGENTS.md).
- Wrap additive runtime surface from the June→August window in [`Images`](packages/effect-cf/src/Images.ts), [`WorkflowBinding`](packages/effect-cf/src/WorkflowBinding.ts), and [`WorkerContext.abort`](packages/effect-cf/src/internal/WorkerContext.ts).

### Investigation: what changed vs what didn't

**Already skewed before this PR:** `@cloudflare/vitest-plugin@1.0.0` depended on wrangler `4.125.0` / miniflare / workerd `1.20260820.1`, while the catalog still pinned wrangler `4.100.0` + workers-types `4.20260611.1`. wrangler `4.125` peers `@cloudflare/workers-types@^5`.

**workers-types v4 → v5:** dated entrypoints removed; package exposes latest + `/experimental` only. Importable types from `@cloudflare/workers-types` still work for this package.

| Area | Change in workerd / types | effect-cf impact |
| --- | --- | --- |
| Images | `text()` rasterization | wrapped (`text`, `process` text input) |
| Images | hosted `createDirectUpload`, `signedUrl` | wrapped |
| Images | `response(options?)` headers | `result.response` is now a method |
| Images | list metadata filter | flows via existing `list(options)` types |
| Workflow | `locationHint` on create | flows via existing create options types |
| Workflow | `terminate({ rollback })`, `delete()` | wrapped |
| Workflow | delay-function retries / specialized step context | fixture typing only |
| Worker | `ExecutionContext.abort` non-experimental; `exports`/`tracing` required | `WorkerContext.abort` wrapped; fixtures updated |
| DO SQL | SQLite row limit → 4 MiB | runtime-only |
| Containers | start image/instance flags stabilized | no effect-cf API change |
| Cache / streams / NMR | internal / compat | no wrapper changes |
| KV / D1 / R2 / Queues / Email / AE / Vectorize / AI | no material public API delta | unchanged |

**Consumer notes:** optional peer is now `@cloudflare/workers-types@^5.20260820.1`. `ImagesTransformationResultClient.response` and `WorkflowInstance.terminate` are methods (were bare `Effect`s).

## Validation

- `vp check` — pass
- `vp run typecheck` — pass
- `vp test` — 47 files, 343 passed / 3 skipped

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b35653f-94df-42cb-aefc-ea6a05e4d242?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b35653f-94df-42cb-aefc-ea6a05e4d242&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

