### PR TITLE
fix: correct resource ownership across Cloudflare and WebTransport

### DIFF
--- a/.changeset/owned-native-callbacks.md
+++ b/.changeset/owned-native-callbacks.md
@@ -1,0 +1,10 @@
+---
+"effect-cf": minor
+"effect-webtransport": minor
+---
+
+Keep Worker event-layer resources alive through Effect HTTP response streams, give background work and Workflow steps their own resource scopes, and join interrupted native callbacks before returning. Durable Object transactions now await rollback and cleanup on interruption, including accidental asynchronous work in synchronous transactions. Queue handlers also schedule telemetry flushes after success or failure.
+
+Propagate fetch cancellation to service bindings and Durable Objects. Report scoped RPC failures, malformed embedding responses, and invalid Analytics Engine URLs through tagged errors. Computer workspace acquisition now exposes `WorkspaceAcquireError` in its layer error channel. Typed WebSocket attachments enforce their declared shape, and fresh RPC connections replace reserved metadata without losing application fields.
+
+Support modern WebTransport datagram writers and buffered-datagram options while retaining legacy compatibility. Release stream locks after cleanup and datagram writer locks when either peer closes. Failed or interrupted fallback candidates release their resources before selection continues.

--- a/packages/effect-cf/src/AnalyticsEngine.ts
+++ b/packages/effect-cf/src/AnalyticsEngine.ts
@@ -572,7 +572,14 @@ const executeQueryRequest = (
   options?: AnalyticsEngineQueryOptions,
 ) =>
   Effect.gen(function* () {
-    const response = yield* httpClient.execute(queryRequest(definition, sql, options)).pipe(
+    const request = yield* Effect.try({
+      try: () => queryRequest(definition, sql, options),
+      catch: (cause) =>
+        analyticsEngineQueryError(definition, "query", "Invalid Analytics Engine SQL API URL", {
+          cause,
+        }),
+    });
+    const response = yield* httpClient.execute(request).pipe(
       Effect.mapError((cause) =>
         analyticsEngineQueryError(definition, "query", "Analytics Engine SQL API request failed", {
           cause,

--- a/packages/effect-cf/src/CloudflareOtlp.ts
+++ b/packages/effect-cf/src/CloudflareOtlp.ts
@@ -1,7 +1,8 @@
 /**
- * Worker fetch/RPC and Durable Object alarm/RPC handlers schedule a best-effort
- * flusher. It settles within two seconds; queues and other lifecycles must
- * flush explicitly. Failures are ignored so telemetry cannot fail user events.
+ * Worker fetch/queue/RPC and Durable Object alarm/RPC handlers schedule a
+ * best-effort flusher. It settles within two seconds; other lifecycles must
+ * flush explicitly. Scheduled flush failures cannot fail user events. Exporter
+ * layer finalizers run separately and follow their configured shutdown timeout.
  */
 import { ConfigProvider, Effect, Layer, Option } from "effect";
 import type * as Tracer from "effect/Tracer";
@@ -207,6 +208,8 @@ export const layerProtobuf = (
  *
  * Provide this layer at runtime scope for long-lived metrics aggregation, or at
  * handler scope when traces/logs should flush as the Cloudflare event finishes.
+ * A handler-scoped exporter can delay scope closure while its own finalizer
+ * flushes; the two-second background flush limit does not bound layer shutdown.
  */
 export const layerWorker = (options: WorkerLayerOptions = {}): Layer.Layer<OtlpExporter.Flusher> =>
   makeLayer(options, {

--- a/packages/effect-cf/src/ComputerWorkspace.ts
+++ b/packages/effect-cf/src/ComputerWorkspace.ts
@@ -100,6 +100,17 @@ export class WorkspaceAssetsError extends Schema.TaggedError<WorkspaceAssetsErro
   },
 ) {}
 
+/** Schema-serializable error while acquiring the Computer workspace client. */
+export class WorkspaceAcquireError extends Schema.TaggedError<WorkspaceAcquireError>()(
+  "WorkspaceAcquireError",
+  {
+    operation: Schema.String,
+    message: Schema.String,
+    code: Schema.optionalKey(Schema.String),
+    cause: Schema.optionalKey(Schema.Defect({ includeStack: true })),
+  },
+) {}
+
 export type WorkspaceReadFileOptions = Omit<CloudflareReadFileOptions, "encoding">;
 export type ReadTextFileOptions = WorkspaceReadFileOptions;
 export type ListDirectoryOptions = CloudflareReaddirOptions;
@@ -467,6 +478,21 @@ const execError = (operation: string, cause: unknown) => {
   }
 
   return WorkspaceExecError.make(properties);
+};
+
+const acquireError = (operation: string, cause: unknown) => {
+  const properties: WorkspaceOperationErrorProperties = {
+    operation,
+    message: errorMessage(cause),
+    cause,
+  };
+  const code = errorCode(cause);
+
+  if (code !== undefined) {
+    properties.code = code;
+  }
+
+  return WorkspaceAcquireError.make(properties);
 };
 
 const assetsError = (operation: string, path: string, cause: unknown) => {
@@ -887,9 +913,6 @@ const wrapRun = <Encoding extends WorkspaceExecEncoding>(
   return { id: handle.id, backend: handle.backend, events, result, kill };
 };
 
-const releaseRun = (handle: CloudflareWorkspaceRuntimeExecHandle<"utf8" | undefined>) =>
-  Effect.sync(() => handle[Symbol.dispose]());
-
 const makeRuntime = (client: CloudflareWorkspaceClient): ComputerWorkspaceRuntime => {
   const execImplementation = Effect.fn("ComputerWorkspace.runtime.exec", {
     attributes: { family: "runtime", operation: "exec" },
@@ -905,7 +928,7 @@ const makeRuntime = (client: CloudflareWorkspaceClient): ComputerWorkspaceRuntim
       : undefined;
 
     yield* Effect.annotateCurrentSpan({ backend: options?.backend, runId: options?.id });
-    const handle = yield* Effect.acquireRelease(
+    const handle = yield* Effect.acquireDisposable(
       Effect.tryPromise({
         try: () => {
           if (Predicate.isString(source)) {
@@ -926,7 +949,6 @@ const makeRuntime = (client: CloudflareWorkspaceClient): ComputerWorkspaceRuntim
         },
         catch: (cause) => execError("exec", cause),
       }),
-      releaseRun,
     );
 
     // SAFETY: runtimeExecOptions carries Encoding to Cloudflare's corresponding handle overload.
@@ -945,12 +967,11 @@ const makeRuntime = (client: CloudflareWorkspaceClient): ComputerWorkspaceRuntim
     options?: WorkspaceGetExecOptions<Encoding>,
   ) {
     yield* Effect.annotateCurrentSpan({ backend: options?.backend, runId: id });
-    const handle = yield* Effect.acquireRelease(
+    const handle = yield* Effect.acquireDisposable(
       Effect.tryPromise({
         try: () => client.runtime.getExec(id, runtimeGetOptions(options)),
         catch: (cause) => execError("getExec", cause),
       }),
-      releaseRun,
     );
 
     // SAFETY: runtimeGetOptions carries Encoding to Cloudflare's corresponding handle overload.
@@ -1169,25 +1190,31 @@ export class ComputerWorkspace extends Context.Service<
    * Acquires the single workspace registered by `withComputerWorkspace` and
    * releases its RPC client when the layer scope closes.
    */
-  static readonly layer: Layer.Layer<ComputerWorkspace, never, DurableObjectState> = Layer.effect(
-    ComputerWorkspace,
-    Effect.gen(function* () {
-      const state = yield* DurableObjectState;
-      const host = HostRegistry.lookup(state.raw);
+  static readonly layer: Layer.Layer<ComputerWorkspace, WorkspaceAcquireError, DurableObjectState> =
+    Layer.effect(
+      ComputerWorkspace,
+      Effect.gen(function* () {
+        const state = yield* DurableObjectState;
+        const host = HostRegistry.lookup(state.raw);
 
-      if (host === undefined) {
-        return yield* Effect.die(
-          "ComputerWorkspace.layer requires a Durable Object class built with withComputerWorkspace",
+        if (host === undefined) {
+          return yield* Effect.die(
+            "ComputerWorkspace.layer requires a Durable Object class built with withComputerWorkspace",
+          );
+        }
+
+        const computer = yield* Effect.tryPromise({
+          try: () => import("@cloudflare/computer"),
+          catch: (cause) => acquireError("import", cause),
+        });
+        const client = yield* Effect.acquireDisposable(
+          Effect.tryPromise({
+            try: () => computer.getWorkspace(host),
+            catch: (cause) => acquireError("getWorkspace", cause),
+          }),
         );
-      }
 
-      const computer = yield* Effect.promise(() => import("@cloudflare/computer"));
-      const client = yield* Effect.acquireRelease(
-        Effect.promise(() => computer.getWorkspace(host)),
-        (workspace) => Effect.sync(() => workspace[Symbol.dispose]()),
-      );
-
-      return ComputerWorkspace.of(fromWorkspaceClient(client));
-    }),
-  );
+        return ComputerWorkspace.of(fromWorkspaceClient(client));
+      }),
+    );
 }

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -5,19 +5,12 @@ import { NativeRequest } from "./Worker";
 import { WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { DurableObjectState, fromDurableObjectState } from "./DurableObjectState";
 import { fromWebSocket, type DurableWebSocket } from "./DurableObjectWebSocket";
+import * as RpcDefinition from "./RpcDefinition";
 import * as Entrypoint from "./internal/Entrypoint";
 import * as Runtime from "./internal/Runtime";
 import * as Telemetry from "./internal/Telemetry";
 
-const reservedMethodNames = new Set<string>([
-  "constructor",
-  "dup",
-  "fetch",
-  "alarm",
-  "webSocketMessage",
-  "webSocketClose",
-  "webSocketError",
-]);
+const reservedMethodNames: ReadonlySet<string> = RpcDefinition.reservedMethodNames;
 
 type RuntimeContext<ROut> = DurableObjectState | WorkerEnvironment | ROut;
 
@@ -148,6 +141,12 @@ export type DurableObjectClass<Rpc extends DurableObjectRpc<ROut>, ROut> = new (
   env: WorkerEnv,
 ) => CloudflareDurableObject<WorkerEnv> & DurableObjectRpcApi<Rpc, ROut>;
 
+/**
+ * Builds a Durable Object whose base `layer` lives for the in-memory instance.
+ * Cloudflare does not expose an eviction or shutdown hook, so finalizers in
+ * that layer are not guaranteed to run. Put resources that require timely
+ * release in `eventLayer`, whose scope closes after each handled event.
+ */
 export const make = <
   ROut,
   LayerError,

--- a/packages/effect-cf/src/DurableObjectNamespace.ts
+++ b/packages/effect-cf/src/DurableObjectNamespace.ts
@@ -247,7 +247,7 @@ export type DurableObjectNamespaceEffectClient<
     stub: DurableObjectStubClient<Api>,
     method: Method,
     ...args: StubMethodArgs<Api, Method>
-  ) => Effect.Effect<Awaited<StubMethodSuccess<Api, Method>>, unknown, Scope.Scope>;
+  ) => Effect.Effect<Awaited<StubMethodSuccess<Api, Method>>, DurableObjectRpcError, Scope.Scope>;
   /**
    * Exposes the underlying native Durable Object namespace binding.
    *
@@ -297,7 +297,11 @@ export type DurableObjectNamespaceStaticClient<
     stub: DurableObjectStubClient<Api>,
     method: Method,
     ...args: StubMethodArgs<Api, Method>
-  ) => Effect.Effect<Awaited<StubMethodSuccess<Api, Method>>, unknown, Scope.Scope | R>;
+  ) => Effect.Effect<
+    Awaited<StubMethodSuccess<Api, Method>>,
+    DurableObjectRpcError,
+    Scope.Scope | R
+  >;
   readonly rawUnsafe: () => Effect.Effect<DurableObjectNamespaceClient<Api>, never, R>;
 };
 
@@ -348,7 +352,22 @@ export const makeClient = <
 
     const fetch = (stub: StubClient, input: RequestInfo | URL, init?: RequestInit) =>
       Effect.tryPromise({
-        try: () => stub.fetch(input, init),
+        try: (signal) => {
+          const callerSignal =
+            init?.signal !== undefined
+              ? init.signal
+              : input instanceof Request
+                ? input.signal
+                : undefined;
+
+          return stub.fetch(input, {
+            ...init,
+            signal:
+              callerSignal === null || callerSignal === undefined
+                ? signal
+                : AbortSignal.any([callerSignal, signal]),
+          });
+        },
         catch: (cause) => new DurableObjectFetchError({ binding: definition.binding, cause }),
       });
 
@@ -440,7 +459,16 @@ export const makeClient = <
     >(stub: StubClient, method: Method, ...args: StubMethodArgs<Api, Method>) {
       const methodName = String(method);
       const result = yield* rpc(stub, method, ...args);
-      const value = yield* CloudflareRpc.scoped(result);
+      const value = yield* CloudflareRpc.scoped(result).pipe(
+        Effect.mapError(
+          (cause) =>
+            new DurableObjectRpcError({
+              binding: definition.binding,
+              method: methodName,
+              cause,
+            }),
+        ),
+      );
 
       return yield* decodeSuccess<Method>(methodName, value);
     });

--- a/packages/effect-cf/src/DurableObjectRpcWebSocket.ts
+++ b/packages/effect-cf/src/DurableObjectRpcWebSocket.ts
@@ -230,7 +230,6 @@ export const layer = (
       const disconnects = yield* Queue.make<number>();
       const connectionsBySocket = new Map<WebSocket, RpcConnection>();
       const connectionsById = new Map<number, RpcConnection>();
-      const clientIds = new Set<number>();
       const resetSockets = new WeakSet<WebSocket>();
       const declarationsById = new Map<string, AnyResumableStreamDeclaration>();
       const declarationsByTag = new Map<string, AnyResumableStreamDeclaration>();
@@ -268,21 +267,6 @@ export const layer = (
       }
 
       const reserveClientId = (socket: DurableWebSocket): AttachmentMetadata => {
-        const attachment = readAttachment(socket.raw, attachmentKey);
-
-        if (attachment._tag === "Invalid") {
-          throw new Error("Invalid Durable Object RPC websocket attachment metadata");
-        }
-
-        if (attachment._tag === "Valid") {
-          const metadata = attachment.metadata;
-
-          nextClientId = Math.max(nextClientId, metadata.clientId + 1);
-          writeAttachment(socket.raw, attachmentKey, metadata);
-
-          return metadata;
-        }
-
         const id = nextClientId++;
         const created: LegacyAttachmentMetadata = {
           version: legacyAttachmentVersion,
@@ -377,7 +361,6 @@ export const layer = (
 
         connectionsBySocket.set(socket.raw, connection);
         connectionsById.set(connection.id, connection);
-        clientIds.add(connection.id);
         nextClientId = Math.max(nextClientId, connection.id + 1);
 
         return connection;
@@ -434,7 +417,6 @@ export const layer = (
 
         connectionsBySocket.delete(socket.raw);
         connectionsById.delete(connection.id);
-        clientIds.delete(connection.id);
         activeNonResumableRequestCount -= connection.nonResumableRequestIds.size;
         connection.requestIds.clear();
         connection.nonResumableRequestIds.clear();
@@ -847,7 +829,7 @@ export const layer = (
 
               connection?.socket.raw.close();
             }),
-          clientIds: Effect.sync(() => clientIds),
+          clientIds: Effect.sync(() => new Set(connectionsById.keys())),
           initialMessage: Effect.succeedNone,
           supportsAck: true,
           supportsTransferables: false,
@@ -1141,17 +1123,10 @@ const writeAttachment = (socket: WebSocket, key: string, metadata: AttachmentMet
   }
 
   const attachment = Predicate.isObject(current) ? current : {};
-  const currentMetadata =
-    Predicate.hasProperty(attachment, key) && Predicate.isObject(attachment[key])
-      ? attachment[key]
-      : {};
 
   socket.serializeAttachment({
     ...attachment,
-    [key]: {
-      ...currentMetadata,
-      ...metadata,
-    },
+    [key]: metadata,
   });
 };
 

--- a/packages/effect-cf/src/DurableObjectState.ts
+++ b/packages/effect-cf/src/DurableObjectState.ts
@@ -3,6 +3,7 @@ import { Cause, Context, Effect, Exit } from "effect";
 import { fromDurableObjectStorage, type DurableObjectStorage } from "./DurableObjectStorage";
 import { fromWebSocket, type DurableWebSocket } from "./DurableObjectWebSocket";
 import type { WorkerContextWaitUntilOptions } from "./Worker";
+import { runNativeCallback } from "./internal/NativeCallback";
 import { makeWaitUntilScheduler } from "./internal/WorkerContext";
 
 /**
@@ -87,24 +88,21 @@ export const fromDurableObjectState = (
     storage: fromDurableObjectStorage(state.storage),
     waitUntil,
     blockConcurrencyWhile: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-      Effect.context<R>().pipe(
-        Effect.flatMap((context) =>
-          Effect.promise(() =>
-            state.blockConcurrencyWhile(() =>
-              runPromiseExitPreservingTypedFailures(context, effect),
-            ),
-          ),
-        ),
-        Effect.flatten,
-      ),
+      runNativeCallback<A, E, R, Exit.Exit<A, E>>((run) =>
+        state.blockConcurrencyWhile(() => runExitPreservingTypedFailures(run, effect)),
+      ).pipe(Effect.orDie, Effect.flatten),
     blockConcurrencyWhileOrReset: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-      Effect.context<R>().pipe(
-        Effect.flatMap((context) =>
-          Effect.promise(() =>
-            state.blockConcurrencyWhile(() => Effect.runPromiseWith(context)(effect)),
-          ),
-        ),
-      ),
+      runNativeCallback<A, E, R, A>((run) =>
+        state.blockConcurrencyWhile(async () => {
+          const exit = await run(effect);
+
+          if (Exit.isFailure(exit)) {
+            throw Cause.squash(exit.cause);
+          }
+
+          return exit.value;
+        }),
+      ).pipe(Effect.orDie),
     acceptWebSocket: (ws: DurableWebSocket, tags?: Array<string>) =>
       Effect.sync(() => state.acceptWebSocket(ws.raw, tags)),
     getWebSockets: (tag?: string) =>
@@ -125,11 +123,11 @@ export const fromDurableObjectState = (
   };
 };
 
-const runPromiseExitPreservingTypedFailures = async <A, E, R>(
-  context: Context.Context<R>,
+const runExitPreservingTypedFailures = async <A, E, R>(
+  run: (effect: Effect.Effect<A, E, R>) => Promise<Exit.Exit<A, E>>,
   effect: Effect.Effect<A, E, R>,
 ): Promise<Exit.Exit<A, E>> => {
-  const exit = await Effect.runPromiseExitWith(context)(effect);
+  const exit = await run(effect);
 
   if (Exit.isFailure(exit) && (Cause.hasDies(exit.cause) || Cause.hasInterrupts(exit.cause))) {
     throw Cause.squash(exit.cause);

--- a/packages/effect-cf/src/DurableObjectStorage.ts
+++ b/packages/effect-cf/src/DurableObjectStorage.ts
@@ -1,6 +1,19 @@
-import { Clock, Data, Duration, Effect, Exit, Option, Predicate, Schema as S } from "effect";
+import {
+  Cause,
+  Clock,
+  Data,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Option,
+  Predicate,
+  Result,
+  Schema as S,
+} from "effect";
 
 import * as ErrorMessage from "./internal/ErrorMessage";
+import { runNativeCallback } from "./internal/NativeCallback";
 
 export type SqlStorageValue = globalThis.SqlStorageValue;
 
@@ -331,6 +344,7 @@ export const fromDurableObjectStorage = (
           // failed Exit is thrown to abort it. Keep a typed reference to that
           // Exit rather than recovering its type from the untyped catch binding.
           let aborted: Exit.Exit<A, E> | undefined;
+          let escapedFiber: Fiber.Fiber<unknown, unknown> | undefined;
 
           try {
             return Effect.succeed(
@@ -340,55 +354,59 @@ export const fromDurableObjectStorage = (
                 if (Exit.isSuccess(exit)) {
                   return exit.value;
                 }
+                const defect = Cause.findDefect(exit.cause);
+
+                if (Result.isSuccess(defect) && Cause.isAsyncFiberError(defect.success)) {
+                  escapedFiber = defect.success.fiber;
+                  escapedFiber.interruptUnsafe();
+                }
                 aborted = exit;
 
                 throw exit;
               }),
             );
           } catch (cause) {
-            if (aborted !== undefined && cause === aborted && Exit.isFailure(aborted)) {
-              return Effect.failCause(aborted.cause);
+            const failure: Effect.Effect<never, E | StorageOperationError> =
+              aborted !== undefined && cause === aborted && Exit.isFailure(aborted)
+                ? Effect.failCause(aborted.cause)
+                : Effect.fail(storageError("transactionSync", cause));
+            const fiber = escapedFiber;
+
+            if (fiber !== undefined) {
+              return Fiber.interrupt(fiber).pipe(Effect.andThen(failure));
             }
 
-            return Effect.fail(storageError("transactionSync", cause));
+            return failure;
           }
         }),
       ),
     ),
   transaction: <A, E, R>(closure: (txn: DurableObjectTransaction) => Effect.Effect<A, E, R>) =>
-    Effect.context<R>().pipe(
-      Effect.flatMap((context) =>
-        Effect.callback<A, E | StorageOperationError>((resume) => {
-          // See `transactionSync`: the thrown Exit aborts Cloudflare's
-          // transaction, and holding it here keeps its error type.
-          let aborted: Exit.Exit<A, E> | undefined;
+    Effect.suspend(() => {
+      // See `transactionSync`: the thrown Exit aborts Cloudflare's
+      // transaction, and holding it here keeps its error type.
+      let aborted: Exit.Exit<A, E> | undefined;
 
-          void storage
-            .transaction(async (txn) => {
-              const exit = await Effect.runPromiseExitWith(context)(
-                closure(fromDurableObjectTransaction(txn)),
-              );
+      return runNativeCallback<A, E, R, A>((run) =>
+        storage.transaction(async (txn) => {
+          const exit = await run(Effect.suspend(() => closure(fromDurableObjectTransaction(txn))));
 
-              if (Exit.isSuccess(exit)) {
-                return exit.value;
-              }
-              aborted = exit;
+          if (Exit.isSuccess(exit)) {
+            return exit.value;
+          }
+          aborted = exit;
 
-              throw exit;
-            })
-            .then(
-              (value) => resume(Effect.succeed(value)),
-              (cause) => {
-                if (aborted !== undefined && cause === aborted && Exit.isFailure(aborted)) {
-                  resume(Effect.failCause(aborted.cause));
-                } else {
-                  resume(Effect.fail(storageError("transaction", cause)));
-                }
-              },
-            );
+          throw exit;
         }),
-      ),
-    ),
+      ).pipe(
+        Effect.catch(
+          (cause): Effect.Effect<never, E | StorageOperationError> =>
+            aborted !== undefined && cause === aborted && Exit.isFailure(aborted)
+              ? Effect.failCause(aborted.cause)
+              : Effect.fail(storageError("transaction", cause)),
+        ),
+      );
+    }),
   sync: () => tryStoragePromise("sync", () => storage.sync()),
   getCurrentBookmark: () =>
     tryStoragePromise("getCurrentBookmark", () => storage.getCurrentBookmark()),

--- a/packages/effect-cf/src/DurableObjectWebSocket.ts
+++ b/packages/effect-cf/src/DurableObjectWebSocket.ts
@@ -38,53 +38,37 @@ export interface DurableWebSocket<Attachment = unknown> {
   send(data: DurableWebSocketSendData): Effect.Effect<void, DurableWebSocketSendError>;
   close(code?: number, reason?: string): Effect.Effect<void, DurableWebSocketCloseError>;
   /** Serializes hibernation attachment metadata onto the socket. */
-  serializeAttachment<A = Attachment>(
+  serializeAttachment<A extends Attachment = Attachment>(
     value: A,
   ): Effect.Effect<void, DurableWebSocketAttachmentError>;
   /** Deserializes hibernation attachment metadata from the socket. */
   readonly deserializeAttachment: Effect.Effect<unknown, DurableWebSocketAttachmentError>;
 }
 
-const wrappers = new WeakMap<WebSocket, DurableWebSocket<unknown>>();
-
 export const fromWebSocket = <Attachment = unknown>(
   raw: WebSocket,
-): DurableWebSocket<Attachment> => {
-  const existing = wrappers.get(raw);
-
-  if (existing !== undefined) {
-    // SAFETY: Attachment is phantom; a wrapper's runtime behavior is independent of that type.
-    return existing as DurableWebSocket<Attachment>;
-  }
-
-  const socket: DurableWebSocket<unknown> = {
-    raw,
-    send: (data) =>
-      Effect.try({
-        try: () => raw.send(data),
-        catch: (cause) => new DurableWebSocketSendError({ cause }),
-      }),
-    close: (code, reason) =>
-      Effect.try({
-        try: () => raw.close(code, reason),
-        catch: (cause) => new DurableWebSocketCloseError({ cause }),
-      }),
-    serializeAttachment: (value) =>
-      Effect.try({
-        try: () => raw.serializeAttachment(value),
-        catch: (cause) => new DurableWebSocketAttachmentError({ operation: "serialize", cause }),
-      }),
-    deserializeAttachment: Effect.try({
-      try: () => raw.deserializeAttachment(),
-      catch: (cause) => new DurableWebSocketAttachmentError({ operation: "deserialize", cause }),
+): DurableWebSocket<Attachment> => ({
+  raw,
+  send: (data) =>
+    Effect.try({
+      try: () => raw.send(data),
+      catch: (cause) => new DurableWebSocketSendError({ cause }),
     }),
-  };
-
-  wrappers.set(raw, socket);
-
-  // SAFETY: Attachment is phantom; the newly created wrapper supports values through its generic serializer.
-  return socket as DurableWebSocket<Attachment>;
-};
+  close: (code, reason) =>
+    Effect.try({
+      try: () => raw.close(code, reason),
+      catch: (cause) => new DurableWebSocketCloseError({ cause }),
+    }),
+  serializeAttachment: <A extends Attachment = Attachment>(value: A) =>
+    Effect.try({
+      try: () => raw.serializeAttachment(value),
+      catch: (cause) => new DurableWebSocketAttachmentError({ operation: "serialize", cause }),
+    }),
+  deserializeAttachment: Effect.try({
+    try: () => raw.deserializeAttachment(),
+    catch: (cause) => new DurableWebSocketAttachmentError({ operation: "deserialize", cause }),
+  }),
+});
 
 export interface AcceptUpgradeOptions<Attachment = unknown> {
   readonly tags?: ReadonlyArray<string> | undefined;
@@ -165,15 +149,13 @@ export const attachment = <const AttachmentSchema extends S.Codec<any, any, neve
   S.Codec.Encoded<AttachmentSchema>
 > => {
   type Attachment = S.Schema.Type<AttachmentSchema>;
-  type Encoded = S.Codec.Encoded<AttachmentSchema>;
 
   const serialize = (socket: DurableWebSocket<unknown>, value: Attachment) =>
     S.encodeEffect(schema)(value).pipe(
       Effect.mapError(
         (cause) => new DurableWebSocketAttachmentError({ operation: "serialize", cause }),
       ),
-      // SAFETY: S.encodeEffect returns this codec's declared Encoded representation.
-      Effect.flatMap((encoded) => socket.serializeAttachment(encoded as Encoded)),
+      Effect.flatMap((encoded) => socket.serializeAttachment(encoded)),
     );
 
   const deserialize = (socket: DurableWebSocket<unknown>) =>

--- a/packages/effect-cf/src/RpcDefinition.ts
+++ b/packages/effect-cf/src/RpcDefinition.ts
@@ -124,7 +124,7 @@ export const decodeWireError = (cause: WireValue): WireValue => {
   }
 };
 
-export const reservedMethodNames = new Set([
+const reservedMethodNameValues = [
   "constructor",
   "fetch",
   "connect",
@@ -137,21 +137,11 @@ export const reservedMethodNames = new Set([
   "dispose",
   "serialize",
   "deserialize",
-]);
+] as const;
 
-export type ReservedMethodName =
-  | "constructor"
-  | "fetch"
-  | "connect"
-  | "alarm"
-  | "webSocketMessage"
-  | "webSocketClose"
-  | "webSocketError"
-  | "then"
-  | "dup"
-  | "dispose"
-  | "serialize"
-  | "deserialize";
+export const reservedMethodNames = new Set<string>(reservedMethodNameValues);
+
+export type ReservedMethodName = (typeof reservedMethodNameValues)[number];
 
 export type ServiceFreeSchema = S.Codec<any, any, never, never>;
 

--- a/packages/effect-cf/src/ServiceBinding.ts
+++ b/packages/effect-cf/src/ServiceBinding.ts
@@ -142,7 +142,11 @@ export type ServiceBindingEffectClient<
   readonly scopedCall: <Method extends ServiceMethodKey<Api>>(
     method: Method,
     ...args: ServiceMethodArgs<Api, Method>
-  ) => Effect.Effect<Awaited<ServiceMethodSuccess<Api, Method>>, unknown, Scope.Scope>;
+  ) => Effect.Effect<
+    Awaited<ServiceMethodSuccess<Api, Method>>,
+    ServiceBindingRpcError,
+    Scope.Scope
+  >;
 };
 
 export type ServiceBindingStaticClient<
@@ -165,7 +169,11 @@ export type ServiceBindingStaticClient<
   readonly scopedCall: <Method extends ServiceMethodKey<Api>>(
     method: Method,
     ...args: ServiceMethodArgs<Api, Method>
-  ) => Effect.Effect<Awaited<ServiceMethodSuccess<Api, Method>>, unknown, Scope.Scope | R>;
+  ) => Effect.Effect<
+    Awaited<ServiceMethodSuccess<Api, Method>>,
+    ServiceBindingRpcError,
+    Scope.Scope | R
+  >;
 };
 
 type ServiceBindingValue = Schema.Schema.Type<typeof Schema.Unknown>;
@@ -192,7 +200,22 @@ export const makeClient = <
       init?: RequestInit,
     ) {
       return yield* Effect.tryPromise({
-        try: () => service.fetch(input, init),
+        try: (signal) => {
+          const callerSignal =
+            init?.signal !== undefined
+              ? init.signal
+              : input instanceof Request
+                ? input.signal
+                : undefined;
+
+          return service.fetch(input, {
+            ...init,
+            signal:
+              callerSignal === null || callerSignal === undefined
+                ? signal
+                : AbortSignal.any([callerSignal, signal]),
+          });
+        },
         catch: (cause) => new ServiceBindingFetchError({ binding: definition.binding, cause }),
       });
     });
@@ -288,7 +311,16 @@ export const makeClient = <
     >(method: Method, ...args: ServiceMethodArgs<Api, Method>) {
       const methodName = String(method);
       const result = yield* rpc(method, ...args);
-      const value = yield* CloudflareRpc.scoped(result);
+      const value = yield* CloudflareRpc.scoped(result).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ServiceBindingRpcError({
+              binding: definition.binding,
+              method: methodName,
+              cause,
+            }),
+        ),
+      );
 
       return yield* decodeSuccess<Method>(methodName, value);
     });

--- a/packages/effect-cf/src/Vitest.ts
+++ b/packages/effect-cf/src/Vitest.ts
@@ -33,6 +33,7 @@ import {
 } from "./DurableObjectState";
 import { WorkerConfig, WorkerEnvironment, type WorkerEnv } from "./Environment";
 import type { WorkflowInstanceStatusName } from "./WorkflowBinding";
+import { runNativeCallback } from "./internal/NativeCallback";
 
 const currentEnv: WorkerEnv = env;
 
@@ -207,15 +208,20 @@ export const runInDurableObject = Effect.fn("effect-cf/vitest/runInDurableObject
   stub: globalThis.DurableObjectStub<Object>,
   use: (instance: Object, state: DurableObjectStateService) => Effect.Effect<A, E, R>,
 ): Effect.fn.Return<A, E, Exclude<R, DurableObjectState>> {
-  const context = yield* Effect.context<Exclude<R, DurableObjectState>>();
-  const exit = yield* Effect.promise(() =>
-    runInDurableObjectPromise(stub, (instance, nativeState) => {
-      const state = fromDurableObjectState(nativeState);
-      const effect = Effect.provideService(use(instance, state), DurableObjectState, state);
+  const exit = yield* runNativeCallback<A, E, Exclude<R, DurableObjectState>, Exit.Exit<A, E>>(
+    (run) =>
+      runInDurableObjectPromise(stub, (instance, nativeState) => {
+        const state = fromDurableObjectState(nativeState);
 
-      return Effect.runPromiseExitWith(context)(effect);
-    }),
-  );
+        return run(
+          Effect.provideService(
+            Effect.suspend(() => use(instance, state)),
+            DurableObjectState,
+            state,
+          ),
+        );
+      }),
+  ).pipe(Effect.orDie);
 
   return yield* exit;
 });
@@ -394,15 +400,12 @@ const runWorkflowModifier = Effect.fnUntraced(function* <A, E, R>(
   register: (use: (modifier: NativeWorkflowInstanceModifier) => Promise<void>) => Promise<any>,
   use: (modifier: WorkflowInstanceModifier) => Effect.Effect<A, E, R>,
 ): Effect.fn.Return<A, E, R> {
-  const context = yield* Effect.context<R>();
-  const exit = yield* Effect.promise(async () => {
+  const exit = yield* runNativeCallback<A, E, R, Exit.Exit<A, E>>(async (run) => {
     let callbackExit: Exit.Exit<A, E> | undefined;
 
     try {
       await register(async (modifier) => {
-        callbackExit = await Effect.runPromiseExitWith(context)(
-          use(wrapWorkflowModifier(modifier)),
-        );
+        callbackExit = await run(Effect.suspend(() => use(wrapWorkflowModifier(modifier))));
 
         if (Exit.isFailure(callbackExit)) {
           throw callbackExit;
@@ -421,7 +424,7 @@ const runWorkflowModifier = Effect.fnUntraced(function* <A, E, R>(
     }
 
     return callbackExit;
-  });
+  }).pipe(Effect.orDie);
 
   return yield* exit;
 });

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -1,10 +1,23 @@
 import { WorkerEntrypoint as CloudflareWorkerEntrypoint } from "cloudflare:workers";
-import { type Cause, Context, Effect, Layer, type ManagedRuntime, type Scope } from "effect";
-import { HttpEffect, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import {
+  type Cause,
+  Context,
+  Effect,
+  Layer,
+  type ManagedRuntime,
+  References,
+  type Scope,
+} from "effect";
+import {
+  HttpEffect,
+  HttpMiddleware,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http";
 
 import { WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { fromMessage, fromMessageBatch, type QueueHandler } from "./Queue";
-import type * as RpcDefinition from "./RpcDefinition";
+import * as RpcDefinition from "./RpcDefinition";
 import * as Entrypoint from "./internal/Entrypoint";
 import * as Runtime from "./internal/Runtime";
 import * as Telemetry from "./internal/Telemetry";
@@ -66,20 +79,13 @@ export type ReservedMethodName =
   | "webSocketError";
 
 const reservedMethodNames = new Set<string>([
-  "constructor",
-  "dup",
-  "fetch",
-  "connect",
+  ...RpcDefinition.reservedMethodNames,
   "queue",
   "scheduled",
   "tail",
   "tailStream",
   "test",
   "trace",
-  "alarm",
-  "webSocketMessage",
-  "webSocketClose",
-  "webSocketError",
 ]);
 
 type WorkerBaseContext<ROut> = ExecutionContext | WorkerContext | WorkerEnvironment | ROut;
@@ -148,10 +154,12 @@ export interface WorkerOptions<
   /**
    * Layer provided around each Cloudflare event handled by this Worker.
    *
-   * The layer is built inside the event's Effect scope and finalized when the
-   * event effect completes. Use this for event-scoped resources such as OTLP
-   * trace/log exporters. Worker fetch and RPC handlers schedule a best-effort
-   * flush capped at two seconds; queue handlers do not flush automatically.
+   * The layer is built inside the event's Effect scope. For fetch handlers that
+   * return an Effect `HttpServerResponse` stream, its scope remains open until
+   * the response body finishes or is canceled. Native `Response` values pass
+   * through unchanged, so their body streams do not carry this scoped-lifetime
+   * guarantee. Fetch, queue, and RPC handlers schedule a best-effort telemetry
+   * flush capped at two seconds.
    */
   readonly eventLayer?: Layer.Layer<REvent, EventLayerError, WorkerBaseContext<RRuntime>>;
   readonly fetch?: Effect.Effect<
@@ -216,9 +224,14 @@ export interface FetchHandler<Env extends WorkerEnv = WorkerEnv> {
   ) => Promise<Response>;
 }
 
-const renderFetchSuccess = <E, R>(
+const renderFetchSuccess = <E, R, REvent, EventLayerError, EventLayerRequirements>(
   effect: Effect.Effect<WorkerFetchSuccess, E, R>,
-): Effect.Effect<Response, E, Exclude<R, Scope.Scope> | HttpServerRequest.HttpServerRequest> =>
+  eventLayer: Layer.Layer<REvent, EventLayerError, EventLayerRequirements> | undefined,
+): Effect.Effect<
+  Response,
+  E | EventLayerError,
+  Exclude<R | EventLayerRequirements, Scope.Scope> | HttpServerRequest.HttpServerRequest
+> =>
   Effect.suspend(() => {
     // Native `Response` values bypass all HTTP response processing: WebSocket
     // upgrade responses and app-level `HttpEffect.toHandled` results pass
@@ -227,26 +240,64 @@ const renderFetchSuccess = <E, R>(
     let nativeResponse: Response | undefined;
     let webResponse: Response | undefined;
 
-    const handled = HttpEffect.toHandled(
-      Effect.flatMap(effect, (response) => {
-        if (response instanceof Response) {
-          nativeResponse = response;
+    const httpApp = Effect.flatMap(effect, (response) => {
+      if (response instanceof Response) {
+        nativeResponse = response;
 
-          return Effect.succeed(HttpServerResponse.empty());
-        }
+        return Effect.succeed(HttpServerResponse.empty());
+      }
 
-        return Effect.succeed(response);
+      return Effect.succeed(response);
+    });
+    const handleResponse = (
+      request: HttpServerRequest.HttpServerRequest,
+      response: HttpServerResponse.HttpServerResponse,
+    ) =>
+      nativeResponse !== undefined
+        ? Effect.void
+        : Effect.map(Effect.context<never>(), (context) => {
+            webResponse = HttpServerResponse.toWeb(HttpEffect.scopeTransferToStream(response), {
+              withoutBody: request.method === "HEAD",
+              context,
+            });
+          });
+    const telemetryMiddleware = HttpMiddleware.make((self) =>
+      Effect.gen(function* () {
+        yield* Effect.addFinalizer(() => scheduleTelemetryFlush);
+
+        return yield* self;
       }),
-      (request, response) =>
-        nativeResponse !== undefined
-          ? Effect.void
-          : Effect.map(Effect.context<never>(), (context) => {
-              webResponse = HttpServerResponse.toWeb(HttpEffect.scopeTransferToStream(response), {
-                withoutBody: request.method === "HEAD",
-                context,
-              });
-            }),
     );
+    const handled =
+      eventLayer === undefined
+        ? HttpEffect.toHandled(httpApp, handleResponse, telemetryMiddleware)
+        : Effect.flatMap(References.TracerEnabled, (tracerEnabled) =>
+            HttpEffect.toHandled(
+              httpApp,
+              handleResponse,
+              HttpMiddleware.make((self) =>
+                Effect.provideService(
+                  Effect.gen(function* () {
+                    const context = yield* Layer.build(Layer.fresh(eventLayer));
+
+                    yield* Effect.addFinalizer(() =>
+                      Effect.provideContext(scheduleTelemetryFlush, context),
+                    );
+
+                    return yield* HttpMiddleware.tracer(self).pipe(
+                      // The tracer schedules span completion. Let it publish on
+                      // every exit with event references still installed, before
+                      // the exporter scope finalizes.
+                      Effect.onExit(() => Effect.yieldNow),
+                      Effect.provideContext(context),
+                    );
+                  }),
+                  References.TracerEnabled,
+                  tracerEnabled,
+                ),
+              ),
+            ).pipe(Effect.withTracerEnabled(false)),
+          );
 
     // `toHandled` re-fails with the original cause after rendering the error
     // response, so both branches return the response captured above.
@@ -260,13 +311,13 @@ const isWorkerOptions = <ROut, REvent, EventLayerError, Rpc extends WorkerRpc<RO
 ): options is WorkerOptions<ROut, REvent, EventLayerError, Rpc> => !Effect.isEffect(options);
 
 /**
- * Drains buffered OTLP telemetry once the fetch handler has produced its
- * response.
+ * Drains buffered OTLP telemetry when the fetch Effect scope closes. Effect
+ * response streams transfer that scope to the body and schedule the flush when
+ * the body finishes or is canceled.
  *
- * The flush is handed to `ctx.waitUntil` so it never delays the response
- * (including streaming bodies still being consumed). It is a no-op when the
- * context does not contain an `OtlpExporter.Flusher`. The handed-off effect is
- * best-effort and silently settles within two seconds.
+ * The flush is handed to `ctx.waitUntil` instead of being awaited by the
+ * handler. It is a no-op when the context does not contain an
+ * `OtlpExporter.Flusher`, and silently settles within two seconds.
  */
 const scheduleTelemetryFlush: Effect.Effect<void, never, WorkerContext> =
   Telemetry.scheduleTelemetryFlush((flush) =>
@@ -274,8 +325,10 @@ const scheduleTelemetryFlush: Effect.Effect<void, never, WorkerContext> =
   );
 
 /**
- * The layer is built once per Worker instance and reused for its events.
- * Eviction skips finalizers, so use `eventLayer` for per-event resources.
+ * Cloudflare creates a new `WorkerEntrypoint` instance for each native
+ * invocation, so this base layer is not shared across invocations. Its managed
+ * runtime has no deterministic disposal point in this adapter; use
+ * `eventLayer` for resources whose finalizers must run with an event.
  */
 export function make<ROut, LayerError>(
   layer: Layer.Layer<ROut, LayerError, ExecutionContext | WorkerContext | WorkerEnvironment>,
@@ -381,12 +434,16 @@ export function make<
         Layer.succeed(WorkerContext, fromExecutionContext(ctx)),
       );
 
-      // SAFETY: requestServices provides the HTTP/request contexts introduced by renderFetchSuccess.
-      return this[RunSymbol](
-        renderFetchSuccess(fetchHandler).pipe(
-          Effect.tap(() => scheduleTelemetryFlush),
+      // The request services wrap eventLayer construction so cached object handlers
+      // never build an event layer against a previous request's ExecutionContext.
+      // HttpEffect owns the inner scope and transfers it to streaming response bodies.
+      // SAFETY: requestServices and the middleware-built eventLayer provide every
+      // fetch-only context removed from the runtime effect below.
+      return Runtime.runEventPromise(
+        this.runtime,
+        renderFetchSuccess(fetchHandler, options.eventLayer).pipe(
           Effect.provide(requestServices),
-        ) as Effect.Effect<Response, unknown, RuntimeContext<ROut> | REvent | Scope.Scope>,
+        ) as Effect.Effect<Response, unknown, RuntimeContext<ROut> | Scope.Scope>,
       );
     }
 
@@ -399,7 +456,11 @@ export function make<
 
       const messages = batch.messages.map((message) => fromMessage(message, message.body));
 
-      return this[RunSymbol](queueHandler(fromMessageBatch(batch, messages)));
+      return this[RunSymbol](
+        queueHandler(fromMessageBatch(batch, messages)).pipe(
+          Effect.onExit(() => scheduleTelemetryFlush),
+        ),
+      );
     }
   }
 
@@ -423,12 +484,13 @@ interface FetchCapableInstance {
  * Creates an `ExportedHandler`-compatible `{ fetch }` object backed by
  * {@link make}.
  *
- * The Effect runtime is cached per `env` identity, so the user layer builds
- * once per isolate instead of once per request. `ExecutionContext`-backed
- * services (`Worker.ExecutionContext`, `Worker.WorkerContext`) are still
- * provided fresh for every request. Layer finalizers do not run when the
- * isolate is evicted; Cloudflare provides no shutdown hook. Use `eventLayer`
- * for resources that must be finalized per event.
+ * The Effect runtime is cached per `env` identity, so the base layer builds
+ * once for that cached handler. Request handlers and `eventLayer` receive fresh
+ * `ExecutionContext` and `WorkerContext` services. A service constructed by the
+ * cached base layer from either context instead captures the first request's
+ * value, so construct invocation-bound services in `eventLayer`. Cloudflare
+ * provides no isolate shutdown hook, so cached base-layer finalizers are not
+ * guaranteed to run.
  */
 export function makeFetchHandler<
   ROut,

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -459,12 +459,8 @@ export function make<
       // The request services wrap eventLayer construction so cached object handlers
       // never build an event layer against a previous request's ExecutionContext.
       // HttpEffect owns the inner scope and transfers it to streaming response bodies.
-      // SAFETY: requestServices and the middleware-built eventLayer provide every
-      // fetch-only context removed from the runtime effect below.
       return this[RunSymbol](
-        renderFetchSuccess(fetchHandler, options.eventLayer).pipe(
-          Effect.provide(requestServices),
-        ) as Effect.Effect<Response, unknown, RuntimeContext<ROut> | Scope.Scope>,
+        renderFetchSuccess(fetchHandler, options.eventLayer).pipe(Effect.provide(requestServices)),
         { event: "fetch" },
       );
     }

--- a/packages/effect-cf/src/WorkersAi.ts
+++ b/packages/effect-cf/src/WorkersAi.ts
@@ -186,7 +186,7 @@ export const embeddingResponse = (value: {
   [embeddingDimensionsKey]: value[embeddingDimensionsKey] ?? [],
 });
 
-const decodeEmbeddingResponse = S.decodeUnknownOption(
+const decodeEmbeddingResponse = S.decodeUnknownEffect(
   S.Struct({
     data: S.optional(S.Array(S.Array(S.Number))),
     [embeddingDimensionsKey]: S.optional(S.Array(S.Number)),
@@ -212,21 +212,28 @@ export const makeClient =
         () => ai.aiGatewayLogId,
       ),
       run,
-      runEmbedding: Effect.fn("WorkersAi.runEmbedding")(
-        (model: string, input: WorkersAiEmbeddingInput, options?: WorkersAiOptions) => {
-          // SAFETY: every WorkersAiEmbeddingInput variant is a string-keyed Workers AI payload.
-          const modelInput = input as Parameters<WorkersAiBinding["run"]>[1];
+      runEmbedding: Effect.fn("WorkersAi.runEmbedding")(function* (
+        model: string,
+        input: WorkersAiEmbeddingInput,
+        options?: WorkersAiOptions,
+      ) {
+        // SAFETY: every WorkersAiEmbeddingInput variant is a string-keyed Workers AI payload.
+        const modelInput = input as Parameters<WorkersAiBinding["run"]>[1];
 
-          return run(model, modelInput, options).pipe(
-            Effect.map((response) =>
-              Option.match(decodeEmbeddingResponse(response), {
-                onNone: () => embeddingResponse({}),
-                onSome: embeddingResponse,
+        const response = yield* run(model, modelInput, options);
+        const decoded = yield* decodeEmbeddingResponse(response).pipe(
+          Effect.mapError(
+            (cause) =>
+              new WorkersAiOperationError({
+                binding: definition.binding,
+                operation: "runEmbedding",
+                cause,
               }),
-            ),
-          );
-        },
-      ),
+          ),
+        );
+
+        return embeddingResponse(decoded);
+      }),
       models: Effect.fn("WorkersAi.models")((params?: WorkersAiModelsSearchParams) =>
         tryWorkersAiPromise(definition.binding, "models", () => ai.models(params)),
       ),

--- a/packages/effect-cf/src/Workflow.ts
+++ b/packages/effect-cf/src/Workflow.ts
@@ -14,6 +14,7 @@ import {
   Context,
   Data,
   Effect,
+  FiberSet,
   Layer,
   type ManagedRuntime,
   Option,
@@ -39,8 +40,6 @@ export interface WorkflowEventService<Payload = unknown> {
 export class WorkflowEvent extends Context.Service<WorkflowEvent, WorkflowEventService>()(
   "effect-cf/WorkflowEvent",
 ) {}
-
-type RunWorkflowStepEffect = <A, E>(effect: Effect.Effect<A, E, never>) => Promise<A>;
 
 export class WorkflowStepError extends Data.TaggedError("WorkflowStepError")<{
   readonly step?: string;
@@ -135,52 +134,52 @@ const exposeCloudflareNonRetryableError = <A, E, R>(
       : Effect.failCause(cause);
   });
 
-const fromWorkflowStep = (
-  step: CloudflareWorkflowStep,
-  runPromise: RunWorkflowStepEffect,
-): WorkflowStepService => ({
+const fromWorkflowStep = (step: CloudflareWorkflowStep): WorkflowStepService => ({
   raw: step,
   do: <A, E, R>(name: string, effect: Effect.Effect<A, E, R>, config?: WorkflowStepConfig) =>
-    Effect.context<Exclude<R, WorkflowStepContext>>().pipe(
-      Effect.flatMap((context) =>
-        Effect.tryPromise({
-          try: () => {
-            const run = (stepContext: CloudflareWorkflowStepContext) =>
-              runPromise(
-                exposeCloudflareNonRetryableError(
-                  Effect.scoped(
-                    Effect.provideService(
-                      Effect.provideContext(
-                        // SAFETY: WorkflowStepContext is provided immediately below; context supplies every other R service.
-                        // @effect-diagnostics-next-line unsafeEffectTypeAssertion:off
-                        effect as Effect.Effect<A, E, Exclude<R, WorkflowStepContext>>,
-                        context,
-                      ),
-                      WorkflowStepContext,
-                      stepContext,
-                    ),
-                  ),
-                ),
-              );
-            // SAFETY: these overloads reproduce the Cloudflare WorkflowStep.do runtime signatures used here.
-            const rawStep = step as {
-              do(
-                name: string,
-                callback: (context: CloudflareWorkflowStepContext) => Promise<A>,
-              ): Promise<A>;
-              do(
-                name: string,
-                config: WorkflowStepConfig,
-                callback: (context: CloudflareWorkflowStepContext) => Promise<A>,
-              ): Promise<A>;
-            };
+    Effect.gen(function* () {
+      const context = yield* Effect.context<Exclude<R, WorkflowStepContext>>();
 
-            return config === undefined ? rawStep.do(name, run) : rawStep.do(name, config, run);
-          },
-          catch: (cause) => new WorkflowStepError({ step: name, operation: "do", cause }),
+      return yield* Effect.scoped(
+        Effect.gen(function* () {
+          // Cloudflare owns retry timing and exposes no step cancellation API.
+          // Join the current callback on interruption and prevent later retry
+          // callbacks from starting, without waiting for native retry delays.
+          const runPromise = yield* FiberSet.makeRuntimePromise<never, A, E>();
+
+          return yield* Effect.tryPromise({
+            try: () => {
+              const run = (stepContext: CloudflareWorkflowStepContext) => {
+                const stepEffect: Effect.Effect<
+                  A,
+                  E,
+                  Exclude<R, WorkflowStepContext>
+                > = Effect.scoped(Effect.provideService(effect, WorkflowStepContext, stepContext));
+
+                return runPromise(
+                  exposeCloudflareNonRetryableError(Effect.provideContext(stepEffect, context)),
+                );
+              };
+              // SAFETY: these overloads reproduce the Cloudflare WorkflowStep.do runtime signatures used here.
+              const rawStep = step as {
+                do(
+                  name: string,
+                  callback: (context: CloudflareWorkflowStepContext) => Promise<A>,
+                ): Promise<A>;
+                do(
+                  name: string,
+                  config: WorkflowStepConfig,
+                  callback: (context: CloudflareWorkflowStepContext) => Promise<A>,
+                ): Promise<A>;
+              };
+
+              return config === undefined ? rawStep.do(name, run) : rawStep.do(name, config, run);
+            },
+            catch: (cause) => new WorkflowStepError({ step: name, operation: "do", cause }),
+          });
         }),
-      ),
-    ),
+      );
+    }),
   sleep: (name, duration) =>
     Effect.tryPromise({
       try: () => step.sleep(name, duration),
@@ -263,10 +262,7 @@ export const make = <ROut, LayerError, Payload = unknown, Result = unknown>(
     ): Promise<Result> {
       const workflowServices = Layer.mergeAll(
         Layer.succeed(WorkflowEvent, fromWorkflowEvent(event)),
-        Layer.succeed(
-          WorkflowStep,
-          fromWorkflowStep(step, (effect) => this.runtime.runPromise(effect)),
-        ),
+        Layer.succeed(WorkflowStep, fromWorkflowStep(step)),
       );
 
       return Runtime.runEventPromise(this.runtime, options.run(event.payload), workflowServices);

--- a/packages/effect-cf/src/internal/NativeCallback.ts
+++ b/packages/effect-cf/src/internal/NativeCallback.ts
@@ -1,0 +1,55 @@
+import { Effect, Exit, FiberSet } from "effect";
+
+type RunCallback<A, E, R> = (effect: Effect.Effect<A, E, R>) => Promise<Exit.Exit<A, E>>;
+
+/**
+ * Runs an Effect callback owned by a native Promise operation.
+ *
+ * The callback keeps the caller's context, while a private scope owns its
+ * fiber. Closing that scope interrupts and joins the callback before awaiting
+ * the native operation's settlement.
+ */
+export const runNativeCallback = Effect.fnUntraced(function* <A, E, R, B>(
+  operation: (run: RunCallback<A, E, R>) => Promise<B>,
+): Effect.fn.Return<B, unknown, R> {
+  const callerContext = yield* Effect.context<R>();
+
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      let nativePromise: Promise<B> | undefined;
+
+      // Registered before the FiberSet so scope closure first interrupts and
+      // joins the callback, then waits for the native rollback/gate to settle.
+      yield* Effect.addFinalizer(() => {
+        const promise = nativePromise;
+
+        return promise === undefined
+          ? Effect.void
+          : Effect.promise(() =>
+              promise.then(
+                () => undefined,
+                () => undefined,
+              ),
+            );
+      });
+      const runPromise = yield* FiberSet.makeRuntimePromise<never, Exit.Exit<A, E>, never>();
+
+      return yield* Effect.callback<B, unknown>((resume) => {
+        try {
+          nativePromise = operation((effect) =>
+            runPromise(Effect.provideContext(Effect.exit(effect), callerContext)),
+          );
+        } catch (cause) {
+          resume(Effect.fail(cause));
+
+          return;
+        }
+
+        nativePromise.then(
+          (value) => resume(Effect.succeed(value)),
+          (cause) => resume(Effect.fail(cause)),
+        );
+      });
+    }),
+  );
+});

--- a/packages/effect-cf/src/internal/WorkerContext.ts
+++ b/packages/effect-cf/src/internal/WorkerContext.ts
@@ -17,7 +17,9 @@ const failureHandler = <E, R>(
   cause: Cause.Cause<E>,
   options: WorkerContextWaitUntilOptions<E, R> | undefined,
 ) =>
-  (options?.onFailure?.(cause) ?? Effect.logError(`${label} failed`, Cause.pretty(cause))).pipe(
+  Effect.suspend(
+    () => options?.onFailure?.(cause) ?? Effect.logError(`${label} failed`, Cause.pretty(cause)),
+  ).pipe(
     Effect.catchCause((handlerCause) =>
       Effect.logError(
         `${label} failure handler failed`,
@@ -42,7 +44,7 @@ export const makeWaitUntilScheduler = (
         Effect.sync(() => {
           const runHandler = (cause: Cause.Cause<E>) =>
             runPromiseExit(
-              Effect.scoped(Effect.provideContext(failureHandler(label, cause, options), context)),
+              Effect.provideContext(Effect.scoped(failureHandler(label, cause, options)), context),
             ).then((exit) => {
               if (Exit.isFailure(exit)) {
                 console.error(`${label} failure handler failed`, Cause.pretty(exit.cause));
@@ -50,7 +52,7 @@ export const makeWaitUntilScheduler = (
             });
 
           register(
-            runPromiseExit(Effect.scoped(Effect.provideContext(effect, context))).then(
+            runPromiseExit(Effect.provideContext(Effect.scoped(effect), context)).then(
               async (exit) => {
                 if (Exit.isSuccess(exit)) {
                   return;

--- a/packages/effect-cf/tests/AnalyticsEngine.test.ts
+++ b/packages/effect-cf/tests/AnalyticsEngine.test.ts
@@ -538,6 +538,22 @@ test("AnalyticsEngine query client maps non-2xx responses", async () => {
   });
 });
 
+test("AnalyticsEngine query client maps invalid API URLs to its typed error", async () => {
+  const client = await Effect.runPromise(
+    AnalyticsEngine.makeQueryClient({
+      accountId: "account-1",
+      apiToken: Redacted.make("secret-token"),
+      apiBaseUrl: "not a URL",
+    }).pipe(Effect.provide(fetchLayer(async () => new Response("unused")))),
+  );
+
+  await expect(Effect.runPromise(client.query("SELECT 1"))).rejects.toMatchObject({
+    _tag: "AnalyticsEngineQueryError",
+    operation: "query",
+    accountId: "account-1",
+  });
+});
+
 test("AnalyticsEngine query client surfaces schema failures", async () => {
   const client = await Effect.runPromise(
     AnalyticsEngine.makeQueryClient({

--- a/packages/effect-cf/tests/CloudflareOtlp.test.ts
+++ b/packages/effect-cf/tests/CloudflareOtlp.test.ts
@@ -200,7 +200,7 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
           ),
           fetch: (status === 200
             ? Effect.succeed(new Response("ok"))
-            : Effect.fail(new Error("expected handler failure"))
+            : Effect.fail("expected handler failure")
           ).pipe(Effect.withSpan("test.fetch", { attributes: { route: "/" } })),
         });
 

--- a/packages/effect-cf/tests/CloudflareOtlp.test.ts
+++ b/packages/effect-cf/tests/CloudflareOtlp.test.ts
@@ -1,7 +1,13 @@
 import { NodeHttpServer } from "@effect/platform-node";
 import { expect, it, layer } from "@effect/vitest";
 import { ConfigProvider, Context, Effect, Layer, Queue, Schema as S } from "effect";
-import { HttpServer, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import {
+  Headers,
+  HttpMiddleware,
+  HttpServer,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http";
 import { OtlpExporter } from "effect/unstable/observability";
 import process from "node:process";
 
@@ -176,56 +182,70 @@ layer(OtlpCollector.layer)("CloudflareOtlp collector", (it) => {
     }),
   );
 
-  it.effect("exports Worker spans through the public fetch handler", () =>
-    Effect.gen(function* () {
-      const collector = yield* OtlpCollector;
-      const handler = Worker.makeFetchHandler(Layer.empty, {
-        eventLayer: CloudflareOtlp.layerWorker({
-          signals: ["traces"],
-          serialization: "json",
-          resource: { serviceName: "effect-cf-test" },
-          workerName: "api-worker",
-        }),
-        fetch: Effect.succeed(new Response("ok")).pipe(
-          Effect.withSpan("test.fetch", { attributes: { route: "/" } }),
-        ),
-      });
+  it.effect.each([200, 500])(
+    "exports Worker spans through the public fetch handler (%s)",
+    (status) =>
+      Effect.gen(function* () {
+        const collector = yield* OtlpCollector;
+        const handler = Worker.makeFetchHandler(Layer.empty, {
+          eventLayer: Layer.mergeAll(
+            CloudflareOtlp.layerWorker({
+              signals: ["traces"],
+              serialization: "json",
+              resource: { serviceName: "effect-cf-test" },
+              workerName: "api-worker",
+            }),
+            Layer.succeed(HttpMiddleware.SpanNameGenerator)(() => "event.server"),
+            Layer.succeed(Headers.CurrentRedactedNames)(["x-event-secret"]),
+          ),
+          fetch: (status === 200
+            ? Effect.succeed(new Response("ok"))
+            : Effect.fail(new Error("expected handler failure"))
+          ).pipe(Effect.withSpan("test.fetch", { attributes: { route: "/" } })),
+        });
 
-      const response = yield* Effect.promise(() =>
-        handler.fetch(
-          new Request("https://worker.test/"),
-          makeEnv({
-            OTEL_TRACES_EXPORTER: "otlp",
-            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: `${collector.endpoint}/v1/traces`,
-            OTEL_EXPORTER_OTLP_HEADERS: "x-api-key=test-secret,x-shared=common",
-            OTEL_EXPORTER_OTLP_TRACES_HEADERS: "x-api-key=trace-secret,x-trace-key=trace-only",
-          }),
-          makeExecutionContext(),
-        ),
-      );
+        const response = yield* Effect.promise(() =>
+          handler.fetch(
+            new Request("https://worker.test/", {
+              headers: { "x-event-secret": "redaction-test-value" },
+            }),
+            makeEnv({
+              OTEL_TRACES_EXPORTER: "otlp",
+              OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: `${collector.endpoint}/v1/traces`,
+              OTEL_EXPORTER_OTLP_HEADERS: "x-api-key=test-secret,x-shared=common",
+              OTEL_EXPORTER_OTLP_TRACES_HEADERS: "x-api-key=trace-secret,x-trace-key=trace-only",
+            }),
+            makeExecutionContext(),
+          ),
+        );
 
-      expect(response.status).toBe(200);
+        expect(response.status).toBe(status);
 
-      const request = yield* collector.nextRequest;
+        const request = yield* collector.nextRequest;
 
-      expect(request.path).toBe("/v1/traces");
-      expect(request.headers["x-api-key"]).toBe("trace-secret");
-      expect(request.headers["x-trace-key"]).toBe("trace-only");
-      expect(request.headers["x-shared"]).toBeUndefined();
+        expect(request.path).toBe("/v1/traces");
+        expect(request.headers["x-api-key"]).toBe("trace-secret");
+        expect(request.headers["x-trace-key"]).toBe("trace-only");
+        expect(request.headers["x-shared"]).toBeUndefined();
+        expect(request.body).not.toContain("redaction-test-value");
 
-      const payload = decodeOtlpPayload(request.body);
-      const firstResourceSpan = payload.resourceSpans[0];
-      const resourceAttributes = firstResourceSpan.resource.attributes;
-      const spans = firstResourceSpan.scopeSpans[0].spans;
-      const firstSpan = spans[0];
-      const spanAttributes = firstSpan.attributes;
+        const payload = decodeOtlpPayload(request.body);
+        const firstResourceSpan = payload.resourceSpans[0];
+        const resourceAttributes = firstResourceSpan.resource.attributes;
+        const spans = firstResourceSpan.scopeSpans[0].spans;
 
-      expect(getStringAttribute(resourceAttributes, "service.name")).toBe("effect-cf-test");
-      expect(getStringAttribute(resourceAttributes, "cloudflare.resource_type")).toBe("worker");
-      expect(getStringAttribute(resourceAttributes, "cloudflare.worker.name")).toBe("api-worker");
-      expect(spans.map((span) => span.name)).toContain("test.fetch");
-      expect(getStringAttribute(spanAttributes, "route")).toBe("/");
-    }),
+        expect(getStringAttribute(resourceAttributes, "service.name")).toBe("effect-cf-test");
+        expect(getStringAttribute(resourceAttributes, "cloudflare.resource_type")).toBe("worker");
+        expect(getStringAttribute(resourceAttributes, "cloudflare.worker.name")).toBe("api-worker");
+        expect(spans.map((span) => span.name)).toContain("test.fetch");
+        expect(spans.map((span) => span.name)).toContain("event.server");
+        expect(
+          spans.some(
+            (span) =>
+              span.name === "test.fetch" && getStringAttribute(span.attributes, "route") === "/",
+          ),
+        ).toBe(true);
+      }),
   );
 
   it.effect("exports WorkerDefinition RPC spans through waitUntil", () =>

--- a/packages/effect-cf/tests/DurableObjectNamespaceFetch.test.ts
+++ b/packages/effect-cf/tests/DurableObjectNamespaceFetch.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "vite-plus/test";
+import { Effect, Fiber } from "effect";
+
+import { DurableObjectNamespace } from "../src/index";
+
+const makeClient = (fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) => {
+  // SAFETY: fetch is the only namespace capability exercised by this focused client test.
+  const namespace = {} as DurableObjectNamespace.DurableObjectNamespaceClient<{}>;
+  // SAFETY: the fetch adapter only reads the stub's fetch method for this focused client test.
+  const stub = { fetch } as DurableObjectNamespace.DurableObjectStubClient<{}>;
+
+  return {
+    client: DurableObjectNamespace.makeClient<{}>({ binding: "COUNTER" })(namespace),
+    stub,
+  };
+};
+
+test("Durable Object fetch aborts an in-flight native request on interruption", async () => {
+  let capturedSignal: AbortSignal | null | undefined;
+  let started = () => {};
+  const requestStarted = new Promise<void>((resolve) => {
+    started = resolve;
+  });
+  const { client, stub } = makeClient((_input, init) => {
+    capturedSignal = init?.signal;
+    started();
+
+    return new Promise<Response>((_resolve, reject) => {
+      capturedSignal?.addEventListener("abort", () => reject(capturedSignal?.reason), {
+        once: true,
+      });
+    });
+  });
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fiber = yield* Effect.forkChild(client.fetch(stub, "https://example.test"));
+
+      yield* Effect.promise(() => requestStarted);
+      yield* Fiber.interrupt(fiber);
+    }),
+  );
+
+  expect(capturedSignal).toBeDefined();
+  expect(capturedSignal?.aborted).toBe(true);
+});
+
+test("Durable Object fetch follows Request signal override and null semantics", async () => {
+  const capturedSignals: Array<AbortSignal | null | undefined> = [];
+  const { client, stub } = makeClient(async (_input, init) => {
+    capturedSignals.push(init?.signal);
+
+    return new Response("ok");
+  });
+  const inputController = new AbortController();
+  const initController = new AbortController();
+  const request = new Request("https://example.test", { signal: inputController.signal });
+
+  await Effect.runPromise(client.fetch(stub, request, { signal: initController.signal }));
+  inputController.abort();
+  const overrideSignal = capturedSignals[0];
+
+  expect(overrideSignal?.aborted).toBe(false);
+  initController.abort();
+  expect(overrideSignal?.aborted).toBe(true);
+
+  const nullInputController = new AbortController();
+  const nullRequest = new Request("https://example.test", { signal: nullInputController.signal });
+
+  await Effect.runPromise(client.fetch(stub, nullRequest, { signal: null }));
+  const nullSignal = capturedSignals[1];
+
+  nullInputController.abort();
+
+  expect(nullSignal?.aborted).toBe(false);
+});

--- a/packages/effect-cf/tests/DurableObjectRpcWebSocket.test.ts
+++ b/packages/effect-cf/tests/DurableObjectRpcWebSocket.test.ts
@@ -197,6 +197,38 @@ Object.defineProperty(globalThis, "WebSocketRequestResponsePair", {
 }
 
 {
+  const socket = makeFakeWebSocket({
+    application: "preserved",
+    effectCloudflareRpcClientId: {
+      version: 1,
+      clientId: 99,
+      hasPendingRequests: true,
+    },
+  });
+  const durableSocket = DurableObjectWebSocket.fromWebSocket(socket);
+  const state = makeFakeDurableObjectState();
+
+  layer(makeAppLayer(state))("DurableObjectRpcWebSocket fresh attachment reservation", (it) => {
+    it.effect("replaces reserved metadata while preserving application fields", () =>
+      Effect.gen(function* () {
+        const transport = yield* DurableObjectRpcWebSocket.DurableObjectRpcWebSocket;
+
+        yield* transport.accept(durableSocket);
+
+        assert.deepStrictEqual(socket.deserializeAttachment(), {
+          application: "preserved",
+          effectCloudflareRpcClientId: {
+            version: 1,
+            clientId: 0,
+            hasPendingRequests: false,
+          },
+        });
+      }),
+    );
+  });
+}
+
+{
   layer(Layer.empty)("DurableObjectRpcWebSocket restoration isolation", (it) => {
     it.effect("continues restoring healthy sockets when an invalid socket cannot close", () =>
       Effect.scoped(

--- a/packages/effect-cf/tests/DurableObjectRpcWebSocket.worker.test.ts
+++ b/packages/effect-cf/tests/DurableObjectRpcWebSocket.worker.test.ts
@@ -438,10 +438,14 @@ test("a hibernated in-flight finite RPC is reset without replay", async () => {
   client.accept();
   client.send(request("lost-request", "never", "HibernationNever"));
 
-  const pending = await runInDurableObject(stub, async (_instance, state) => ({
-    attachments: state.getWebSockets().map((socket) => socket.deserializeAttachment()),
-    neverStarts: await state.storage.get<number>("hibernation-never-starts"),
-  }));
+  const pending = await runInDurableObject(stub, async (_instance, state) => {
+    const neverStarts = await state.storage.get<number>("hibernation-never-starts");
+
+    return {
+      attachments: state.getWebSockets().map((socket) => socket.deserializeAttachment()),
+      neverStarts,
+    };
+  });
 
   expect(pending.attachments).toMatchObject([
     {

--- a/packages/effect-cf/tests/DurableObjectState.test.ts
+++ b/packages/effect-cf/tests/DurableObjectState.test.ts
@@ -1,7 +1,7 @@
 import { assert, it } from "@effect/vitest";
-import { Cause, Context, Effect, Exit } from "effect";
+import { Cause, Context, Deferred, Effect, Exit, Fiber } from "effect";
 
-import { DurableObjectState, DurableObjectWebSocket } from "../src/index";
+import { DurableObjectState } from "../src/index";
 import { makePartialTestDouble } from "./TestDoubles";
 
 const FailureMessage = Context.Service<{ readonly message: string }>(
@@ -70,6 +70,44 @@ it.effect("blockConcurrencyWhileOrReset intentionally rejects the callback on fa
   }),
 );
 
+it.effect("blockConcurrencyWhile joins interrupted callback finalizers before returning", () =>
+  Effect.gen(function* () {
+    const { state, tracker } = makeRawDurableObjectState();
+    const service = DurableObjectState.fromDurableObjectState(state);
+    const started = yield* Deferred.make<void>();
+    const continueCallback = yield* Deferred.make<void>();
+    const releaseFinalizer = yield* Deferred.make<void>();
+    const finalized = yield* Deferred.make<void>();
+
+    const callback = Deferred.succeed(started, undefined).pipe(
+      Effect.andThen(Deferred.await(continueCallback)),
+      Effect.onInterrupt(() =>
+        Deferred.await(releaseFinalizer).pipe(
+          Effect.andThen(Deferred.succeed(finalized, undefined)),
+        ),
+      ),
+    );
+    const fiber = yield* Effect.forkChild(service.blockConcurrencyWhile(callback));
+
+    yield* Deferred.await(started);
+    fiber.interruptUnsafe();
+    yield* Effect.yieldNow;
+
+    yield* Effect.sync(() => assert.isUndefined(fiber.pollUnsafe())).pipe(
+      Effect.ensuring(
+        Deferred.succeed(continueCallback, undefined).pipe(
+          Effect.andThen(Deferred.succeed(releaseFinalizer, undefined)),
+        ),
+      ),
+    );
+    yield* Fiber.awaitAll([fiber]);
+
+    assert.isTrue(yield* Deferred.isDone(finalized));
+    assert.strictEqual(tracker.resolved.length, 0);
+    assert.strictEqual(tracker.rejected.length, 1);
+  }),
+);
+
 it.effect("waitUntil runs background Effects with the caller's context", () =>
   Effect.gen(function* () {
     const { state, tracker } = makeRawDurableObjectState();
@@ -117,56 +155,10 @@ it.effect("waitUntil propagate mode rejects the native waitUntil promise", () =>
   }),
 );
 
-it.effect("wraps hibernation metadata and abort helpers", () =>
-  Effect.gen(function* () {
-    const { state, tracker } = makeRawDurableObjectState();
-    const service = DurableObjectState.fromDurableObjectState(state);
-    const ws = makePartialTestDouble<WebSocket>({});
-    const timestamp = new Date("2026-04-25T00:00:00.000Z");
-
-    tracker.tags.set(ws, ["room:general", "user:1"]);
-    tracker.autoResponseTimestamps.set(ws, timestamp);
-    tracker.sockets = [ws];
-    const socket = DurableObjectWebSocket.fromWebSocket(ws);
-
-    assert.deepStrictEqual(yield* service.getTags(socket), ["room:general", "user:1"]);
-    assert.strictEqual(yield* service.getWebSocketAutoResponseTimestamp(socket), timestamp);
-    yield* service.acceptWebSocket(socket, ["room:general"]);
-    assert.deepStrictEqual(tracker.acceptedSockets, [{ socket: ws, tags: ["room:general"] }]);
-    assert.deepStrictEqual(
-      (yield* service.getWebSockets()).map((socket) => socket.raw),
-      [ws],
-    );
-
-    assert.strictEqual(yield* service.getHibernatableWebSocketEventTimeout, null);
-    yield* service.setHibernatableWebSocketEventTimeout(1_000);
-    assert.strictEqual(yield* service.getHibernatableWebSocketEventTimeout, 1_000);
-    yield* service.setHibernatableWebSocketEventTimeout();
-    assert.strictEqual(yield* service.getHibernatableWebSocketEventTimeout, null);
-
-    yield* service.abort("cleanup complete", { retryAlarm: false });
-    assert.deepStrictEqual(tracker.aborts, [
-      { reason: "cleanup complete", options: { retryAlarm: false } },
-    ]);
-  }),
-);
-
 interface BlockConcurrencyTracker {
   calls: number;
   readonly resolved: Array<unknown>;
   readonly rejected: Array<unknown>;
-  readonly tags: Map<WebSocket, Array<string>>;
-  readonly autoResponseTimestamps: Map<WebSocket, Date>;
-  readonly acceptedSockets: Array<{
-    readonly socket: WebSocket;
-    readonly tags: Array<string> | undefined;
-  }>;
-  sockets: Array<WebSocket>;
-  hibernatableTimeout: number | null;
-  readonly aborts: Array<{
-    readonly reason: string | undefined;
-    readonly options: globalThis.DurableObjectAbortOptions | undefined;
-  }>;
   readonly waitUntilPromises: Array<Promise<unknown>>;
 }
 
@@ -180,12 +172,6 @@ function makeRawDurableObjectState(): RawStateFixture {
     calls: 0,
     resolved: [],
     rejected: [],
-    tags: new Map(),
-    autoResponseTimestamps: new Map(),
-    acceptedSockets: [],
-    sockets: [],
-    hibernatableTimeout: null,
-    aborts: [],
     waitUntilPromises: [],
   };
 
@@ -208,22 +194,6 @@ function makeRawDurableObjectState(): RawStateFixture {
         tracker.rejected.push(error);
         throw error;
       }
-    },
-    acceptWebSocket: (socket: WebSocket, tags?: Array<string>) => {
-      tracker.acceptedSockets.push({ socket, tags });
-    },
-    getWebSockets: () => tracker.sockets,
-    setWebSocketAutoResponse: () => {},
-    getWebSocketAutoResponse: () => null,
-    getWebSocketAutoResponseTimestamp: (ws: WebSocket) =>
-      tracker.autoResponseTimestamps.get(ws) ?? null,
-    setHibernatableWebSocketEventTimeout: (timeoutMs?: number) => {
-      tracker.hibernatableTimeout = timeoutMs && timeoutMs > 0 ? timeoutMs : null;
-    },
-    getHibernatableWebSocketEventTimeout: () => tracker.hibernatableTimeout,
-    getTags: (ws: WebSocket) => tracker.tags.get(ws) ?? [],
-    abort: (reason?: string, options?: globalThis.DurableObjectAbortOptions) => {
-      tracker.aborts.push({ reason, options });
     },
   });
 

--- a/packages/effect-cf/tests/DurableObjectStorage.test.ts
+++ b/packages/effect-cf/tests/DurableObjectStorage.test.ts
@@ -1,5 +1,5 @@
 import { assert, it } from "@effect/vitest";
-import { Cause, Context, Duration, Effect } from "effect";
+import { Cause, Context, Deferred, Duration, Effect, Fiber } from "effect";
 import { TestClock } from "effect/testing";
 
 const TransactionMessage = Context.Service<{ readonly message: string }>(
@@ -7,26 +7,6 @@ const TransactionMessage = Context.Service<{ readonly message: string }>(
 );
 
 import { DurableObjectStorage } from "../src/index";
-
-it.effect("wraps deleteAll, sync, and bookmark APIs", () =>
-  Effect.gen(function* () {
-    const { raw, tracker } = makeRawDurableObjectStorage();
-    const storage = DurableObjectStorage.fromDurableObjectStorage(raw);
-
-    yield* storage.put("key", "value");
-    yield* storage.deleteAll({ allowUnconfirmed: true });
-    yield* storage.sync();
-
-    assert.deepStrictEqual(tracker.deleteAllOptions, [{ allowUnconfirmed: true }]);
-    assert.strictEqual(tracker.syncCalls, 1);
-    assert.strictEqual(yield* storage.get("key"), undefined);
-    assert.strictEqual(yield* storage.getCurrentBookmark(), "bookmark:current");
-    assert.strictEqual(
-      yield* storage.onNextSessionRestoreBookmark("bookmark:restore"),
-      "bookmark:undo:bookmark:restore",
-    );
-  }),
-);
 
 it.effect("wraps transaction with Effect-native callbacks", () =>
   Effect.gen(function* () {
@@ -84,6 +64,28 @@ it.effect("preserves Effect context inside transaction callbacks", () =>
   }),
 );
 
+it.effect("preserves the caller Scope inside transaction callbacks", () =>
+  Effect.gen(function* () {
+    const { raw } = makeRawDurableObjectStorage();
+    const storage = DurableObjectStorage.fromDurableObjectStorage(raw);
+    let releases = 0;
+
+    yield* Effect.scoped(
+      storage
+        .transaction(() =>
+          Effect.acquireRelease(Effect.void, () =>
+            Effect.sync(() => {
+              releases += 1;
+            }),
+          ),
+        )
+        .pipe(Effect.tap(() => Effect.sync(() => assert.strictEqual(releases, 0)))),
+    );
+
+    assert.strictEqual(releases, 1);
+  }),
+);
+
 it.effect("rolls back transaction on typed Effect failure", () =>
   Effect.gen(function* () {
     const { raw, tracker } = makeRawDurableObjectStorage();
@@ -130,6 +132,56 @@ it.effect("wraps transactionSync and preserves typed failures", () =>
     assert.strictEqual(exit._tag, "Failure");
     if (exit._tag === "Failure") {
       assert.strictEqual(Cause.squash(exit.cause), "sync rollback");
+    }
+  }),
+);
+
+it.effect("transactionSync interrupts and joins accidentally asynchronous callbacks", () =>
+  Effect.gen(function* () {
+    const { raw, tracker } = makeRawDurableObjectStorage();
+    const storage = DurableObjectStorage.fromDurableObjectStorage(raw);
+    const started = yield* Deferred.make<void>();
+    const continueCallback = yield* Deferred.make<void>();
+    const releaseFinalizer = yield* Deferred.make<void>();
+    const finalized = yield* Deferred.make<void>();
+    let resumed = false;
+
+    const fiber = yield* Effect.forkChild(
+      storage.transactionSync(() =>
+        Deferred.succeed(started, undefined).pipe(
+          Effect.andThen(Deferred.await(continueCallback)),
+          Effect.tap(() =>
+            Effect.sync(() => {
+              resumed = true;
+            }),
+          ),
+          Effect.ensuring(
+            Deferred.await(releaseFinalizer).pipe(
+              Effect.andThen(Deferred.succeed(finalized, undefined)),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    yield* Deferred.await(started);
+    yield* Effect.yieldNow;
+
+    yield* Effect.sync(() => assert.isUndefined(fiber.pollUnsafe())).pipe(
+      Effect.ensuring(
+        Deferred.succeed(continueCallback, undefined).pipe(
+          Effect.andThen(Deferred.succeed(releaseFinalizer, undefined)),
+        ),
+      ),
+    );
+    yield* Deferred.await(finalized);
+    const [exit] = yield* Fiber.awaitAll([fiber]);
+
+    assert.isFalse(resumed);
+    assert.strictEqual(tracker.transactionSyncRollbacks, 1);
+    assert.strictEqual(exit?._tag, "Failure");
+    if (exit?._tag === "Failure") {
+      assert.isTrue(Cause.isAsyncFiberError(Cause.squash(exit.cause)));
     }
   }),
 );
@@ -199,8 +251,6 @@ interface StorageTracker {
     readonly options: globalThis.DurableObjectSetAlarmOptions | undefined;
     readonly scheduledTime: number | Date;
   }>;
-  readonly deleteAllOptions: Array<globalThis.DurableObjectPutOptions | undefined>;
-  syncCalls: number;
   readonly transactionAlarms: Array<{
     readonly options: globalThis.DurableObjectSetAlarmOptions | undefined;
     readonly scheduledTime: number | Date;
@@ -227,8 +277,6 @@ function makeRawDurableObjectStorage(options: StorageOptions = {}): RawStorageFi
   const values = new Map<string, StorageFixtureValue>();
   const tracker: StorageTracker = {
     alarms: [],
-    deleteAllOptions: [],
-    syncCalls: 0,
     transactionAlarms: [],
     transactionCalls: 0,
     transactionRollbacks: 0,
@@ -242,10 +290,6 @@ function makeRawDurableObjectStorage(options: StorageOptions = {}): RawStorageFi
       values.set(key, value);
     },
     delete: async (key: string) => values.delete(key),
-    deleteAll: async (putOptions?: globalThis.DurableObjectPutOptions) => {
-      tracker.deleteAllOptions.push(putOptions);
-      values.clear();
-    },
     transaction: async <T>(closure: (txn: globalThis.DurableObjectTransaction) => Promise<T>) => {
       tracker.transactionCalls += 1;
       const snapshot = new Map(values);
@@ -271,7 +315,6 @@ function makeRawDurableObjectStorage(options: StorageOptions = {}): RawStorageFi
     },
     deleteAlarm: async () => undefined,
     sync: async () => {
-      tracker.syncCalls += 1;
       if (options.syncError !== undefined) {
         throw options.syncError;
       }
@@ -292,8 +335,6 @@ function makeRawDurableObjectStorage(options: StorageOptions = {}): RawStorageFi
         throw error;
       }
     },
-    getCurrentBookmark: async () => "bookmark:current",
-    onNextSessionRestoreBookmark: async (bookmark: string) => `bookmark:undo:${bookmark}`,
     sql: {
       exec: () => {
         throw new Error("not used");

--- a/packages/effect-cf/tests/DurableObjectStorage.worker.test.ts
+++ b/packages/effect-cf/tests/DurableObjectStorage.worker.test.ts
@@ -1,0 +1,52 @@
+import { env } from "cloudflare:workers";
+import { assert, it } from "@effect/vitest";
+import { Deferred, Effect, Fiber } from "effect";
+
+import * as PoolWorkers from "../src/Vitest";
+
+it.effect("interrupts native transactions and awaits workerd rollback", () => {
+  const namespace = env.TEST_COUNTER_DO!;
+  const stub = namespace.getByName(`storage-rollback-${crypto.randomUUID()}`);
+
+  return PoolWorkers.runInDurableObject(stub, (_instance, state) =>
+    Effect.gen(function* () {
+      const key = "interrupted-transaction";
+      const started = yield* Deferred.make<void>();
+      const continueCallback = yield* Deferred.make<void>();
+      const releaseFinalizer = yield* Deferred.make<void>();
+      const finalized = yield* Deferred.make<void>();
+
+      yield* state.storage.put(key, "before");
+
+      const fiber = yield* Effect.forkChild(
+        state.storage.transaction((txn) =>
+          txn.put(key, "during").pipe(
+            Effect.andThen(Deferred.succeed(started, undefined)),
+            Effect.andThen(Deferred.await(continueCallback)),
+            Effect.onInterrupt(() =>
+              Deferred.await(releaseFinalizer).pipe(
+                Effect.andThen(Deferred.succeed(finalized, undefined)),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      yield* Deferred.await(started);
+      fiber.interruptUnsafe();
+      yield* Effect.yieldNow;
+
+      yield* Effect.sync(() => assert.isUndefined(fiber.pollUnsafe())).pipe(
+        Effect.ensuring(
+          Deferred.succeed(continueCallback, undefined).pipe(
+            Effect.andThen(Deferred.succeed(releaseFinalizer, undefined)),
+          ),
+        ),
+      );
+      yield* Fiber.awaitAll([fiber]);
+
+      assert.isTrue(yield* Deferred.isDone(finalized));
+      assert.strictEqual(yield* state.storage.get(key), "before");
+    }),
+  );
+});

--- a/packages/effect-cf/tests/ServiceBinding.test.ts
+++ b/packages/effect-cf/tests/ServiceBinding.test.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "vite-plus/test";
+import { Effect, Fiber } from "effect";
+
+import { ServiceBinding } from "../src/index";
+
+const makeClient = (fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) =>
+  ServiceBinding.makeClient<{}>({ binding: "SERVICE" })({ fetch });
+
+test("ServiceBinding scopedCall maps resolved RPC rejections to ServiceBindingRpcError", async () => {
+  const cause = new Error("remote unavailable");
+  const service = {
+    fetch: async () => new Response("ok"),
+    fail: () => Promise.reject(cause),
+  };
+  // SAFETY: this boundary fixture has the only two service-binding methods exercised by this test.
+  const client = ServiceBinding.makeClient<{ readonly fail: () => Promise<string> }>({
+    binding: "SERVICE",
+  })(service as ServiceBinding.ServiceBindingClient<{ readonly fail: () => Promise<string> }>);
+
+  await expect(Effect.runPromise(Effect.scoped(client.scopedCall("fail")))).rejects.toMatchObject({
+    _tag: "ServiceBindingRpcError",
+    binding: "SERVICE",
+    method: "fail",
+    cause,
+  });
+});
+
+test("ServiceBinding fetch preserves a Request input signal when init does not select one", async () => {
+  let capturedSignal: AbortSignal | null | undefined;
+  let started = () => {};
+  const requestStarted = new Promise<void>((resolve) => {
+    started = resolve;
+  });
+  const client = makeClient((_input, init) => {
+    capturedSignal = init?.signal;
+    started();
+
+    return new Promise<Response>((_resolve, reject) => {
+      capturedSignal?.addEventListener("abort", () => reject(capturedSignal?.reason), {
+        once: true,
+      });
+    });
+  });
+  const inputController = new AbortController();
+  const request = new Request("https://example.test", { signal: inputController.signal });
+
+  const program = client.fetch(request);
+  const fiber = Effect.runFork(program);
+
+  let aborted = false;
+
+  try {
+    await requestStarted;
+    inputController.abort(new Error("input cancelled"));
+    await Promise.resolve();
+    aborted = capturedSignal?.aborted === true;
+  } finally {
+    await Effect.runPromise(Fiber.interrupt(fiber));
+  }
+
+  expect(capturedSignal).toBeDefined();
+  expect(aborted).toBe(true);
+});
+
+test("ServiceBinding fetch follows Request signal override semantics", async () => {
+  const capturedSignals: Array<AbortSignal | null | undefined> = [];
+  const client = makeClient(async (_input, init) => {
+    capturedSignals.push(init?.signal);
+
+    return new Response("ok");
+  });
+  const inputController = new AbortController();
+  const initController = new AbortController();
+  const request = new Request("https://example.test", { signal: inputController.signal });
+
+  await Effect.runPromise(client.fetch(request, { signal: initController.signal }));
+  inputController.abort();
+  const overrideSignal = capturedSignals[0];
+
+  expect(overrideSignal?.aborted).toBe(false);
+  initController.abort();
+  expect(overrideSignal?.aborted).toBe(true);
+
+  const nullInputController = new AbortController();
+  const nullRequest = new Request("https://example.test", { signal: nullInputController.signal });
+
+  await Effect.runPromise(client.fetch(nullRequest, { signal: null }));
+  const nullSignal = capturedSignals[1];
+
+  nullInputController.abort();
+
+  expect(nullSignal?.aborted).toBe(false);
+});
+
+test("ServiceBinding fetch aborts in-flight requests on interruption", async () => {
+  let capturedSignal: AbortSignal | null | undefined;
+  let started = () => {};
+  const requestStarted = new Promise<void>((resolve) => {
+    started = resolve;
+  });
+  const client = makeClient((_input, init) => {
+    capturedSignal = init?.signal;
+    started();
+
+    return new Promise<Response>((_resolve, reject) => {
+      capturedSignal?.addEventListener("abort", () => reject(capturedSignal?.reason), {
+        once: true,
+      });
+    });
+  });
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fiber = yield* Effect.forkChild(client.fetch("https://example.test"));
+
+      yield* Effect.promise(() => requestStarted);
+      yield* Fiber.interrupt(fiber);
+    }),
+  );
+
+  expect(capturedSignal).toBeDefined();
+  expect(capturedSignal?.aborted).toBe(true);
+});

--- a/packages/effect-cf/tests/Vitest.worker.test.ts
+++ b/packages/effect-cf/tests/Vitest.worker.test.ts
@@ -1,6 +1,6 @@
 import { env } from "cloudflare:workers";
 import { assert, it } from "@effect/vitest";
-import { Config, Context, Effect, Layer, Schema as S } from "effect";
+import { Config, Context, Deferred, Effect, Fiber, Layer, Schema as S } from "effect";
 
 import { DurableObjectState, QueueDefinition, Worker, WorkerEnvironment } from "../src/index";
 import * as PoolWorkers from "../src/Vitest";
@@ -215,6 +215,69 @@ it.effect("runs Effects inside Durable Objects with caller services and state", 
     assert.notStrictEqual(globallyEvictedInstanceId, evictedInstanceId);
   }).pipe(Effect.provideService(TestValue, "from-test-context"));
 });
+
+it.effect("interrupting a Durable Object callback waits for its cleanup", () => {
+  const stub = env.TEST_COUNTER_DO!.getByName(`callback-interruption-${crypto.randomUUID()}`);
+
+  return Effect.gen(function* () {
+    const started = yield* Deferred.make<void>();
+    const continueCallback = yield* Deferred.make<void>();
+    const finalized = yield* Deferred.make<void>();
+    const fiber = yield* Effect.forkChild(
+      PoolWorkers.runInDurableObject(stub, () =>
+        Deferred.succeed(started, undefined).pipe(
+          Effect.andThen(Deferred.await(continueCallback)),
+          Effect.ensuring(
+            Effect.yieldNow.pipe(Effect.andThen(Deferred.succeed(finalized, undefined))),
+          ),
+        ),
+      ),
+    );
+
+    yield* Deferred.await(started);
+    yield* Fiber.interrupt(fiber);
+
+    const joinedCleanup = yield* Deferred.isDone(finalized);
+
+    // Release the callback even if the wrapper regresses to a detached fiber.
+    yield* Deferred.succeed(continueCallback, undefined);
+    yield* Deferred.await(finalized);
+    assert.isTrue(joinedCleanup);
+  });
+});
+
+it.effect("interrupting a Workflow modifier waits for its cleanup", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const introspector = yield* PoolWorkers.introspectWorkflowInstance(
+        env.TEST_WORKFLOW!,
+        crypto.randomUUID(),
+      );
+      const started = yield* Deferred.make<void>();
+      const continueCallback = yield* Deferred.make<void>();
+      const finalized = yield* Deferred.make<void>();
+      const fiber = yield* Effect.forkChild(
+        introspector.modify(() =>
+          Deferred.succeed(started, undefined).pipe(
+            Effect.andThen(Deferred.await(continueCallback)),
+            Effect.ensuring(
+              Effect.yieldNow.pipe(Effect.andThen(Deferred.succeed(finalized, undefined))),
+            ),
+          ),
+        ),
+      );
+
+      yield* Deferred.await(started);
+      yield* Fiber.interrupt(fiber);
+
+      const joinedCleanup = yield* Deferred.isDone(finalized);
+
+      yield* Deferred.succeed(continueCallback, undefined);
+      yield* Deferred.await(finalized);
+      assert.isTrue(joinedCleanup);
+    }),
+  ),
+);
 
 it.effect("introspects one Workflow instance with Effect-native modifiers", () => {
   const workflow = env.TEST_WORKFLOW!;

--- a/packages/effect-cf/tests/WorkerBoundary.test.ts
+++ b/packages/effect-cf/tests/WorkerBoundary.test.ts
@@ -32,6 +32,11 @@ class EventValue extends Context.Service<EventValue, string>()(
   "effect-cf/test/WorkerBoundary/EventValue",
 ) {}
 
+class StreamResource extends Context.Service<
+  StreamResource,
+  { readonly read: Effect.Effect<string>; readonly release: () => void }
+>()("effect-cf/test/WorkerBoundary/StreamResource") {}
+
 class BoomError extends Data.TaggedError("BoomError") {}
 
 interface HeadersWithSetCookie extends Headers {
@@ -155,6 +160,29 @@ test("Worker.makeFetchHandler builds the runtime once per env and rebinds reques
   expect(second.waitUntilPromises).toHaveLength(1);
 });
 
+test("Worker.makeFetchHandler builds eventLayer with the current request context", async () => {
+  const eventLayer = Layer.effectDiscard(
+    Effect.gen(function* () {
+      const ctx = yield* Worker.WorkerContext;
+
+      yield* ctx.waitUntil(Effect.void);
+    }),
+  );
+  const handler = Worker.makeFetchHandler(Layer.empty, {
+    eventLayer,
+    fetch: Effect.succeed(new Response("ok")),
+  });
+  const env = makePartialTestDouble<Cloudflare.Env>({});
+  const first = makeWaitUntilContext();
+  const second = makeWaitUntilContext();
+
+  await handler.fetch(new Request("https://worker.test/one"), env, first.executionContext);
+  await handler.fetch(new Request("https://worker.test/two"), env, second.executionContext);
+
+  expect(first.waitUntilPromises).toHaveLength(1);
+  expect(second.waitUntilPromises).toHaveLength(1);
+});
+
 test("Worker.fetch flushes runtime OTLP telemetry through waitUntil", async () => {
   const flushes: Array<string> = [];
   const flusherProbe = Layer.effectDiscard(
@@ -183,6 +211,31 @@ test("Worker.fetch flushes runtime OTLP telemetry through waitUntil", async () =
   await Promise.all(waitUntilPromises);
 
   expect(flushes).toEqual(["flush"]);
+});
+
+test("Worker.queue flushes event telemetry after success and failure", async () => {
+  const outcomes: Array<"fulfilled" | "rejected"> = [];
+
+  for (const handler of [Effect.void, Effect.fail(new BoomError())]) {
+    const flushes: Array<string> = [];
+    const Live = Worker.make(Layer.empty, {
+      eventLayer: makeFlusherProbeLayer(flushes),
+      queue: () => handler,
+    });
+    const { executionContext, waitUntilPromises } = makeWaitUntilContext();
+    const worker = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+    const outcome = await Promise.resolve(worker.queue(makeMessageBatch("telemetry"))).then(
+      () => "fulfilled" as const,
+      () => "rejected" as const,
+    );
+
+    outcomes.push(outcome);
+    expect(waitUntilPromises).toHaveLength(1);
+    await expect(Promise.all(waitUntilPromises)).resolves.toEqual([undefined]);
+    expect(flushes).toEqual(["flush"]);
+  }
+
+  expect(outcomes).toEqual(["fulfilled", "rejected"]);
 });
 
 test("WorkerDefinition RPC schedules event-scoped OTLP telemetry after success", async () => {
@@ -340,6 +393,16 @@ test("Worker.make accepts a fetch Effect shorthand", async () => {
   const response = await worker.fetch(new Request("https://worker.test/"));
 
   await expect(response.text()).resolves.toBe("from-shorthand");
+});
+
+test("Worker.make rejects reserved RPC protocol methods at runtime", () => {
+  expect(() =>
+    Worker.make(Layer.empty, {
+      rpc: {
+        then: () => Effect.void,
+      },
+    }),
+  ).toThrow(/reserved/i);
 });
 
 test("Worker.fetch renders Effect HttpServerResponse values", async () => {
@@ -502,6 +565,87 @@ test("Worker.fetch keeps request-scoped resources alive while streaming bodies",
   await expect(response.text()).resolves.toBe("chunk-1chunk-2");
   await expect.poll(() => events).toEqual(["acquire", "chunk-1", "chunk-2", "release"]);
 });
+
+test.each(["finish", "cancel"] as const)(
+  "Worker.fetch keeps eventLayer resources alive until streaming bodies %s",
+  async (outcome) => {
+    const events: Array<string> = [];
+    const flushes: Array<string> = [];
+    const continueBody = Promise.withResolvers<void>();
+    const resourceReleased = Promise.withResolvers<void>();
+    const streamResourceLayer = Layer.effect(
+      StreamResource,
+      Effect.acquireRelease(
+        Effect.sync(() => {
+          let released = false;
+
+          events.push("acquire");
+
+          return StreamResource.of({
+            read: Effect.sync(() => (released ? "closed" : "open")),
+            release: () => {
+              released = true;
+            },
+          });
+        }),
+        (resource) =>
+          Effect.sync(() => {
+            resource.release();
+            events.push("release");
+            resourceReleased.resolve();
+          }),
+      ),
+    );
+    const eventLayer = Layer.merge(streamResourceLayer, makeFlusherProbeLayer(flushes));
+    const Live = Worker.make(Layer.empty, {
+      eventLayer,
+      fetch: Effect.gen(function* () {
+        const resource = yield* StreamResource;
+
+        return HttpServerResponse.stream(
+          Stream.fromEffect(
+            Effect.promise(() => continueBody.promise).pipe(Effect.andThen(resource.read)),
+          ).pipe(Stream.encodeText),
+        );
+      }),
+    });
+    const { executionContext, waitUntilPromises } = makeWaitUntilContext();
+    const worker = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+
+    const response = await worker.fetch(new Request("https://worker.test/stream"));
+
+    if (response.body === null) {
+      throw new Error("Expected a streaming response body");
+    }
+
+    let body: string | undefined;
+
+    try {
+      expect(events).toEqual(["acquire"]);
+      expect(waitUntilPromises).toHaveLength(0);
+
+      if (outcome === "finish") {
+        continueBody.resolve();
+        body = await response.text();
+      } else {
+        await response.body.cancel();
+      }
+
+      expect(body).toBe(outcome === "finish" ? "open" : undefined);
+      await resourceReleased.promise;
+      expect(events).toEqual(["acquire", "release"]);
+      expect(waitUntilPromises).toHaveLength(1);
+      await expect(Promise.all(waitUntilPromises)).resolves.toEqual([undefined]);
+      expect(flushes).toEqual(["flush"]);
+    } finally {
+      continueBody.resolve();
+      if (!response.body.locked) {
+        await response.body.cancel();
+      }
+      await Promise.all(waitUntilPromises);
+    }
+  },
+);
 
 test("Worker.fetch renders handler failures as HTTP error responses", async () => {
   const Live = Worker.make(Layer.empty, {

--- a/packages/effect-cf/tests/WorkerContext.test.ts
+++ b/packages/effect-cf/tests/WorkerContext.test.ts
@@ -14,31 +14,17 @@ class TestService extends Context.Service<
 
 const makeExecutionContext = () => {
   const waitUntilPromises: Array<Promise<unknown>> = [];
-  let passThroughCalls = 0;
-  const abortReasons: Array<unknown> = [];
-
   const executionContext = makePartialTestDouble<globalThis.ExecutionContext>({
     props: undefined,
     waitUntil: (promise: Promise<unknown>) => {
       waitUntilPromises.push(promise);
     },
-    passThroughOnException: () => {
-      passThroughCalls++;
-    },
-    abort: (reason?: string) => {
-      abortReasons.push(reason);
-    },
+    passThroughOnException: () => {},
   });
 
   return {
     executionContext,
     waitUntilPromises,
-    get passThroughCalls() {
-      return passThroughCalls;
-    },
-    get abortReasons() {
-      return abortReasons;
-    },
   };
 };
 
@@ -74,6 +60,47 @@ test("WorkerContext.waitUntil preserves Effect context through the worker runtim
   expect(state.completed).toEqual(["done"]);
 });
 
+test("WorkerContext.waitUntil owns resources acquired by background work", async () => {
+  const events: Array<string> = [];
+  const started = Promise.withResolvers<void>();
+  const complete = Promise.withResolvers<void>();
+  const { executionContext, waitUntilPromises } = makeExecutionContext();
+  const Live = Worker.make(Layer.empty, {
+    fetch: Effect.gen(function* () {
+      const ctx = yield* Worker.WorkerContext;
+
+      yield* ctx.waitUntil(
+        Effect.acquireRelease(
+          Effect.sync(() => events.push("acquire")),
+          () => Effect.sync(() => events.push("release")),
+        ).pipe(
+          Effect.andThen(
+            Effect.promise(() => {
+              started.resolve();
+
+              return complete.promise;
+            }),
+          ),
+        ),
+      );
+
+      return new Response("ok");
+    }),
+  });
+  const worker = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+
+  await worker.fetch(new Request("https://example.com/"));
+  await started.promise;
+
+  try {
+    expect(events).toEqual(["acquire"]);
+  } finally {
+    complete.resolve();
+    await expect(Promise.all(waitUntilPromises)).resolves.toEqual([undefined]);
+  }
+  expect(events).toEqual(["acquire", "release"]);
+});
+
 test("WorkerContext.waitUntil routes failures to onFailure with preserved context", async () => {
   const state: TestService["Service"] = { completed: [], failures: [] };
   const Live = Worker.make(Layer.succeed(TestService, state), {
@@ -101,6 +128,71 @@ test("WorkerContext.waitUntil routes failures to onFailure with preserved contex
   await expect(Promise.all(waitUntilPromises)).resolves.toEqual([undefined]);
   expect(state.failures).toHaveLength(1);
   expect(state.failures[0]).toContain("expected waitUntil failure");
+});
+
+test("WorkerContext.waitUntil owns resources acquired by onFailure", async () => {
+  const events: Array<string> = [];
+  const started = Promise.withResolvers<void>();
+  const complete = Promise.withResolvers<void>();
+  const { executionContext, waitUntilPromises } = makeExecutionContext();
+  const Live = Worker.make(Layer.empty, {
+    fetch: Effect.gen(function* () {
+      const ctx = yield* Worker.WorkerContext;
+
+      yield* ctx.waitUntil(Effect.fail("expected"), {
+        onFailure: () =>
+          Effect.acquireRelease(
+            Effect.sync(() => events.push("acquire")),
+            () => Effect.sync(() => events.push("release")),
+          ).pipe(
+            Effect.andThen(
+              Effect.promise(() => {
+                started.resolve();
+
+                return complete.promise;
+              }),
+            ),
+          ),
+      });
+
+      return new Response("ok");
+    }),
+  });
+  const worker = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+
+  await worker.fetch(new Request("https://example.com/"));
+  await started.promise;
+
+  try {
+    expect(events).toEqual(["acquire"]);
+  } finally {
+    complete.resolve();
+    await expect(Promise.all(waitUntilPromises)).resolves.toEqual([undefined]);
+  }
+  expect(events).toEqual(["acquire", "release"]);
+});
+
+test("WorkerContext.waitUntil observes synchronous onFailure throws", async () => {
+  const { executionContext, waitUntilPromises } = makeExecutionContext();
+  const Live = Worker.make(Layer.empty, {
+    fetch: Effect.gen(function* () {
+      const ctx = yield* Worker.WorkerContext;
+
+      yield* ctx.waitUntil(Effect.fail("expected"), {
+        onFailure: () => {
+          throw new Error("failure handler construction failed");
+        },
+      });
+
+      return new Response("ok");
+    }),
+  });
+  const worker = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+
+  await worker.fetch(new Request("https://example.com/"));
+
+  expect(waitUntilPromises).toHaveLength(1);
+  await expect(Promise.all(waitUntilPromises)).resolves.toEqual([undefined]);
 });
 
 test("WorkerContext.waitUntil can propagate failures to native waitUntil", async () => {
@@ -148,42 +240,6 @@ test("WorkerContext.waitUntilPropagating rejects native waitUntil promises", asy
 
   expect(waitUntilPromises).toHaveLength(1);
   await expect(Promise.all(waitUntilPromises)).rejects.toThrow("expected propagating failure");
-});
-
-test("WorkerContext.passThroughOnException delegates to the raw ExecutionContext", async () => {
-  const Live = Worker.make(Layer.empty, {
-    fetch: Effect.gen(function* () {
-      const ctx = yield* Worker.WorkerContext;
-
-      yield* ctx.passThroughOnException;
-
-      return new Response("ok");
-    }),
-  });
-  const context = makeExecutionContext();
-  const worker = new Live(context.executionContext, makePartialTestDouble<Cloudflare.Env>({}));
-
-  await worker.fetch!(new Request("https://example.com/"));
-
-  expect(context.passThroughCalls).toBe(1);
-});
-
-test("WorkerContext.abort delegates to the raw ExecutionContext", async () => {
-  const Live = Worker.make(Layer.empty, {
-    fetch: Effect.gen(function* () {
-      const ctx = yield* Worker.WorkerContext;
-
-      yield* ctx.abort("shutdown");
-
-      return new Response("ok");
-    }),
-  });
-  const context = makeExecutionContext();
-  const worker = new Live(context.executionContext, makePartialTestDouble<Cloudflare.Env>({}));
-
-  await worker.fetch!(new Request("https://example.com/"));
-
-  expect(context.abortReasons).toEqual(["shutdown"]);
 });
 
 const makeMessageBatch = (queue: string): globalThis.MessageBatch<unknown> =>

--- a/packages/effect-cf/tests/WorkersAi.test.ts
+++ b/packages/effect-cf/tests/WorkersAi.test.ts
@@ -113,3 +113,28 @@ test("Workers AI wraps operation failures", async () => {
     cause,
   });
 });
+
+test("Workers AI rejects malformed embedding responses", async () => {
+  await expect(
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const ai = yield* TestAi;
+
+        yield* ai.runEmbedding("@cf/qwen/qwen3-embedding-0.6b", { text: "tomato soup" });
+      }).pipe(
+        Effect.provide(
+          aiLayer(
+            makeFakeAi({
+              // SAFETY: this fixture deliberately crosses the foreign Workers AI output boundary.
+              run: async () => ({ data: "not an embedding" }) as UnknownModelOutput,
+            }),
+          ),
+        ),
+      ),
+    ),
+  ).rejects.toMatchObject({
+    _tag: "WorkersAiOperationError",
+    binding: "AI",
+    operation: "runEmbedding",
+  });
+});

--- a/packages/effect-cf/tests/Workflow.test.ts
+++ b/packages/effect-cf/tests/Workflow.test.ts
@@ -6,7 +6,7 @@ import type {
 } from "cloudflare:workers";
 import { NonRetryableError } from "cloudflare:workflows";
 import { assert, test } from "@effect/vitest";
-import { Effect, Layer, Predicate } from "effect";
+import { Deferred, Effect, Fiber, Layer, Predicate } from "effect";
 
 import { Workflow } from "../src/index";
 import { makePartialTestDouble } from "./TestDoubles";
@@ -23,7 +23,7 @@ const makeEvent = (): Readonly<CloudflareWorkflowEvent<undefined>> => ({
   workflowName: "TestWorkflow",
 });
 
-type FakeStepCallback = (context: CloudflareWorkflowStepContext) => Promise<never>;
+type FakeStepCallback = (context: CloudflareWorkflowStepContext) => Promise<number | void>;
 
 const makeExecutingStep = (onReject?: (cause: Error) => void): CloudflareWorkflowStep => {
   const implementation = {
@@ -107,6 +107,98 @@ test("non-retryable Effect failures reach Cloudflare as NonRetryableError", asyn
   assert.strictEqual(error.step, "validate source");
   assert.strictEqual(error.operation, "do");
   assert.strictEqual(error.cause, boundaryError);
+});
+
+test("Workflow.step releases its resources before the workflow continues", async () => {
+  const events: Array<string> = [];
+  const stepCompleted = Promise.withResolvers<void>();
+  const workflowCompleted = Promise.withResolvers<void>();
+  const Live = Workflow.make(Layer.empty, {
+    run: () =>
+      Effect.gen(function* () {
+        yield* Workflow.step(
+          "scoped resource",
+          Effect.acquireRelease(
+            Effect.sync(() => events.push("acquire")),
+            () => Effect.sync(() => events.push("release")),
+          ),
+        );
+
+        stepCompleted.resolve();
+        yield* Effect.promise(() => workflowCompleted.promise);
+      }),
+  });
+  const workflow = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+  const running = workflow.run(makeEvent(), makeExecutingStep());
+
+  await stepCompleted.promise;
+
+  try {
+    assert.deepStrictEqual(events, ["acquire", "release"]);
+  } finally {
+    workflowCompleted.resolve();
+    await running;
+  }
+});
+
+test("Workflow.step uses the current native step context", async () => {
+  const Live = Workflow.make(Layer.empty, {
+    run: () =>
+      Workflow.step(
+        "current step",
+        Effect.gen(function* () {
+          const context = yield* Workflow.WorkflowStepContext;
+
+          assert.strictEqual(context.step.name, "current step");
+
+          return context.attempt;
+        }),
+      ).pipe(
+        Effect.provideService(Workflow.WorkflowStepContext, {
+          step: { name: "previous step", count: 99 },
+          attempt: 99,
+          config: {},
+        }),
+      ),
+  });
+  const workflow = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+
+  assert.strictEqual(await workflow.run(makeEvent(), makeExecutingStep()), 1);
+});
+
+test("interrupting Workflow.step waits for the current callback's cleanup", async () => {
+  const Live = Workflow.make(Layer.empty, {
+    run: () =>
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>();
+        const continueCallback = yield* Deferred.make<void>();
+        const finalized = yield* Deferred.make<void>();
+        const fiber = yield* Effect.forkChild(
+          Workflow.step(
+            "interrupted step",
+            Deferred.succeed(started, undefined).pipe(
+              Effect.andThen(Deferred.await(continueCallback)),
+              Effect.ensuring(
+                Effect.yieldNow.pipe(Effect.andThen(Deferred.succeed(finalized, undefined))),
+              ),
+            ),
+          ),
+        );
+
+        yield* Deferred.await(started);
+        yield* Fiber.interrupt(fiber);
+
+        const joinedCleanup = yield* Deferred.isDone(finalized);
+
+        yield* Deferred.succeed(continueCallback, undefined);
+        yield* Deferred.await(finalized);
+
+        return joinedCleanup;
+      }),
+  });
+  const workflow = new Live(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+
+  assert.isTrue(await workflow.run(makeEvent(), makeExecutingStep()));
 });
 
 test("failing sleeps surface WorkflowStepError with the sleep operation", async () => {

--- a/packages/effect-cf/tests/computer-workspace.test-d.ts
+++ b/packages/effect-cf/tests/computer-workspace.test-d.ts
@@ -5,7 +5,7 @@ import type {
 } from "@cloudflare/computer";
 import type { GitClient } from "@cloudflare/computer/git";
 import { expectTypeOf } from "vitest";
-import { Effect, type Scope } from "effect";
+import { Effect, type Layer, type Scope } from "effect";
 
 import * as ComputerArtifacts from "effect-cf/computer-artifacts";
 import * as ComputerWorkspace from "effect-cf/computer-workspace";
@@ -32,6 +32,13 @@ expectTypeOf<MissingFilesystemMethods>().toEqualTypeOf<never>();
 expectTypeOf<MissingGitMethods>().toEqualTypeOf<never>();
 expectTypeOf<MissingRuntimeMethods>().toEqualTypeOf<never>();
 expectTypeOf<MissingThinkMethods>().toEqualTypeOf<never>();
+expectTypeOf(ComputerWorkspace.ComputerWorkspace.layer).toEqualTypeOf<
+  Layer.Layer<
+    ComputerWorkspace.ComputerWorkspace,
+    ComputerWorkspace.WorkspaceAcquireError,
+    import("../src/DurableObjectState").DurableObjectState
+  >
+>();
 
 const program = Effect.gen(function* () {
   const workspace = yield* ComputerWorkspace.ComputerWorkspace;

--- a/packages/effect-cf/tests/definitions.test.ts
+++ b/packages/effect-cf/tests/definitions.test.ts
@@ -14,12 +14,13 @@ import {
 } from "effect";
 
 import {
-  type DurableObjectNamespace,
   type QueueBinding,
   type Rpc,
   type ServiceBinding,
   ContainerNamespace,
+  DurableObject,
   DurableObjectDefinition,
+  DurableObjectNamespace,
   DurableObjectStorage,
   Queue,
   RpcDefinition,
@@ -525,7 +526,9 @@ test("definition-backed Worker RPC validates encoded success values", async () =
       expectType<Effect.Effect<number, ServiceBinding.ServiceBindingRpcError>>(
         service.call("increment", 41),
       );
-      expectType<Effect.Effect<number, unknown, Scope.Scope>>(service.scopedCall("increment", 41));
+      expectType<Effect.Effect<number, ServiceBinding.ServiceBindingRpcError, Scope.Scope>>(
+        service.scopedCall("increment", 41),
+      );
     });
 
     void program;
@@ -647,10 +650,14 @@ test("definition-backed Worker RPC validates encoded success values", async () =
   });
   const NumberRooms = NumberRoom;
   let received: unknown;
+  const remoteError = new Error("room unavailable");
   const stub = {
     id: makeDurableObjectId(),
     fetch: async () => new Response("ok"),
     increment: async (value: string) => {
+      if (value === "0") {
+        throw remoteError;
+      }
       received = value;
 
       return String(Number(value) + 1);
@@ -679,7 +686,7 @@ test("definition-backed Worker RPC validates encoded success values", async () =
       expectType<Effect.Effect<number, DurableObjectNamespace.DurableObjectRpcError>>(
         rooms.call(room, "increment", 41),
       );
-      expectType<Effect.Effect<number, unknown, Scope.Scope>>(
+      expectType<Effect.Effect<number, DurableObjectNamespace.DurableObjectRpcError, Scope.Scope>>(
         rooms.scopedCall(room, "increment", 41),
       );
     });
@@ -714,6 +721,25 @@ test("definition-backed Worker RPC validates encoded success values", async () =
 
         assert.strictEqual(received, "41");
         assert.strictEqual(value, 42);
+      }),
+    );
+
+    it.effect("maps scoped RPC resolution failures to DurableObjectRpcError", () =>
+      Effect.gen(function* () {
+        const room = yield* NumberRooms.getByName("room");
+        const exit = yield* Effect.exit(
+          Effect.scoped(NumberRooms.scopedCall(room, "increment", 0)),
+        );
+
+        assert.strictEqual(exit._tag, "Failure");
+        if (exit._tag === "Failure") {
+          const error = Cause.squash(exit.cause);
+
+          assert.instanceOf(error, DurableObjectNamespace.DurableObjectRpcError);
+          assert.strictEqual(error.binding, "NUMBER_ROOMS");
+          assert.strictEqual(error.method, "increment");
+          assert.strictEqual(error.cause, remoteError);
+        }
       }),
     );
   });
@@ -1007,6 +1033,16 @@ test("reserved RPC method names are rejected", () => {
     // @ts-expect-error This runtime test deliberately supplies a statically reserved method.
     WorkerDefinition.make("BadWorker", {
       fetch: WorkerDefinition.method({ success: S.String }),
+    }),
+  ).toThrow(/reserved/i);
+});
+
+test("raw Durable Object RPC methods use the shared Cloudflare reserved-name set", () => {
+  expect(() =>
+    DurableObject.make(Layer.empty, {
+      rpc: {
+        connect: () => Effect.void,
+      },
     }),
   ).toThrow(/reserved/i);
 });

--- a/packages/effect-cf/tests/durable-websocket.test-d.ts
+++ b/packages/effect-cf/tests/durable-websocket.test-d.ts
@@ -4,14 +4,14 @@ declare const raw: WebSocket;
 
 const typed = DurableObjectWebSocket.fromWebSocket<{ readonly id: string }>(raw);
 
-typed.serializeAttachment({ id: "socket-1" });
-typed.serializeAttachment<{ readonly id: string }>({ id: "socket-1" });
+void typed.serializeAttachment({ id: "socket-1" });
+void typed.serializeAttachment<{ readonly id: string }>({ id: "socket-1" });
 
 // @ts-expect-error typed sockets reject attachments outside their declared shape.
-typed.serializeAttachment({ clientId: 1 });
+void typed.serializeAttachment({ clientId: 1 });
 // @ts-expect-error explicit serializer type arguments must also satisfy the attachment shape.
-typed.serializeAttachment<string>("socket-1");
+void typed.serializeAttachment<string>("socket-1");
 
 const unknown = DurableObjectWebSocket.fromWebSocket(raw);
 
-unknown.serializeAttachment<{ readonly id: string }>({ id: "socket-1" });
+void unknown.serializeAttachment<{ readonly id: string }>({ id: "socket-1" });

--- a/packages/effect-cf/tests/durable-websocket.test-d.ts
+++ b/packages/effect-cf/tests/durable-websocket.test-d.ts
@@ -1,0 +1,17 @@
+import { DurableObjectWebSocket } from "../src/index";
+
+declare const raw: WebSocket;
+
+const typed = DurableObjectWebSocket.fromWebSocket<{ readonly id: string }>(raw);
+
+typed.serializeAttachment({ id: "socket-1" });
+typed.serializeAttachment<{ readonly id: string }>({ id: "socket-1" });
+
+// @ts-expect-error typed sockets reject attachments outside their declared shape.
+typed.serializeAttachment({ clientId: 1 });
+// @ts-expect-error explicit serializer type arguments must also satisfy the attachment shape.
+typed.serializeAttachment<string>("socket-1");
+
+const unknown = DurableObjectWebSocket.fromWebSocket(raw);
+
+unknown.serializeAttachment<{ readonly id: string }>({ id: "socket-1" });

--- a/packages/effect-webtransport/src/Fallback.ts
+++ b/packages/effect-webtransport/src/Fallback.ts
@@ -126,6 +126,9 @@ export const select = <const Candidates extends Arr.NonEmptyReadonlyArray<Candid
       const selected = yield* candidate.socket.pipe(
         Scope.provide(candidateScope),
         Effect.map((socket): SelectedTransport => ({ name: candidate.name, socket })),
+        Effect.onExit((exit) =>
+          Exit.isSuccess(exit) ? Effect.void : Scope.close(candidateScope, exit),
+        ),
         Effect.catch((error) => {
           failures.push({ name: candidate.name, cause: error });
 
@@ -136,7 +139,6 @@ export const select = <const Candidates extends Arr.NonEmptyReadonlyArray<Candid
       if (selected !== undefined) {
         return selected;
       }
-      yield* Scope.close(candidateScope, Exit.void);
     }
 
     return yield* new TransportSelectionError({ failures });

--- a/packages/effect-webtransport/src/WebTransport.ts
+++ b/packages/effect-webtransport/src/WebTransport.ts
@@ -42,9 +42,15 @@ export interface NativeBidirectionalStream {
 
 export interface NativeDatagramDuplexStream {
   readonly readable: ReadableStream<Uint8Array>;
-  readonly writable: WritableStream<Uint8Array>;
+  readonly createWritable?: (() => WritableStream<Uint8Array>) | undefined;
+  /** @deprecated Use `createWritable()` where the platform provides it. */
+  readonly writable?: WritableStream<Uint8Array> | undefined;
   readonly maxDatagramSize: number;
+  incomingMaxBufferedDatagrams?: number;
+  outgoingMaxBufferedDatagrams?: number;
+  /** @deprecated Use `incomingMaxBufferedDatagrams`. */
   incomingHighWaterMark?: number;
+  /** @deprecated Use `outgoingMaxBufferedDatagrams`. */
   outgoingHighWaterMark?: number;
   incomingMaxAge?: number | null;
   outgoingMaxAge?: number | null;
@@ -281,14 +287,17 @@ export interface WebTransport {
   readonly native: NativeWebTransport;
   /**
    * Opens an outgoing reliable bidirectional stream. Releasing the scope
-   * closes the writable half (FIN) and cancels the readable half.
+   * closes the writable half (FIN) and cancels the readable half when they
+   * are unlocked. A caller that acquires either raw stream lock owns its
+   * release and termination.
    */
   readonly openBidirectionalStream: (
     options?: NativeSendStreamOptions,
   ) => Effect.Effect<NativeBidirectionalStream, WebTransportError, Scope.Scope>;
   /**
    * Opens an outgoing reliable unidirectional (send) stream where the
-   * platform supports it. Releasing the scope closes the stream.
+   * platform supports it. Releasing the scope closes an unlocked stream; a
+   * caller that acquires its raw writer lock owns release and termination.
    */
   readonly openUnidirectionalStream: (
     options?: NativeSendStreamOptions,
@@ -337,8 +346,26 @@ const streamFromReadable = <A>(options: {
         yield* Scope.addFinalizer(
           scope,
           options.releaseLockOnEnd
-            ? Effect.sync(() => reader.releaseLock())
-            : Effect.promise(() => reader.cancel().then(constVoid, constVoid)),
+            ? Effect.sync(() => {
+                try {
+                  reader.releaseLock();
+                } catch {
+                  // lock already released
+                }
+              })
+            : Effect.promise(async () => {
+                try {
+                  await reader.cancel();
+                } catch {
+                  // already closed or errored
+                } finally {
+                  try {
+                    reader.releaseLock();
+                  } catch {
+                    // lock already released
+                  }
+                }
+              }),
         );
 
         return Effect.tryPromise({
@@ -374,8 +401,26 @@ const makeDatagrams = (native: NativeWebTransport): Datagrams => {
       : Effect.succeed(native.datagrams),
   );
   let cachedWriter: WritableStreamDefaultWriter<Uint8Array> | undefined;
+  let closed = false;
+  const markClosed = () => {
+    closed = true;
+    try {
+      cachedWriter?.releaseLock();
+    } catch {
+      // lock already released
+    }
+    cachedWriter = undefined;
+  };
+
+  native.closed.then(markClosed, markClosed);
+
   const send = (data: Uint8Array): Effect.Effect<void, WebTransportError> =>
     Effect.flatMap(requireDatagrams, (datagrams) => {
+      if (closed) {
+        return Effect.fail(
+          wtError(new SessionClosedError({ cause: "datagram send after session closure" })),
+        );
+      }
       if (data.byteLength > datagrams.maxDatagramSize) {
         return Effect.fail(
           wtError(
@@ -389,7 +434,16 @@ const makeDatagrams = (native: NativeWebTransport): Datagrams => {
 
       return Effect.tryPromise({
         try: async () => {
-          cachedWriter ??= datagrams.writable.getWriter();
+          if (cachedWriter === undefined) {
+            const writable = Predicate.isFunction(datagrams.createWritable)
+              ? datagrams.createWritable.call(datagrams)
+              : datagrams.writable;
+
+            if (writable === undefined) {
+              throw new Error("the platform does not expose a writable datagram stream");
+            }
+            cachedWriter = writable.getWriter();
+          }
           const writer = cachedWriter;
 
           await writer.ready;
@@ -524,7 +578,19 @@ export const fromNative = (native: NativeWebTransport): WebTransport => ({
 });
 
 export interface DatagramBufferOptions {
+  /** Maximum number of incoming datagrams buffered by the platform. */
+  readonly incomingMaxBufferedDatagrams?: number | undefined;
+  /** Maximum number of outgoing datagrams buffered by the platform. */
+  readonly outgoingMaxBufferedDatagrams?: number | undefined;
+  /**
+   * @deprecated Use `incomingMaxBufferedDatagrams`. The modern option takes
+   * precedence when both are supplied.
+   */
   readonly incomingHighWaterMark?: number | undefined;
+  /**
+   * @deprecated Use `outgoingMaxBufferedDatagrams`. The modern option takes
+   * precedence when both are supplied.
+   */
   readonly outgoingHighWaterMark?: number | undefined;
   readonly incomingMaxAge?: number | null | undefined;
   readonly outgoingMaxAge?: number | null | undefined;
@@ -542,21 +608,14 @@ export const connect = Effect.fn("WebTransport.connect")(function* (
 ): Effect.fn.Return<WebTransport, WebTransportError, WebTransportConstructor | Scope.Scope> {
   const makeNative = yield* WebTransportConstructor;
   const resolvedUrl = Predicate.isString(url) ? url : yield* url;
-  const native = yield* Effect.acquireRelease(
+  const session = yield* Effect.acquireRelease(
     Effect.try({
-      try: () => makeNative(resolvedUrl, options),
+      try: () => fromNative(makeNative(resolvedUrl, options)),
       catch: (cause) => wtError(new ConnectError({ kind: "OpenFailed", cause })),
     }),
-    (native) =>
-      Effect.promise(async () => {
-        try {
-          native.close(options?.closeInfo);
-        } catch {
-          // session already closed or failed
-        }
-        await native.closed.then(constVoid, constVoid);
-      }),
+    (session) => session.close(options?.closeInfo),
   );
+  const native = session.native;
 
   yield* Effect.tryPromise({
     try: () => native.ready,
@@ -579,12 +638,24 @@ export const connect = Effect.fn("WebTransport.connect")(function* (
 
   if (datagramOptions !== undefined && native.datagrams !== undefined) {
     const datagrams = native.datagrams;
+    const incomingMaxBufferedDatagrams =
+      datagramOptions.incomingMaxBufferedDatagrams ?? datagramOptions.incomingHighWaterMark;
+    const outgoingMaxBufferedDatagrams =
+      datagramOptions.outgoingMaxBufferedDatagrams ?? datagramOptions.outgoingHighWaterMark;
 
-    if (datagramOptions.incomingHighWaterMark !== undefined) {
-      datagrams.incomingHighWaterMark = datagramOptions.incomingHighWaterMark;
+    if (incomingMaxBufferedDatagrams !== undefined) {
+      if ("incomingMaxBufferedDatagrams" in datagrams) {
+        datagrams.incomingMaxBufferedDatagrams = incomingMaxBufferedDatagrams;
+      } else if ("incomingHighWaterMark" in datagrams) {
+        datagrams.incomingHighWaterMark = incomingMaxBufferedDatagrams;
+      }
     }
-    if (datagramOptions.outgoingHighWaterMark !== undefined) {
-      datagrams.outgoingHighWaterMark = datagramOptions.outgoingHighWaterMark;
+    if (outgoingMaxBufferedDatagrams !== undefined) {
+      if ("outgoingMaxBufferedDatagrams" in datagrams) {
+        datagrams.outgoingMaxBufferedDatagrams = outgoingMaxBufferedDatagrams;
+      } else if ("outgoingHighWaterMark" in datagrams) {
+        datagrams.outgoingHighWaterMark = outgoingMaxBufferedDatagrams;
+      }
     }
     if (datagramOptions.incomingMaxAge !== undefined) {
       datagrams.incomingMaxAge = datagramOptions.incomingMaxAge;
@@ -594,7 +665,7 @@ export const connect = Effect.fn("WebTransport.connect")(function* (
     }
   }
 
-  return fromNative(native);
+  return session;
 });
 
 export const layer = (
@@ -629,12 +700,19 @@ export const writer = (
       catch: (cause) => wtError(new WriteError({ source: "stream", cause })),
     }),
     (writer, exit) =>
-      Effect.promise(() =>
-        (Exit.isSuccess(exit) ? writer.close() : writer.abort(exit.cause)).then(
-          constVoid,
-          constVoid,
-        ),
-      ),
+      Effect.promise(async () => {
+        try {
+          await (Exit.isSuccess(exit) ? writer.close() : writer.abort(exit.cause));
+        } catch {
+          // already closed or errored
+        } finally {
+          try {
+            writer.releaseLock();
+          } catch {
+            // lock already released
+          }
+        }
+      }),
   ).pipe(
     Effect.map(
       (writer) =>

--- a/packages/effect-webtransport/src/WebTransportSocket.ts
+++ b/packages/effect-webtransport/src/WebTransportSocket.ts
@@ -47,8 +47,6 @@ const toSocketOpenError = (cause: unknown): Socket.SocketError =>
 
 const encoder = new TextEncoder();
 
-const swallow = () => undefined;
-
 /**
  * Builds a `Socket` from a scoped acquisition of one reliable bidirectional
  * WebTransport stream. The acquisition runs once per `Socket.run`, so a
@@ -85,7 +83,19 @@ export const fromBidirectionalStream = <R>(
 
           yield* Scope.addFinalizer(
             scope,
-            Effect.promise(() => reader.cancel().then(swallow, swallow)),
+            Effect.promise(async () => {
+              try {
+                await reader.cancel();
+              } catch {
+                // already closed or errored
+              } finally {
+                try {
+                  reader.releaseLock();
+                } catch {
+                  // lock already released
+                }
+              }
+            }),
           );
           const writer = yield* Effect.try({
             try: () => stream.writable.getWriter(),
@@ -93,12 +103,19 @@ export const fromBidirectionalStream = <R>(
           });
 
           yield* Scope.addFinalizerExit(scope, (exit) =>
-            Effect.promise(() =>
-              (Exit.isSuccess(exit) ? writer.close() : writer.abort(exit.cause)).then(
-                swallow,
-                swallow,
-              ),
-            ),
+            Effect.promise(async () => {
+              try {
+                await (Exit.isSuccess(exit) ? writer.close() : writer.abort(exit.cause));
+              } catch {
+                // already closed or errored
+              } finally {
+                try {
+                  writer.releaseLock();
+                } catch {
+                  // lock already released
+                }
+              }
+            }),
           );
           const fiberSet = yield* FiberSet.make<any, E | Socket.SocketError>().pipe(
             Scope.provide(scope),

--- a/packages/effect-webtransport/tests/Fallback.test.ts
+++ b/packages/effect-webtransport/tests/Fallback.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
-import { Data, Effect } from "effect";
+import { Data, Deferred, Effect, Exit, Fiber, Option, Scope } from "effect";
 import { Socket } from "effect/unstable/socket";
 
 import * as Fallback from "../src/Fallback";
@@ -100,6 +100,34 @@ describe("Fallback", () => {
 
       assert.strictEqual(selected.name, "fallback");
     }),
+  );
+
+  it.effect("releases an interrupted candidate before selection returns", () =>
+    Effect.acquireUseRelease(
+      Scope.make(),
+      (scope) =>
+        Effect.gen(function* () {
+          const acquired = yield* Deferred.make<void>();
+          const released = yield* Deferred.make<void>();
+          const candidate: Fallback.Candidate<never, Scope.Scope> = {
+            name: "interrupted",
+            socket: Effect.acquireRelease(Deferred.succeed(acquired, undefined), () =>
+              Deferred.succeed(released, undefined),
+            ).pipe(Effect.andThen(Effect.never)),
+          };
+
+          const selection = yield* Fallback.select([candidate]).pipe(
+            Scope.provide(scope),
+            Effect.forkChild,
+          );
+
+          yield* Deferred.await(acquired);
+          yield* Fiber.interrupt(selection);
+
+          assert.isTrue(Option.isSome(yield* Deferred.poll(released)));
+        }),
+      (scope) => Scope.close(scope, Exit.void),
+    ),
   );
 
   it.effect("webSocket candidates acquire lazily and carry their name", () =>

--- a/packages/effect-webtransport/tests/WebTransport.test.ts
+++ b/packages/effect-webtransport/tests/WebTransport.test.ts
@@ -103,7 +103,7 @@ describe("connect", () => {
     }),
   );
 
-  it.effect("applies datagram buffer options", () =>
+  it.effect("maps legacy buffer aliases to modern fields with modern precedence", () =>
     Effect.gen(function* () {
       const fake = makeFakeWebTransport();
 
@@ -111,7 +111,8 @@ describe("connect", () => {
         Effect.gen(function* () {
           yield* WebTransport.connect("https://example.com", {
             datagrams: {
-              incomingHighWaterMark: 5,
+              incomingMaxBufferedDatagrams: 5,
+              incomingHighWaterMark: 50,
               outgoingHighWaterMark: 7,
               incomingMaxAge: 100,
               outgoingMaxAge: null,
@@ -119,23 +120,39 @@ describe("connect", () => {
           });
           const datagrams = fake.datagrams!.native;
 
-          assert.strictEqual(datagrams.incomingHighWaterMark, 5);
-          assert.strictEqual(datagrams.outgoingHighWaterMark, 7);
+          assert.strictEqual(datagrams.incomingMaxBufferedDatagrams, 5);
+          assert.strictEqual(datagrams.outgoingMaxBufferedDatagrams, 7);
+          assert.isFalse("incomingHighWaterMark" in datagrams);
+          assert.isFalse("outgoingHighWaterMark" in datagrams);
           assert.strictEqual(datagrams.incomingMaxAge, 100);
           assert.strictEqual(datagrams.outgoingMaxAge, null);
         }),
       ).pipe(provideConstructor(fake));
     }),
   );
+
+  it.effect("maps modern buffer options to legacy platform fields", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ datagrams: { bufferApi: "legacy" } });
+
+      yield* Effect.scoped(
+        WebTransport.connect("https://example.com", {
+          datagrams: {
+            incomingMaxBufferedDatagrams: 9,
+            outgoingMaxBufferedDatagrams: 11,
+          },
+        }),
+      ).pipe(provideConstructor(fake));
+
+      assert.strictEqual(fake.datagrams!.native.incomingHighWaterMark, 9);
+      assert.strictEqual(fake.datagrams!.native.outgoingHighWaterMark, 11);
+      assert.isFalse("incomingMaxBufferedDatagrams" in fake.datagrams!.native);
+      assert.isFalse("outgoingMaxBufferedDatagrams" in fake.datagrams!.native);
+    }),
+  );
 });
 
 describe("feature detection", () => {
-  it.effect("isSupported is false without a global constructor", () =>
-    Effect.gen(function* () {
-      assert.isFalse(yield* WebTransport.isSupported);
-    }),
-  );
-
   it.effect("layerConstructorGlobal fails typed without a global constructor", () =>
     Effect.gen(function* () {
       const error = yield* Effect.scoped(WebTransport.connect("https://example.com")).pipe(
@@ -281,6 +298,7 @@ describe("streams", () => {
       releaseWrite();
       yield* Fiber.join(interruptFiber);
       assert.isTrue(wasAborted);
+      assert.isFalse(writable.locked);
     }),
   );
 
@@ -387,6 +405,7 @@ describe("streams", () => {
       const collected = yield* Stream.runCollect(WebTransport.readStream(bidi.native.readable));
 
       assert.deepStrictEqual(collected, [bytes(1), bytes(2, 3)]);
+      assert.isFalse(bidi.native.readable.locked);
     }),
   );
 
@@ -428,6 +447,68 @@ describe("datagrams", () => {
       assert.deepStrictEqual(fake.datagrams!.sent, [bytes(1, 2)]);
       fake.datagrams!.push(bytes(9));
       assert.deepStrictEqual(yield* session.datagrams.take, bytes(9));
+    }),
+  );
+
+  it.effect("send supports datagrams exposed through createWritable", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport({ datagrams: { createWritableOnly: true } });
+      const session = WebTransport.fromNative(fake.native);
+
+      yield* session.datagrams.send(bytes(1, 2));
+
+      assert.deepStrictEqual(fake.datagrams!.sent, [bytes(1, 2)]);
+    }),
+  );
+
+  it.effect("close releases the cached datagram writer", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      yield* session.datagrams.send(bytes(1));
+      assert.isTrue(fake.datagrams!.native.writable!.locked);
+      yield* session.close();
+
+      assert.isFalse(fake.datagrams!.native.writable!.locked);
+    }),
+  );
+
+  it.effect("peer closure releases the cached writer and rejects later sends", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      yield* session.datagrams.send(bytes(1));
+      assert.isTrue(fake.datagrams!.writable.locked);
+      fake.resolveClosed({ closeCode: 0, reason: "peer closed" });
+      yield* Effect.promise(() => fake.native.closed.then(() => undefined));
+
+      assert.isFalse(fake.datagrams!.writable.locked);
+      expectReason(
+        yield* session.datagrams.send(bytes(2)).pipe(Effect.flip),
+        WebTransport.SessionClosedError,
+      );
+      assert.isFalse(fake.datagrams!.writable.locked);
+    }),
+  );
+
+  it.effect("abrupt peer closure releases the cached writer", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeWebTransport();
+      const session = WebTransport.fromNative(fake.native);
+
+      yield* session.datagrams.send(bytes(1));
+      assert.isTrue(fake.datagrams!.writable.locked);
+      fake.rejectClosed(new Error("connection lost"));
+      yield* Effect.promise(() =>
+        fake.native.closed.then(
+          () => undefined,
+          () => undefined,
+        ),
+      );
+
+      assert.isFalse(fake.datagrams!.writable.locked);
     }),
   );
 

--- a/packages/effect-webtransport/tests/WebTransportSocket.test.ts
+++ b/packages/effect-webtransport/tests/WebTransportSocket.test.ts
@@ -84,6 +84,10 @@ describe("WebTransportSocket", () => {
       // cancellation of the readable half.
       assert.isTrue(fake.bidis[0]!.writableClosed());
       assert.isTrue(fake.bidis[1]!.writableClosed());
+      assert.isFalse(fake.bidis[0]!.native.readable.locked);
+      assert.isFalse(fake.bidis[0]!.native.writable.locked);
+      assert.isFalse(fake.bidis[1]!.native.readable.locked);
+      assert.isFalse(fake.bidis[1]!.native.writable.locked);
     }),
   );
 

--- a/packages/effect-webtransport/tests/fakes.ts
+++ b/packages/effect-webtransport/tests/fakes.ts
@@ -58,6 +58,7 @@ export const makeFakeBidi = (options?: { readonly echo?: boolean }): FakeBidi =>
 
 export interface FakeDatagrams {
   readonly native: WebTransport.NativeDatagramDuplexStream;
+  readonly writable: WritableStream<Uint8Array>;
   readonly sent: Array<Uint8Array>;
   readonly push: (chunk: Uint8Array) => void;
   readonly end: () => void;
@@ -69,6 +70,8 @@ export interface FakeDatagrams {
 export const makeFakeDatagrams = (options?: {
   readonly maxDatagramSize?: number;
   readonly gated?: boolean;
+  readonly createWritableOnly?: boolean;
+  readonly bufferApi?: "modern" | "legacy" | "both";
 }): FakeDatagrams => {
   let controller!: ReadableStreamDefaultController<Uint8Array>;
   let ended = false;
@@ -87,13 +90,27 @@ export const makeFakeDatagrams = (options?: {
       sent.push(chunk);
     },
   });
+  const bufferApi = options?.bufferApi ?? "modern";
+  const bufferFields =
+    bufferApi === "legacy"
+      ? { incomingHighWaterMark: 0, outgoingHighWaterMark: 0 }
+      : bufferApi === "both"
+        ? {
+            incomingMaxBufferedDatagrams: 0,
+            outgoingMaxBufferedDatagrams: 0,
+            incomingHighWaterMark: 0,
+            outgoingHighWaterMark: 0,
+          }
+        : { incomingMaxBufferedDatagrams: 0, outgoingMaxBufferedDatagrams: 0 };
 
   return {
     native: {
       readable,
-      writable,
+      ...(options?.createWritableOnly ? { createWritable: () => writable } : { writable }),
       maxDatagramSize: options?.maxDatagramSize ?? 1200,
+      ...bufferFields,
     },
+    writable,
     sent,
     push: (chunk) => controller.enqueue(chunk),
     end: () => {
@@ -136,6 +153,8 @@ export interface FakeWebTransportOptions {
   readonly datagrams?: {
     readonly maxDatagramSize?: number;
     readonly gated?: boolean;
+    readonly createWritableOnly?: boolean;
+    readonly bufferApi?: "modern" | "legacy" | "both";
   };
   readonly failBidiOpen?: unknown;
 }


### PR DESCRIPTION
## Summary

Keep Worker event resources alive through Effect response streaming, join interrupted native callbacks before returning, and release WebTransport reader/writer locks on cleanup. Background work and Workflow steps acquire resources in their own scopes.

The pass also propagates fetch cancellation, preserves tagged RPC failures, rejects malformed embedding responses and invalid Analytics Engine URLs through typed errors, and replaces reserved metadata on fresh RPC WebSockets. It removes the stateless WebSocket wrapper cache, duplicated RPC client IDs, duplicated session cleanup, and manual Computer disposal code.

Public additions include `WorkspaceAcquireError` for Computer layer acquisition and modern WebTransport datagram writers and buffer options. Legacy datagram options remain supported. Typed WebSocket attachment writes now enforce the declared attachment type. Runtime pins and dependencies are unchanged.

## What went wrong

Captured Effect contexts include the current Scope. Providing a captured request context inside a new scope replaced the new scope with the request's scope, so background resources could be released while background work was still running. Native callback adapters also started independent root fibers, allowing transactions and test callbacks to continue after their callers were interrupted.

[Native callback ownership](https://github.com/danieljvdm/effect-cf/blob/bdc10ebea6fd44aa6638bc0f07e5848e4d786c6c/packages/effect-cf/src/internal/NativeCallback.ts) now interrupts and joins callback fibers before waiting for the native operation to settle. Transactions therefore finish rollback before returning. [Workflow steps](https://github.com/danieljvdm/effect-cf/blob/bdc10ebea6fd44aa6638bc0f07e5848e4d786c6c/packages/effect-cf/src/Workflow.ts) instead stop their callbacks without waiting through retry delays controlled by Cloudflare, and supply a fresh scope and current step context.

The Worker event layer was built outside the HTTP scope transferred to the response body. [Worker response handling](https://github.com/danieljvdm/effect-cf/blob/bdc10ebea6fd44aa6638bc0f07e5848e4d786c6c/packages/effect-cf/src/Worker.ts) now builds it inside that HTTP scope and keeps event tracing and redaction references installed through deferred span completion. Queue handlers now schedule the same bounded telemetry flush after success or failure. Fetch and queue continue to invoke the public `RunSymbol` instrumentation hook introduced in #129.

[WebTransport cleanup](https://github.com/danieljvdm/effect-cf/blob/bdc10ebea6fd44aa6638bc0f07e5848e4d786c6c/packages/effect-webtransport/src/WebTransport.ts) previously terminated streams without releasing their locks and kept a datagram writer after peer closure. Fallback selection closed failed candidates only through the branch for typed errors. Cleanup now covers interruption and defects, and modern datagram options reach the native fields that current implementations expose.

Scoped RPC resolution errors previously bypassed the adapters' tagged errors. Workers AI discarded embedding decode failures as empty results, and Analytics Engine constructed query URLs outside its typed error boundary. These paths now report the existing operation errors. Fresh WebSocket attachment metadata no longer reuses protocol identity supplied by the application.

Base ManagedRuntime disposal remains unchanged. Cached base layers can retain the first request context, and there is no deterministic disposal point for those runtimes in these adapters. Resources needing timely release still belong in `eventLayer`. Native `Response` streams do not gain automatic scope transfer.

## Validation

Replayed the regression tests against the audit's unchanged original base (`40b64e3`) in a detached worktree, then ran the identical 18-file selection on this branch:

| Source | Passed | Failed | Skipped |
| --- | ---: | ---: | ---: |
| Original source `40b64e3` | 179 | 39 | 3 |
| This branch | 218 | 0 | 3 |

Every baseline failure passes with the fixes. The [streaming regression](https://github.com/danieljvdm/effect-cf/blob/bdc10ebea6fd44aa6638bc0f07e5848e4d786c6c/packages/effect-cf/tests/WorkerBoundary.test.ts#L569) holds the body open after `fetch` returns and checks resource release and telemetry on both completion and cancellation. [Transaction cancellation](https://github.com/danieljvdm/effect-cf/blob/bdc10ebea6fd44aa6638bc0f07e5848e4d786c6c/packages/effect-cf/tests/DurableObjectStorage.worker.test.ts) verifies rollback against workerd.

The existing [RPC tracing integration test](https://github.com/danieljvdm/effect-cf/blob/bdc10ebea6fd44aa6638bc0f07e5848e4d786c6c/packages/effect-cf/tests/RpcTracing.test.ts) now also exercises Worker fetch through that instrumentation hook. It failed when fetch bypassed the hook during integration and passes with the combined changes.

[Repository CI passes on the final commit](https://github.com/danieljvdm/effect-cf/actions/runs/33107846747), including tests, build, lint, formatting, and the patched Effect compiler.

Commands run on the final tree, including main's RPC tracing changes:

- `vp run patch:tsgo` — applied the same Effect TypeScript-Go patch used in CI before the final validation.
- `vp check` — formatting and lint pass without warnings.
- `vp run --no-cache check` — builds and script checks pass; **409 tests pass across 52 files**, with 3 skipped.
- `vp run --no-cache --filter './packages/*' --filter './examples/*' --fail-if-no-match typecheck` — both packages and the example pass with zero cache hits.

Type checks also cover tagged scoped-RPC errors, workspace acquisition errors, attachment shape enforcement, and modern datagram fields.

Removed five forwarding or feature detection tests and their unused fixture state. Transaction cancellation stays in the workerd integration test instead of duplicating it with a mock. Retained tests exercise public APIs, real Effect scopes and Web Streams, native workerd callbacks, and HTTP telemetry export.

The three skipped cases are opt-in Maple OTLP smoke tests. No live Cloudflare deployment or remote SDK account was exercised.

The automated context-replacement finding was checked against the [pinned Effect implementation](https://github.com/Effect-TS/effect/blob/effect@4.0.0-rc.110/packages/effect/src/internal/effect.ts#L2196). `provideContext` uses `Context.merge`, so it preserves Worker and request services not supplied by the event layer. The installed file's blob hash matches upstream, and the fetch and telemetry integration cases pass.

The automated datagram finding was checked against the [Streams standard](https://streams.spec.whatwg.org/#default-writer-release-lock): a valid writer may release its lock before writes finish, and the release algorithm does not reject for pending close operations. The suggested retry state is unnecessary for the declared native API.

