### PR TITLE
fix(effect-cf): reset RPC websocket after protocol errors

### DIFF
--- a/.changeset/slow-rpcs-restart.md
+++ b/.changeset/slow-rpcs-restart.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": patch
+---
+
+Close hibernatable Durable Object RPC WebSockets with code 1012 after protocol errors so pending calls fail instead of hanging.

--- a/packages/effect-cf/src/DurableObjectRpcWebSocket.ts
+++ b/packages/effect-cf/src/DurableObjectRpcWebSocket.ts
@@ -1059,11 +1059,7 @@ export const layer = (
             }),
           ),
         close: unregister,
-        error: (socket, cause) =>
-          Effect.gen(function* () {
-            yield* Effect.logDebug("Durable Object RPC websocket error", cause);
-            yield* unregister(socket);
-          }),
+        error: resetSocket,
         checkpoint,
       });
 

--- a/packages/effect-cf/tests/DurableObjectRpcWebSocket.test.ts
+++ b/packages/effect-cf/tests/DurableObjectRpcWebSocket.test.ts
@@ -9,6 +9,7 @@ import {
   Option,
   Predicate,
   Queue,
+  Ref,
   Schema,
   Scope,
   Stream,
@@ -104,6 +105,8 @@ const ResumableEventsDeclaration = DurableObjectRpcWebSocket.resumableStream({
 
 const makeTestRpcHandlers = (options?: {
   readonly neverStarted?: Deferred.Deferred<void>;
+  readonly neverInterrupted?: Deferred.Deferred<void>;
+  readonly neverInterruptions?: Ref.Ref<number>;
   readonly streamStarted?: Deferred.Deferred<void>;
 }) =>
   TestRpcs.toLayer(
@@ -114,7 +117,20 @@ const makeTestRpcHandlers = (options?: {
           (options?.neverStarted === undefined
             ? Effect.void
             : Deferred.succeed(options.neverStarted, undefined)
-          ).pipe(Effect.andThen(Effect.never)),
+          ).pipe(
+            Effect.andThen(Effect.never),
+            Effect.onInterrupt(() =>
+              Effect.gen(function* () {
+                if (options?.neverInterruptions !== undefined) {
+                  yield* Ref.update(options.neverInterruptions, (count) => count + 1);
+                }
+
+                if (options?.neverInterrupted !== undefined) {
+                  yield* Deferred.succeed(options.neverInterrupted, undefined);
+                }
+              }),
+            ),
+          ),
         Events: () =>
           Stream.fromEffect(
             (options?.streamStarted === undefined
@@ -437,6 +453,118 @@ Object.defineProperty(globalThis, "WebSocketRequestResponsePair", {
         assert.deepStrictEqual(socket.sent, []);
         assert.strictEqual(readRpcAttachment(socket).hasPendingRequests, true);
       }),
+    );
+  });
+}
+
+{
+  layer(Layer.empty)("DurableObjectRpcWebSocket error lifecycle", (it) => {
+    it.effect("quarantines a pending connection without disrupting another socket", () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const responses = yield* Queue.make<RpcMessage.FromServerEncoded>();
+          const neverStarted = yield* Deferred.make<void>();
+          const neverInterrupted = yield* Deferred.make<void>();
+          const neverInterruptions = yield* Ref.make(0);
+          const failedSocket = makeFakeWebSocket(
+            null,
+            (message) => {
+              for (const response of decodeMessage(message)) {
+                Queue.offerUnsafe(responses, response);
+              }
+            },
+            (code, reason) => {
+              Queue.offerUnsafe(responses, {
+                _tag: "ClientProtocolError",
+                error: new RpcClientError({
+                  reason: new Socket.SocketCloseError({ code: code ?? 1001, closeReason: reason }),
+                }),
+              });
+            },
+          );
+          const healthySocket = makeFakeWebSocket();
+          const failedDurableSocket = DurableObjectWebSocket.fromWebSocket(failedSocket);
+          const healthyDurableSocket = DurableObjectWebSocket.fromWebSocket(healthySocket);
+          const state = makeFakeDurableObjectState();
+          const bridge = makeClientProtocolBridge(responses, state, failedDurableSocket);
+          const client = yield* RpcClient.make(TestRpcs).pipe(
+            Effect.provideService(RpcClient.Protocol, bridge.protocol),
+          );
+          const parentScope = yield* Scope.Scope;
+          const activation = yield* makeActivation(
+            parentScope,
+            state,
+            makeTestRpcHandlers({ neverStarted, neverInterrupted, neverInterruptions }),
+          );
+
+          bridge.setTransport(activation.transport);
+          yield* activation.transport.accept(failedDurableSocket);
+          yield* activation.transport.accept(healthyDurableSocket);
+
+          const pendingCall = yield* client.Never().pipe(Effect.forkChild);
+
+          yield* Deferred.await(neverStarted);
+          assert.strictEqual(state.autoResponse, null);
+          assert.strictEqual(readRpcAttachment(failedSocket).hasPendingRequests, true);
+
+          yield* activation.transport.error(failedDurableSocket, new Error("socket failed"));
+
+          assert.deepStrictEqual(failedSocket.closed, [
+            { code: 1012, reason: "Durable Object RPC activation reset" },
+          ]);
+
+          const clientError = yield* Fiber.join(pendingCall).pipe(Effect.flip);
+
+          yield* Deferred.await(neverInterrupted);
+          assert.strictEqual(clientError._tag, "RpcClientError");
+          assert.strictEqual(clientError.reason._tag, "SocketCloseError");
+          if (clientError.reason._tag === "SocketCloseError") {
+            assert.strictEqual(clientError.reason.code, 1012);
+            assert.strictEqual(
+              clientError.reason.closeReason,
+              "Durable Object RPC activation reset",
+            );
+          }
+          assert.strictEqual(yield* Ref.get(neverInterruptions), 1);
+          assert.deepStrictEqual(state.autoResponse, {
+            request: JSON.stringify(RpcMessage.constPing),
+            response: JSON.stringify(RpcMessage.constPong),
+          });
+
+          yield* activation.transport.close(failedDurableSocket);
+          yield* activation.transport.message(
+            failedDurableSocket,
+            JSON.stringify({
+              _tag: "Request",
+              id: "quarantined",
+              tag: "Ping",
+              payload: { nonce: "must-not-run" },
+              headers: [],
+            }),
+          );
+          yield* activation.transport.message(
+            healthyDurableSocket,
+            JSON.stringify({
+              _tag: "Request",
+              id: "healthy",
+              tag: "Ping",
+              payload: { nonce: "still-usable" },
+              headers: [],
+            }),
+          );
+          yield* Effect.promise(() => healthySocket.nextSend);
+
+          assert.strictEqual(yield* Ref.get(neverInterruptions), 1);
+          assert.deepStrictEqual(failedSocket.sent, []);
+          assert.deepStrictEqual(decodeSent(healthySocket), [
+            {
+              _tag: "Exit",
+              requestId: "healthy",
+              exit: { _tag: "Success", value: { nonce: "still-usable" } },
+            },
+          ]);
+        }),
+      ),
     );
   });
 }

