### PR TITLE
feat(effect-cf): support aborting Durable Object alarms without retries

### DIFF
--- a/.changeset/calm-alarms-abort.md
+++ b/.changeset/calm-alarms-abort.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Expose `DurableObjectState.abort(reason, { retryAlarm: false })` so alarm handlers can reset the object without retrying the current alarm. The package now targets workerd `1.20260825.1` and recommends `compatibility_date` `2026-08-25`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Do not use `bun run`, `npm run`, `pnpm run`, or `yarn run` in this repository. D
 
 - `packages/effect-cf` and `packages/effect-webtransport` are the publishable packages.
 - `packages/effect-cf` holds Cloudflare-specific primitives; `packages/effect-webtransport` is a platform-generic Effect WebTransport library with no Cloudflare dependency.
-- `effect-cf` pins Cloudflare workerd `1.20260820.1` via the root catalog (`@cloudflare/workers-types@5.20260820.1`, `wrangler@4.125.0`) and recommends `compatibility_date` `2026-08-20`. Keep those three in lockstep when bumping the runtime.
+- `effect-cf` pins Cloudflare workerd `1.20260825.1` via the root catalog (`@cloudflare/workers-types@5.20260825.1`, `miniflare@5.20260825.0-alpha`, `wrangler@4.126.0`) and recommends `compatibility_date` `2026-08-25`. Keep the dated runtime packages and compatibility date in lockstep.
 - `examples/` contains consumer and example applications.
 - Reusable package code belongs under a package's `src/` and must be exported from that package's `src/index.ts`.
 - Worker projects use `@cloudflare/workers-types` directly for Cloudflare runtime types.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This monorepo also publishes [`effect-webtransport`](packages/effect-webtranspor
 
 ## Install
 
-`effect-cf` targets Effect `^4.0.0-beta.105` and Cloudflare workerd `1.20260820.1`
-(`@cloudflare/workers-types@5.20260820.1`, recommended `compatibility_date` `2026-08-20`).
+`effect-cf` targets Effect `^4.0.0-beta.105` and Cloudflare workerd `1.20260825.1`
+(`@cloudflare/workers-types@5.20260825.1`, recommended `compatibility_date` `2026-08-25`).
 
 ```bash
 bun add effect-cf "effect@^4.0.0-beta.105"

--- a/bun.lock
+++ b/bun.lock
@@ -294,7 +294,7 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "devDependencies": {
         "@cloudflare/computer": "0.2.0",
         "@cloudflare/containers": "catalog:",
@@ -316,7 +316,7 @@
         "@cloudflare/computer": "^0.2.0",
         "@cloudflare/sandbox": "^0.13.0-next.738.2",
         "@cloudflare/vitest-plugin": "^1.0.0",
-        "@cloudflare/workers-types": "^5.20260820.1",
+        "@cloudflare/workers-types": "^5.20260825.1",
         "@effect/sql-d1": "^4.0.0-rc.110",
         "@effect/sql-pg": "^4.0.0-rc.110",
         "@effect/sql-sqlite-do": "^4.0.0-rc.110",
@@ -351,24 +351,27 @@
   "overrides": {
     "@cloudflare/workers-types": "catalog:",
     "@effect/platform-node-shared": "^4.0.0-rc.110",
+    "miniflare": "catalog:",
     "typescript": "7.0.2",
     "vite": "catalog:",
     "vitest": "catalog:",
+    "wrangler": "catalog:",
   },
   "catalog": {
     "@cloudflare/containers": "0.3.7",
     "@cloudflare/vitest-plugin": "1.0.0",
-    "@cloudflare/workers-types": "5.20260820.1",
+    "@cloudflare/workers-types": "5.20260825.1",
     "@effect/platform-node": "^4.0.0-rc.110",
     "@effect/sql-d1": "^4.0.0-rc.110",
     "@effect/sql-pg": "^4.0.0-rc.110",
     "@effect/sql-sqlite-do": "^4.0.0-rc.110",
     "@effect/vitest": "^4.0.0-rc.110",
     "effect": "^4.0.0-rc.110",
+    "miniflare": "5.20260825.0-alpha",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.2.6",
     "vite-plus": "0.2.6",
     "vitest": "4.1.10",
-    "wrangler": "4.125.0",
+    "wrangler": "4.126.0",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -431,17 +434,17 @@
 
     "@cloudflare/vitest-plugin": ["@cloudflare/vitest-plugin@1.0.0", "", { "dependencies": { "cjs-module-lexer": "1.2.3", "esbuild": "0.28.1", "miniflare": "5.20260820.0-alpha", "wrangler": "4.125.0", "zod": "4.4.3" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-AhOD/JysC15kYw25uwdkcpbsbN86jjiv0crHobViU3U/34ImWHXIiTnwqr3ZU0gXO+dIC30LUWS6bL/N+BaDbQ=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260820.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260825.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260820.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260825.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260820.1", "", { "os": "linux", "cpu": "x64" }, "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260825.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260820.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260825.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260825.1", "", { "os": "win32", "cpu": "x64" }, "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260820.1", "", {}, "sha512-KFRmtV4toMf1LL2yXylFTIs7YAS1IYo6jrJCneBG8I1VXHcKCIdqPROH6lGum+gZ+ZgdcNZqxDgjM1yEMgma2w=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260825.1", "", {}, "sha512-/XZntbK+BlJWC5jxkaDNhnDLr2Bf2627sZ6VMrxqKrnc84pc6gNu5NdAyaTkZn1LzQVFIa3SL7V/7veLF59P7w=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -1217,7 +1220,7 @@
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
-    "miniflare": ["miniflare@5.20260820.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260820.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ=="],
+    "miniflare": ["miniflare@5.20260825.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260825.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ=="],
 
     "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
@@ -1527,9 +1530,9 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "workerd": ["workerd@1.20260820.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260820.1", "@cloudflare/workerd-darwin-arm64": "1.20260820.1", "@cloudflare/workerd-linux-64": "1.20260820.1", "@cloudflare/workerd-linux-arm64": "1.20260820.1", "@cloudflare/workerd-windows-64": "1.20260820.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w=="],
+    "workerd": ["workerd@1.20260825.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260825.1", "@cloudflare/workerd-darwin-arm64": "1.20260825.1", "@cloudflare/workerd-linux-64": "1.20260825.1", "@cloudflare/workerd-linux-arm64": "1.20260825.1", "@cloudflare/workerd-windows-64": "1.20260825.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA=="],
 
-    "wrangler": ["wrangler@4.125.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260820.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260820.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260820.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg=="],
+    "wrangler": ["wrangler@4.126.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260825.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260825.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260825.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -1552,8 +1555,6 @@
     "yuku-parser": ["yuku-parser@0.5.48", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" }, "optionalDependencies": { "@yuku-parser/binding-darwin-arm64": "0.5.48", "@yuku-parser/binding-darwin-x64": "0.5.48", "@yuku-parser/binding-freebsd-x64": "0.5.48", "@yuku-parser/binding-linux-arm-gnu": "0.5.48", "@yuku-parser/binding-linux-arm-musl": "0.5.48", "@yuku-parser/binding-linux-arm64-gnu": "0.5.48", "@yuku-parser/binding-linux-arm64-musl": "0.5.48", "@yuku-parser/binding-linux-x64-gnu": "0.5.48", "@yuku-parser/binding-linux-x64-musl": "0.5.48", "@yuku-parser/binding-win32-arm64": "0.5.48", "@yuku-parser/binding-win32-x64": "0.5.48" } }, "sha512-OWBfhrpgK9+/4+IXG9oT8Bao4AhViQA7vdyNNH7EUg8dQYgwa70XtIBWTpCEme1P1ECyoDNYkn0wT63f8XRcVA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
-    "@effect/sql-d1/@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260611.1", "", {}, "sha512-DLiz8Ol1OIWLigJ+dGvuQ5Nm66D/CHNPasl8YnPiz6fGo10ggYSIVuEDMlFk6oho+piAHstNmZMl088w8xqW6g=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/examples/chat/durable-objects/chat-room/wrangler.jsonc
+++ b/examples/chat/durable-objects/chat-room/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-chat-room",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,

--- a/examples/chat/workers/analytics/wrangler.jsonc
+++ b/examples/chat/workers/analytics/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-chat-analytics",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,

--- a/examples/chat/workers/api/wrangler.jsonc
+++ b/examples/chat/workers/api/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-chat-api",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,

--- a/examples/containers/README.md
+++ b/examples/containers/README.md
@@ -45,7 +45,7 @@ Durable Object namespace:
 {
   "name": "container-example",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "containers": [
     {
       "class_name": "RendererContainer",

--- a/examples/email/README.md
+++ b/examples/email/README.md
@@ -62,7 +62,7 @@ locally:
 {
   "name": "email-example",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "send_email": [
     {
       "name": "EMAIL",

--- a/examples/todo-http/workers/api/wrangler.jsonc
+++ b/examples/todo-http/workers/api/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todo-http-api",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "d1_databases": [

--- a/examples/todo-rpc-http/workers/api/wrangler.jsonc
+++ b/examples/todo-rpc-http/workers/api/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todo-rpc-http-api",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "d1_databases": [

--- a/examples/todo-rpc-ws/durable-objects/todo-store/wrangler.jsonc
+++ b/examples/todo-rpc-ws/durable-objects/todo-store/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todo-rpc-ws-store",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "durable_objects": {

--- a/examples/todo-rpc-ws/workers/api/wrangler.jsonc
+++ b/examples/todo-rpc-ws/workers/api/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todo-rpc-ws-api",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "durable_objects": {

--- a/examples/todos/workers/api/wrangler.jsonc
+++ b/examples/todos/workers/api/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todos-api",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,

--- a/examples/todos/workers/web/wrangler.jsonc
+++ b/examples/todos/workers/web/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-todos-web",
   "main": "src/index.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -55,9 +55,11 @@
   "overrides": {
     "@cloudflare/workers-types": "catalog:",
     "@effect/platform-node-shared": "^4.0.0-rc.110",
+    "miniflare": "catalog:",
     "typescript": "7.0.2",
     "vite": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "wrangler": "catalog:"
   },
   "engines": {
     "bun": ">=1.3.0",
@@ -66,7 +68,7 @@
   "packageManager": "bun@1.3.14",
   "catalog": {
     "@cloudflare/containers": "0.3.7",
-    "@cloudflare/workers-types": "5.20260820.1",
+    "@cloudflare/workers-types": "5.20260825.1",
     "@cloudflare/vitest-plugin": "1.0.0",
     "@effect/platform-node": "^4.0.0-rc.110",
     "@effect/sql-d1": "^4.0.0-rc.110",
@@ -74,9 +76,10 @@
     "@effect/sql-sqlite-do": "^4.0.0-rc.110",
     "@effect/vitest": "^4.0.0-rc.110",
     "effect": "^4.0.0-rc.110",
+    "miniflare": "5.20260825.0-alpha",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.2.6",
     "vitest": "4.1.10",
     "vite-plus": "0.2.6",
-    "wrangler": "4.125.0"
+    "wrangler": "4.126.0"
   }
 }

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -4,8 +4,8 @@ Effect-native Cloudflare primitives for Workers, Durable Objects, Containers, bi
 
 ## Install
 
-`effect-cf` targets Effect `^4.0.0-beta.105` and Cloudflare workerd `1.20260820.1`
-(`@cloudflare/workers-types@5.20260820.1`, recommended `compatibility_date` `2026-08-20`).
+`effect-cf` targets Effect `^4.0.0-beta.105` and Cloudflare workerd `1.20260825.1`
+(`@cloudflare/workers-types@5.20260825.1`, recommended `compatibility_date` `2026-08-25`).
 
 ```bash
 bun add effect-cf "effect@^4.0.0-beta.105"
@@ -273,6 +273,10 @@ Effect form runs in the background with the caller's Effect context and the
 same failure modes as `WorkerContext.waitUntil`, so Durable Objects can
 schedule background Effects (for example a pump consuming an outbound
 WebSocket) without capturing a Context and calling `Effect.runPromiseWith`.
+
+`DurableObjectState.abort(reason, { retryAlarm: false })` resets the current
+Durable Object without retrying the alarm that triggered the reset. The option
+has no effect outside an alarm handler and defaults to retrying the alarm.
 
 ## Container Example
 
@@ -729,16 +733,19 @@ export const resizeAvatar = (image: Images.ImageInputValue) =>
 `effect-cf` develops and tests against a fixed Cloudflare Workers runtime stack. Keep consumer
 `compatibility_date` and optional `@cloudflare/workers-types` peers at or above this pin:
 
-| Pin                                         | Version        |
-| ------------------------------------------- | -------------- |
-| workerd                                     | `1.20260820.1` |
-| `@cloudflare/workers-types` (optional peer) | `5.20260820.1` |
-| wrangler (repo catalog / examples)          | `4.125.0`      |
-| Recommended `compatibility_date`            | `2026-08-20`   |
+| Pin                                         | Version              |
+| ------------------------------------------- | -------------------- |
+| workerd                                     | `1.20260825.1`       |
+| `@cloudflare/workers-types` (optional peer) | `5.20260825.1`       |
+| miniflare (repo override / tests)           | `5.20260825.0-alpha` |
+| wrangler (repo catalog / examples)          | `4.126.0`            |
+| Recommended `compatibility_date`            | `2026-08-25`         |
 
 The date in the `workerd` / `@cloudflare/workers-types` version is the API surface this package wraps.
 Repo catalog pins live in the root `package.json` `catalog` field (`@cloudflare/workers-types`, `wrangler`).
-`wrangler@4.125.0` pulls `workerd@1.20260820.1` and peers `@cloudflare/workers-types@^5.20260820.1`.
+`wrangler@4.126.0` pulls `workerd@1.20260825.1` and peers `@cloudflare/workers-types@^5.20260825.1`.
+The Miniflare and Wrangler overrides keep worker tests on the same runtime when
+`@cloudflare/vitest-plugin` lags the repo catalog.
 
 ## Email Example
 

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -85,7 +85,7 @@
     "@cloudflare/computer": "^0.2.0",
     "@cloudflare/sandbox": "^0.13.0-next.738.2",
     "@cloudflare/vitest-plugin": "^1.0.0",
-    "@cloudflare/workers-types": "^5.20260820.1",
+    "@cloudflare/workers-types": "^5.20260825.1",
     "@effect/sql-d1": "^4.0.0-rc.110",
     "@effect/sql-pg": "^4.0.0-rc.110",
     "@effect/sql-sqlite-do": "^4.0.0-rc.110",

--- a/packages/effect-cf/src/DurableObjectState.ts
+++ b/packages/effect-cf/src/DurableObjectState.ts
@@ -66,9 +66,11 @@ export interface DurableObjectStateService {
   /**
    * Forcibly resets the Durable Object. Cloudflare logs an uncaught Error using
    * the optional reason, and the method is not available in `wrangler dev` local
-   * development according to the Durable Object State docs.
+   * development according to the Durable Object State docs. Set
+   * `retryAlarm: false` to prevent the current alarm invocation from retrying;
+   * this option has no effect outside an alarm handler.
    */
-  abort(reason?: string): Effect.Effect<void>;
+  abort(reason?: string, options?: globalThis.DurableObjectAbortOptions): Effect.Effect<void>;
 }
 
 /**
@@ -136,7 +138,8 @@ export const fromDurableObjectState = (
       state.getHibernatableWebSocketEventTimeout(),
     ),
     getTags: (ws: DurableWebSocket) => Effect.sync(() => state.getTags(ws.raw)),
-    abort: (reason?: string) => Effect.sync(() => state.abort(reason)),
+    abort: (reason?: string, options?: globalThis.DurableObjectAbortOptions) =>
+      Effect.sync(() => state.abort(reason, options)),
   };
 };
 

--- a/packages/effect-cf/tests/DurableObjectState.test.ts
+++ b/packages/effect-cf/tests/DurableObjectState.test.ts
@@ -144,8 +144,10 @@ it.effect("wraps hibernation metadata and abort helpers", () =>
     yield* service.setHibernatableWebSocketEventTimeout();
     assert.strictEqual(yield* service.getHibernatableWebSocketEventTimeout, null);
 
-    yield* service.abort("reset requested");
-    assert.deepStrictEqual(tracker.abortReasons, ["reset requested"]);
+    yield* service.abort("cleanup complete", { retryAlarm: false });
+    assert.deepStrictEqual(tracker.aborts, [
+      { reason: "cleanup complete", options: { retryAlarm: false } },
+    ]);
   }),
 );
 
@@ -161,7 +163,10 @@ interface BlockConcurrencyTracker {
   }>;
   sockets: Array<WebSocket>;
   hibernatableTimeout: number | null;
-  readonly abortReasons: Array<string | undefined>;
+  readonly aborts: Array<{
+    readonly reason: string | undefined;
+    readonly options: globalThis.DurableObjectAbortOptions | undefined;
+  }>;
   readonly waitUntilPromises: Array<Promise<unknown>>;
 }
 
@@ -180,7 +185,7 @@ function makeRawDurableObjectState(): RawStateFixture {
     acceptedSockets: [],
     sockets: [],
     hibernatableTimeout: null,
-    abortReasons: [],
+    aborts: [],
     waitUntilPromises: [],
   };
 
@@ -217,8 +222,8 @@ function makeRawDurableObjectState(): RawStateFixture {
     },
     getHibernatableWebSocketEventTimeout: () => tracker.hibernatableTimeout,
     getTags: (ws: WebSocket) => tracker.tags.get(ws) ?? [],
-    abort: (reason?: string) => {
-      tracker.abortReasons.push(reason);
+    abort: (reason?: string, options?: globalThis.DurableObjectAbortOptions) => {
+      tracker.aborts.push({ reason, options });
     },
   });
 

--- a/packages/effect-cf/tests/wrangler.jsonc
+++ b/packages/effect-cf/tests/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../../../node_modules/wrangler/config-schema.json",
   "name": "effect-cf-tests",
   "main": "./worker-fixture.ts",
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "directory": "./assets",


### PR DESCRIPTION
## Summary

- Expose [`DurableObjectState.abort(reason, options)`](https://github.com/danieljvdm/effect-cf/blob/5706868a14ea4d68070cec1f0f646a3054ea0aaa/packages/effect-cf/src/DurableObjectState.ts#L66-L73) and forward `retryAlarm: false`, allowing an alarm handler to reset its Durable Object without Cloudflare retrying the current alarm. The [adapter test](https://github.com/danieljvdm/effect-cf/blob/5706868a14ea4d68070cec1f0f646a3054ea0aaa/packages/effect-cf/tests/DurableObjectState.test.ts#L147-L150) covers the new argument.
- Move the Workers types, Miniflare, Wrangler, workerd, examples, and recommended compatibility date to the 2026-08-25 runtime set. Root overrides keep the Vitest plugin on that same workerd build. A minor changeset documents the public addition.

## Validation

- `vp run check`: 363 tests passed, 3 skipped