--- a/packages/effect-cf/tests/DurableObjectRpcWebSocket.worker.test.ts
+++ b/packages/effect-cf/tests/DurableObjectRpcWebSocket.worker.test.ts
@@ -40,6 +40,12 @@ const ResumableAttachment = Schema.Struct({
 
 const readResumableAttachment = Schema.decodeUnknownSync(ResumableAttachment);
 
+const RpcClientAttachment = Schema.Struct({
+  effectCloudflareRpcClientId: Schema.Struct({ clientId: Schema.Finite }),
+});
+
+const readRpcClientAttachment = Schema.decodeUnknownSync(RpcClientAttachment);
+
 test("a declared RPC stream resumes on the original client stream after hibernation", async () => {
   const namespace = env.TEST_HIBERNATION_RPC_DO;
 
@@ -337,6 +343,79 @@ test("a hibernated RPC websocket accepts a new finite call after activation recr
 
   expect(recreatedInstanceId).not.toBe(firstInstanceId);
   expect(attachments).toMatchObject([{ application: "survives", applicationMessageCount: 2 }]);
+});
+
+test("webSocketError closes only the affected idle RPC socket with 1012", async () => {
+  const namespace = env.TEST_HIBERNATION_RPC_DO;
+
+  if (namespace === undefined) {
+    throw new Error("TEST_HIBERNATION_RPC_DO binding is missing");
+  }
+
+  const stub = namespace.get(namespace.idFromName(`hibernation-error-${crypto.randomUUID()}`));
+  const firstResponse = await stub.fetch(
+    new Request("https://example.test/rpc", { headers: { Upgrade: "websocket" } }),
+  );
+  const secondResponse = await stub.fetch(
+    new Request("https://example.test/rpc", { headers: { Upgrade: "websocket" } }),
+  );
+  const firstClient = firstResponse.webSocket;
+  const secondClient = secondResponse.webSocket;
+
+  if (firstClient === null || secondClient === null) {
+    throw new Error("Durable Object did not return both websocket upgrades");
+  }
+
+  firstClient.accept();
+  secondClient.accept();
+
+  const closed = waitForClose(firstClient);
+
+  await runInDurableObject(stub, async (instance: TestHibernationRpcDurableObject, state) => {
+    const sockets = state.getWebSockets();
+    const target = sockets.find(
+      (socket) =>
+        readRpcClientAttachment(socket.deserializeAttachment()).effectCloudflareRpcClientId
+          .clientId === 0,
+    );
+
+    if (target === undefined) {
+      throw new Error("First RPC websocket is missing");
+    }
+
+    if (instance.webSocketError === undefined) {
+      throw new Error("Durable Object websocket error handler is missing");
+    }
+
+    await instance.webSocketError(target, new Error("injected websocket error"));
+  });
+
+  await expect(closed).resolves.toEqual({
+    code: 1012,
+    reason: "Durable Object RPC activation reset",
+  });
+
+  const remaining = await runInDurableObject(stub, (_instance, state) => ({
+    clientIds: state
+      .getWebSockets()
+      .map(
+        (socket) =>
+          readRpcClientAttachment(socket.deserializeAttachment()).effectCloudflareRpcClientId
+            .clientId,
+      ),
+    heartbeat: state.getWebSocketAutoResponse(),
+  }));
+
+  expect(remaining.clientIds).toEqual([1]);
+  expect(remaining.heartbeat).toMatchObject({
+    request: JSON.stringify(RpcMessage.constPing),
+    response: JSON.stringify(RpcMessage.constPong),
+  });
+
+  const second = waitForMessage(secondClient);
+
+  secondClient.send(request("after-peer-error", "still-usable"));
+  await expect(second).resolves.toEqual(success("after-peer-error", "still-usable"));
 });
 
 test("a hibernated in-flight finite RPC is reset without replay", async () => {


### PR DESCRIPTION
## Summary

- Route the public hibernatable RPC WebSocket error handler through the existing [connection reset lifecycle](https://github.com/danieljvdm/effect-cf/blob/76fe827/packages/effect-cf/src/DurableObjectRpcWebSocket.ts#L1061-L1063), which unregisters the RPC connection, updates heartbeat state, and closes the physical socket with code 1012.
- Add a [direct lifecycle regression test](https://github.com/danieljvdm/effect-cf/blob/76fe827/packages/effect-cf/tests/DurableObjectRpcWebSocket.test.ts#L460-L570) for pending-call settlement, one-time server interruption, quarantine, heartbeat recovery, and peer-socket isolation.
- Add [workerd callback coverage](https://github.com/danieljvdm/effect-cf/blob/76fe827/packages/effect-cf/tests/DurableObjectRpcWebSocket.worker.test.ts#L348-L423) proving an idle affected socket closes while another socket in the same Durable Object remains usable.

## What went wrong

Cloudflare calls `webSocketError` for errors that do not disconnect the socket. The adapter logged the error and unregistered its RPC connection, which interrupted pending server work but left the physical WebSocket open. The client received neither an RPC `Exit` nor a close event, and the dirty attachment could remain associated with a socket that still answered heartbeats.

The existing reset path already owns the required ordering and bookkeeping. Reusing it quarantines the socket before unregistering, emits the server disconnect once, recomputes heartbeat state from the remaining connections, and closes only the affected socket with the existing service-restart code and reason.

## Evidence

- Before the production change, the direct regression test failed because `transport.error` recorded no socket close. It now observes `RpcClientError` with `SocketCloseError(1012)` and one server interruption.
- The workerd test calls the Durable Object `webSocketError` callback with a real managed socket, observes close code 1012, confirms only the peer attachment remains, and completes another finite RPC on that peer.
- Workerd does not expose native WebSocket error injection, so the test invokes the callback directly through `runInDurableObject`.

## Validation

- `vp run check`
- 48 test files passed, with 365 tests passed and 3 skipped. Formatting, lint, and typecheck passed.