### PR TITLE
feat(effect-cf): compose application storage and alarm transactions

### DIFF
--- a/.changeset/durable-alarm-transactions.md
+++ b/.changeset/durable-alarm-transactions.md
@@ -1,0 +1,7 @@
+---
+"effect-cf": minor
+---
+
+Add `DurableObjectAlarm.transaction` to commit application storage and logical alarm schedule, replacement, or cancellation together in one native SQLite Durable Object transaction. Application queries can use the existing storage wrapper or a `SqlClient` from `@effect/sql-sqlite-do` backed by the same object. The callback receives transaction-only alarm mutations and preserves the caller's success value, typed errors, and service requirements.
+
+Failures before commit roll back application rows, logical alarms, and native alarm reconciliation together. Interruption or a lost reply after commit does not undo committed state. Keep external effects outside the transaction and durably pre-arm a later wake before fallible external work; Cloudflare's native alarm retries remain bounded.

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -47,44 +47,7 @@ Declare `SETTINGS` in `wrangler.jsonc` and pass `SettingsLive` to `Worker.make`.
 
 The [counter example](https://github.com/danieljvdm/effect-cf/tree/main/examples/counter) shows `DurableObject.Tag`, storage, a typed RPC call, and the complete Wrangler configuration.
 
-## Durable Object alarm transactions
-
-`DurableObjectAlarm` schedules logical alarms identified by `{ tag, id }`. Scheduling the same pair replaces it. To commit application rows and alarm changes together, use `alarms.transaction`. The callback receives `scheduleAlarm` and `cancelAlarm` methods that share one native SQLite Durable Object transaction.
-
-```ts
-import { DateTime, Effect, Layer } from "effect";
-import { SqlClient } from "effect/unstable/sql";
-import { DurableObjectAlarm, DurableObjectSqlite } from "effect-cf";
-
-export const AlarmStorageLive = Layer.merge(
-  DurableObjectAlarm.DurableObjectAlarm.layer,
-  DurableObjectSqlite.layer(),
-);
-
-export const scheduleJob = Effect.fn("scheduleJob")(function* (id: string, runAt: DateTime.Utc) {
-  const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
-  const sql = yield* SqlClient.SqlClient;
-
-  yield* sql`CREATE TABLE IF NOT EXISTS jobs (id TEXT PRIMARY KEY, run_at INTEGER NOT NULL)`;
-
-  return yield* alarms.transaction((tx) =>
-    Effect.gen(function* () {
-      yield* sql`INSERT OR REPLACE INTO jobs (id, run_at) VALUES (${id}, ${DateTime.toEpochMillis(runAt)})`;
-      yield* tx.scheduleAlarm({ tag: "job", id, runAt, payload: null });
-
-      return id;
-    }),
-  );
-});
-```
-
-Pass `AlarmStorageLive` to `DurableObject.make` and use `scheduleJob` in a handler. This [compiling example](tests/fixtures/alarm-transaction-consumer.ts) uses `@effect/sql-sqlite-do` through `DurableObjectSqlite.layer()`. An existing `SqlClient` backed by the same object's storage works too. Application operations through `DurableObjectState.storage`, including `storage.sql.exec`, also participate. Do not wrap this boundary in `SqlClient.withTransaction` or `storage.transaction`, or call standalone alarm methods inside it. Run the supplied mutations in the callback's fiber; forked work and escaped handles fail with `StorageOperationError`.
-
-The caller's success value, typed errors, and service requirements remain visible. Reconciliation adds `StorageOperationError`; schedule and cancel retain their existing validation errors. Before commit, an uncaught typed failure, defect, interruption, or native alarm failure rolls back application rows, logical alarms, and the native alarm together. Once committed, interruption or a lost reply does not undo that state. A failed observation alone does not prove rollback.
-
-The native alarm is reconciled once before commit to the earliest remaining deadline, or cleared when no logical alarms remain. Standalone scheduling and cancellation use the same implementation. A due handler may transactionally write application state and replace its own alarm; conditional acknowledgement preserves the replacement.
-
-Keep RPC, network requests, and other external effects outside the transaction. Before fallible external work, durably pre-arm a later wake together with the application state that requires it. Transaction composition makes that pre-arm atomic; it does not remove the pre-arm requirement or promise infinite retry liveness. [Cloudflare limits native alarm retries](https://developers.cloudflare.com/durable-objects/api/alarms/). The scheduler must exclusively own the object's native alarm.
+For atomic application writes and alarm changes, see the [alarm transaction example](tests/fixtures/alarm-transaction-consumer.ts) and [API contract](src/DurableObjectAlarm.ts).
 
 ## Native RPC tracing
 

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -47,6 +47,45 @@ Declare `SETTINGS` in `wrangler.jsonc` and pass `SettingsLive` to `Worker.make`.
 
 The [counter example](https://github.com/danieljvdm/effect-cf/tree/main/examples/counter) shows `DurableObject.Tag`, storage, a typed RPC call, and the complete Wrangler configuration.
 
+## Durable Object alarm transactions
+
+`DurableObjectAlarm` schedules logical alarms identified by `{ tag, id }`. Scheduling the same pair replaces it. To commit application rows and alarm changes together, use `alarms.transaction`. The callback receives `scheduleAlarm` and `cancelAlarm` methods that share one native SQLite Durable Object transaction.
+
+```ts
+import { DateTime, Effect, Layer } from "effect";
+import { SqlClient } from "effect/unstable/sql";
+import { DurableObjectAlarm, DurableObjectSqlite } from "effect-cf";
+
+export const AlarmStorageLive = Layer.merge(
+  DurableObjectAlarm.DurableObjectAlarm.layer,
+  DurableObjectSqlite.layer(),
+);
+
+export const scheduleJob = Effect.fn("scheduleJob")(function* (id: string, runAt: DateTime.Utc) {
+  const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`CREATE TABLE IF NOT EXISTS jobs (id TEXT PRIMARY KEY, run_at INTEGER NOT NULL)`;
+
+  return yield* alarms.transaction((tx) =>
+    Effect.gen(function* () {
+      yield* sql`INSERT OR REPLACE INTO jobs (id, run_at) VALUES (${id}, ${DateTime.toEpochMillis(runAt)})`;
+      yield* tx.scheduleAlarm({ tag: "job", id, runAt, payload: null });
+
+      return id;
+    }),
+  );
+});
+```
+
+Pass `AlarmStorageLive` to `DurableObject.make` and use `scheduleJob` in a handler. This [compiling example](tests/fixtures/alarm-transaction-consumer.ts) uses `@effect/sql-sqlite-do` through `DurableObjectSqlite.layer()`. An existing `SqlClient` backed by the same object's storage works too. Application operations through `DurableObjectState.storage`, including `storage.sql.exec`, also participate. Do not wrap this boundary in `SqlClient.withTransaction` or `storage.transaction`, or call standalone alarm methods inside it. Run the supplied mutations in the callback's fiber; forked work and escaped handles fail with `StorageOperationError`.
+
+The caller's success value, typed errors, and service requirements remain visible. Reconciliation adds `StorageOperationError`; schedule and cancel retain their existing validation errors. Before commit, an uncaught typed failure, defect, interruption, or native alarm failure rolls back application rows, logical alarms, and the native alarm together. Once committed, interruption or a lost reply does not undo that state. A failed observation alone does not prove rollback.
+
+The native alarm is reconciled once before commit to the earliest remaining deadline, or cleared when no logical alarms remain. Standalone scheduling and cancellation use the same implementation. A due handler may transactionally write application state and replace its own alarm; conditional acknowledgement preserves the replacement.
+
+Keep RPC, network requests, and other external effects outside the transaction. Before fallible external work, durably pre-arm a later wake together with the application state that requires it. Transaction composition makes that pre-arm atomic; it does not remove the pre-arm requirement or promise infinite retry liveness. [Cloudflare limits native alarm retries](https://developers.cloudflare.com/durable-objects/api/alarms/). The scheduler must exclusively own the object's native alarm.
+
 ## Native RPC tracing
 
 `call()`, `scopedCall()`, and definition methods create one CLIENT span named `binding/method`, covering argument encoding, the native RPC wait, and success decoding. Raw `rpc()` retains Cloudflare's pipelined result without creating a span. Wrap its complete lifetime with `RpcTracing.withRpcClientSpan` when tracing raw calls.

--- a/packages/effect-cf/src/DurableObjectAlarm.ts
+++ b/packages/effect-cf/src/DurableObjectAlarm.ts
@@ -12,7 +12,7 @@ import {
 } from "effect";
 
 import { DurableObjectState } from "./DurableObjectState";
-import type { SqlStorageValue, StorageOperationError } from "./DurableObjectStorage";
+import { type SqlStorageValue, StorageOperationError } from "./DurableObjectStorage";
 import * as ErrorMessage from "./internal/ErrorMessage";
 
 const INIT_TABLE_SQL = `
@@ -177,8 +177,28 @@ export type ProcessDueAlarmsHandler<R = never, E = never> = (
   event: DurableObjectAlarmEvent,
 ) => Effect.Effect<void, E, R>;
 
+/**
+ * Alarm mutations owned by one transaction callback. Run them in the callback's
+ * fiber; forked work and use after the callback ends fail with StorageOperationError.
+ */
+export type AlarmTransaction = Pick<AlarmScheduler, "scheduleAlarm" | "cancelAlarm">;
+
 /** Own `storage.setAlarm()` exclusively: a Durable Object has one platform alarm timestamp. */
 export type AlarmScheduler = {
+  /**
+   * Commits local application storage and logical alarms in one native SQLite
+   * Durable Object transaction, reconciling the native alarm before commit.
+   * Use the supplied mutations, not standalone alarm methods or nested transactions.
+   * SqlClient queries must use this same Durable Object's storage.
+   *
+   * Failure, defects and interruption before commit roll back. A lost reply or
+   * interruption after commit does not undo committed state. Keep RPC and other
+   * external effects outside; atomically pre-arm a later wake before fallible work.
+   */
+  readonly transaction: <A, E, R>(
+    closure: (alarms: AlarmTransaction) => Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E | StorageOperationError, R>;
+
   readonly cancelAlarm: (
     input: AlarmRef,
   ) => Effect.Effect<void, InvalidAlarmRefError | StorageOperationError>;
@@ -523,17 +543,9 @@ export class DurableObjectAlarm extends Context.Service<DurableObjectAlarm, Alar
       const cancelAlarm = Effect.fn("DurableObjectAlarm.cancelAlarm")(function* (input: AlarmRef) {
         const ref = yield* decodeAlarmRef(input);
 
-        yield* state.storage.transaction(() =>
-          Effect.gen(function* () {
-            yield* ensureTable(state);
-            yield* state.storage.sql
-              .exec(
-                `DELETE FROM effect_cf_scheduled_alarms WHERE storage_id = ?`,
-                getScheduledEventId(ref),
-              )
-              .pipe(Effect.asVoid);
-            yield* reconcileAlarm();
-          }),
+        yield* state.storage.sql.exec(
+          `DELETE FROM effect_cf_scheduled_alarms WHERE storage_id = ?`,
+          getScheduledEventId(ref),
         );
       });
 
@@ -545,26 +557,61 @@ export class DurableObjectAlarm extends Context.Service<DurableObjectAlarm, Alar
         const payload = yield* encodeStoredPayload(input.payload);
         const runAt = DateTime.toEpochMillis(input.runAt);
 
-        yield* state.storage.transaction(() =>
-          Effect.gen(function* () {
-            yield* ensureTable(state);
-            yield* state.storage.sql
-              .exec(
-                `INSERT OR REPLACE INTO effect_cf_scheduled_alarms
+        yield* state.storage.sql.exec(
+          `INSERT OR REPLACE INTO effect_cf_scheduled_alarms
                    (storage_id, alarm_id, tag, run_at, repeat_every_ms, payload)
                  VALUES (?, ?, ?, ?, ?, ?)`,
-                getScheduledEventId(ref),
-                ref.id,
-                ref.tag,
-                runAt,
-                repeatEveryMillis,
-                payload,
-              )
-              .pipe(Effect.asVoid);
-            yield* reconcileAlarm();
-          }),
+          getScheduledEventId(ref),
+          ref.id,
+          ref.tag,
+          runAt,
+          repeatEveryMillis,
+          payload,
         );
       });
+
+      const transaction: AlarmScheduler["transaction"] = (closure) =>
+        state.storage.transaction(() =>
+          Effect.withFiber((owner) => {
+            let active = true;
+
+            // A callback-owned handle cannot escape via a returned Effect or a
+            // detached fiber and write after reconciliation or rollback.
+            const requireActive = <A, E>(effect: Effect.Effect<A, E>) =>
+              Effect.withFiber<A, E | StorageOperationError>((fiber) =>
+                active && fiber === owner
+                  ? effect
+                  : Effect.fail(
+                      new StorageOperationError({
+                        operation: "alarm.transaction",
+                        cause: new Error(
+                          "Alarm mutations require their active transaction callback",
+                        ),
+                      }),
+                    ),
+              );
+
+            return Effect.gen(function* () {
+              yield* ensureTable(state);
+              const result = yield* Effect.suspend(() =>
+                closure({
+                  cancelAlarm: (input) => requireActive(cancelAlarm(input)),
+                  scheduleAlarm: (input) => requireActive(scheduleAlarm(input)),
+                }),
+              ).pipe(
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    active = false;
+                  }),
+                ),
+              );
+
+              yield* reconcileAlarm();
+
+              return result;
+            });
+          }),
+        );
 
       const processDueAlarms = Effect.fn("DurableObjectAlarm.processDueAlarms")(function* <
         R,
@@ -669,9 +716,10 @@ export class DurableObjectAlarm extends Context.Service<DurableObjectAlarm, Alar
       });
 
       return DurableObjectAlarm.of({
-        cancelAlarm,
+        cancelAlarm: (input) => transaction((alarms) => alarms.cancelAlarm(input)),
         processDueAlarms,
-        scheduleAlarm,
+        scheduleAlarm: (input) => transaction((alarms) => alarms.scheduleAlarm(input)),
+        transaction,
       });
     }).pipe(Effect.withSpan("DurableObjectAlarm.layer")),
   );

--- a/packages/effect-cf/src/DurableObjectAlarm.ts
+++ b/packages/effect-cf/src/DurableObjectAlarm.ts
@@ -194,6 +194,8 @@ export type AlarmScheduler = {
    * Failure, defects and interruption before commit roll back. A lost reply or
    * interruption after commit does not undo committed state. Keep RPC and other
    * external effects outside; atomically pre-arm a later wake before fallible work.
+   * Cloudflare's native retries are bounded; composition does not remove the
+   * pre-arm requirement or promise infinite retry liveness.
    */
   readonly transaction: <A, E, R>(
     closure: (alarms: AlarmTransaction) => Effect.Effect<A, E, R>,

--- a/packages/effect-cf/tests/DurableObjectAlarm.test.ts
+++ b/packages/effect-cf/tests/DurableObjectAlarm.test.ts
@@ -1,8 +1,334 @@
 import { assert, expect, it, test } from "@effect/vitest";
-import { Cause, DateTime, Effect, Layer, Schema } from "effect";
+import { Cause, Context, DateTime, Deferred, Effect, Exit, Fiber, Layer, Schema } from "effect";
 
-import { DurableObject, DurableObjectAlarm, DurableObjectState } from "../src/index";
+import {
+  DurableObject,
+  DurableObjectAlarm,
+  DurableObjectState,
+  DurableObjectStorage,
+} from "../src/index";
 import { makePartialTestDouble } from "./TestDoubles";
+
+const Application = Context.Service<{ readonly result: number }>("test/AlarmApplication");
+const writeJob = (storage: DurableObjectStorage.DurableObjectStorage, status: string) =>
+  storage.sql.exec(
+    "INSERT OR REPLACE INTO application_jobs (id, status) VALUES (?, ?)",
+    "job",
+    status,
+  );
+
+it.effect("commits application writes and mixed alarm mutations in one transaction", () =>
+  Effect.gen(function* () {
+    const fixture = makeAlarmFixture();
+
+    yield* fixture.run(
+      Effect.gen(function* () {
+        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+        const result = yield* alarms
+          .transaction((tx) =>
+            Effect.gen(function* () {
+              yield* writeJob(fixture.storage, "ready");
+              yield* tx.scheduleAlarm({
+                tag: "job",
+                id: "a",
+                runAt: atMillis(2_000),
+                payload: "old",
+              });
+              yield* tx.scheduleAlarm({
+                tag: "job",
+                id: "b",
+                runAt: atMillis(1_000),
+                payload: null,
+              });
+              yield* tx.scheduleAlarm({
+                tag: "job",
+                id: "a",
+                runAt: atMillis(3_000),
+                payload: "new",
+              });
+              yield* tx.scheduleAlarm({
+                tag: "other",
+                id: "a",
+                runAt: atMillis(4_000),
+                payload: null,
+              });
+              yield* tx.cancelAlarm({ tag: "job", id: "b" });
+
+              return (yield* Application).result;
+            }),
+          )
+          .pipe(Effect.provideService(Application, { result: 42 }));
+
+        assert.strictEqual(result, 42);
+        assert.strictEqual(fixture.tracker.transactionCalls, 1);
+        assert.strictEqual(fixture.job("job"), "ready");
+        assert.strictEqual(fixture.row("job", "a")?.payload, '"new"');
+        assert.strictEqual(fixture.row("job", "b"), undefined);
+        assert.strictEqual(fixture.row("other", "a")?.run_at, 4_000);
+        assert.strictEqual(fixture.currentAlarm(), 3_000);
+
+        yield* alarms.transaction((tx) =>
+          Effect.gen(function* () {
+            yield* writeJob(fixture.storage, "cancelled");
+            yield* tx.cancelAlarm({ tag: "job", id: "a" });
+            yield* tx.cancelAlarm({ tag: "other", id: "a" });
+          }),
+        );
+
+        assert.strictEqual(fixture.job("job"), "cancelled");
+        assert.strictEqual(fixture.row("job", "a"), undefined);
+        assert.strictEqual(fixture.row("other", "a"), undefined);
+        assert.strictEqual(fixture.currentAlarm(), null);
+      }),
+    );
+  }),
+);
+
+it.effect.each(["typed failure", "defect"] as const)(
+  "rolls back application and alarm changes on %s",
+  (kind) =>
+    Effect.gen(function* () {
+      const fixture = makeAlarmFixture();
+      const failure = new Error("caller failed");
+
+      yield* fixture.run(
+        Effect.gen(function* () {
+          const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+
+          yield* writeJob(fixture.storage, "before");
+          yield* alarms.scheduleAlarm({
+            tag: "job",
+            id: "a",
+            runAt: atMillis(2_000),
+            payload: "before",
+          });
+          const exit = yield* alarms
+            .transaction((tx) =>
+              Effect.gen(function* () {
+                yield* writeJob(fixture.storage, "during");
+                yield* tx.cancelAlarm({ tag: "job", id: "a" });
+                yield* tx.scheduleAlarm({
+                  tag: "job",
+                  id: "b",
+                  runAt: atMillis(1_000),
+                  payload: null,
+                });
+
+                return yield* kind === "typed failure" ? Effect.fail(failure) : Effect.die(failure);
+              }),
+            )
+            .pipe(Effect.exit);
+
+          assert.isTrue(Exit.isFailure(exit));
+          if (Exit.isFailure(exit)) {
+            assert.strictEqual(Cause.squash(exit.cause), failure);
+            assert.strictEqual(Cause.hasDies(exit.cause), kind === "defect");
+          }
+          assert.strictEqual(fixture.job("job"), "before");
+          assert.strictEqual(fixture.row("job", "a")?.payload, '"before"');
+          assert.strictEqual(fixture.row("job", "b"), undefined);
+          assert.strictEqual(fixture.currentAlarm(), 2_000);
+          assert.strictEqual(fixture.tracker.transactionRollbacks, 1);
+        }),
+      );
+    }),
+);
+
+it.effect("rolls back on interruption during native alarm reconciliation", () =>
+  Effect.gen(function* () {
+    const reconciled = yield* Deferred.make<void>();
+    const releaseNative = yield* Deferred.make<void>();
+    const fixture = makeAlarmFixture({
+      afterSetAlarm: () =>
+        Effect.runPromise(
+          Deferred.succeed(reconciled, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseNative)),
+          ),
+        ),
+    });
+
+    const fiber = yield* fixture.run(
+      Effect.gen(function* () {
+        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+
+        return yield* Effect.forkChild(
+          alarms.transaction((tx) =>
+            Effect.gen(function* () {
+              yield* writeJob(fixture.storage, "during");
+              yield* tx.scheduleAlarm({
+                tag: "job",
+                id: "a",
+                runAt: atMillis(1_000),
+                payload: null,
+              });
+            }),
+          ),
+        );
+      }),
+    );
+
+    yield* Deferred.await(reconciled);
+    fiber.interruptUnsafe();
+    yield* Deferred.succeed(releaseNative, undefined);
+    const [exit] = yield* Fiber.awaitAll([fiber]);
+
+    assert.isTrue(Exit.isFailure(exit!));
+    if (Exit.isFailure(exit!)) {
+      assert.isTrue(Cause.hasInterrupts(exit.cause));
+    }
+    assert.strictEqual(fixture.job("job"), undefined);
+    assert.strictEqual(fixture.row("job", "a"), undefined);
+    assert.strictEqual(fixture.currentAlarm(), null);
+    assert.strictEqual(fixture.tracker.transactionRollbacks, 1);
+  }),
+);
+
+it.effect.each(["setAlarm", "deleteAlarm"] as const)(
+  "rolls back application writes when %s fails",
+  (operation) =>
+    Effect.gen(function* () {
+      const fixture = makeAlarmFixture();
+
+      yield* fixture.run(
+        Effect.gen(function* () {
+          const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+
+          yield* writeJob(fixture.storage, "before");
+          yield* alarms.scheduleAlarm({
+            tag: "job",
+            id: "a",
+            runAt: atMillis(2_000),
+            payload: "before",
+          });
+          if (operation === "setAlarm") {
+            fixture.failNextSetAlarm();
+          } else {
+            fixture.failNextDeleteAlarm();
+          }
+          const error = yield* alarms
+            .transaction((tx) =>
+              Effect.gen(function* () {
+                yield* writeJob(fixture.storage, "during");
+                yield* tx.cancelAlarm({ tag: "job", id: "a" });
+                if (operation === "setAlarm") {
+                  yield* tx.scheduleAlarm({
+                    tag: "job",
+                    id: "b",
+                    runAt: atMillis(1_000),
+                    payload: null,
+                  });
+                }
+              }),
+            )
+            .pipe(Effect.flip);
+
+          assert.instanceOf(error, DurableObjectStorage.StorageOperationError);
+          assert.strictEqual(error.operation, operation);
+          assert.strictEqual(fixture.job("job"), "before");
+          assert.strictEqual(fixture.row("job", "a")?.payload, '"before"');
+          assert.strictEqual(fixture.row("job", "b"), undefined);
+          assert.strictEqual(fixture.currentAlarm(), 2_000);
+        }),
+      );
+    }),
+);
+
+it.effect.each(["lost reply", "interruption"] as const)(
+  "preserves committed state after %s",
+  (kind) =>
+    Effect.gen(function* () {
+      const committed = yield* Deferred.make<void>();
+      const releaseReply = yield* Deferred.make<void>();
+      const fixture = makeAlarmFixture({
+        afterCommit: () =>
+          Effect.runPromise(
+            Deferred.succeed(committed, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseReply)),
+              Effect.andThen(
+                kind === "lost reply" ? Effect.fail(new Error("reply lost")) : Effect.void,
+              ),
+            ),
+          ),
+      });
+      const fiber = yield* fixture.run(
+        Effect.gen(function* () {
+          const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+
+          return yield* Effect.forkChild(
+            alarms.transaction((tx) =>
+              Effect.gen(function* () {
+                yield* writeJob(fixture.storage, "committed");
+                yield* tx.scheduleAlarm({
+                  tag: "job",
+                  id: "a",
+                  runAt: atMillis(1_000),
+                  payload: null,
+                });
+              }),
+            ),
+          );
+        }),
+      );
+
+      yield* Deferred.await(committed);
+      if (kind === "interruption") {
+        fiber.interruptUnsafe();
+      }
+      yield* Deferred.succeed(releaseReply, undefined);
+      const [exit] = yield* Fiber.awaitAll([fiber]);
+
+      assert.isTrue(Exit.isFailure(exit!));
+      assert.strictEqual(fixture.job("job"), "committed");
+      assert.strictEqual(fixture.row("job", "a")?.run_at, 1_000);
+      assert.strictEqual(fixture.currentAlarm(), 1_000);
+      assert.strictEqual(fixture.tracker.transactionRollbacks, 0);
+    }),
+);
+
+it.effect("rejects escaped and forked transaction mutations without changing storage", () =>
+  Effect.gen(function* () {
+    const fixture = makeAlarmFixture();
+
+    yield* fixture.run(
+      Effect.gen(function* () {
+        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+        const input = { tag: "job", id: "a", runAt: atMillis(1_000), payload: null };
+        const escaped = yield* alarms.transaction((tx) => Effect.succeed(tx));
+        let aborted = escaped;
+
+        yield* alarms
+          .transaction((tx) =>
+            Effect.sync(() => {
+              aborted = tx;
+            }).pipe(Effect.andThen(Effect.fail("abort"))),
+          )
+          .pipe(Effect.exit);
+
+        for (const effect of [
+          escaped.scheduleAlarm(input),
+          escaped.cancelAlarm(input),
+          aborted.scheduleAlarm(input),
+          aborted.cancelAlarm(input),
+        ]) {
+          assert.instanceOf(yield* Effect.flip(effect), DurableObjectStorage.StorageOperationError);
+        }
+        yield* alarms.transaction((tx) =>
+          Effect.gen(function* () {
+            assert.instanceOf(
+              yield* Effect.flip(escaped.scheduleAlarm(input)),
+              DurableObjectStorage.StorageOperationError,
+            );
+            const fiber = yield* Effect.forkChild(tx.scheduleAlarm(input).pipe(Effect.flip));
+
+            assert.instanceOf(yield* Fiber.join(fiber), DurableObjectStorage.StorageOperationError);
+          }),
+        );
+        assert.strictEqual(fixture.row("job", "a"), undefined);
+        assert.strictEqual(fixture.currentAlarm(), null);
+      }),
+    );
+  }),
+);
 
 it.effect("schedules, replaces, and reconciles to the earliest logical alarm", () =>
   Effect.gen(function* () {
@@ -496,19 +822,29 @@ interface AlarmFixtureTracker {
   readonly setAlarms: Array<number>;
   readonly deletedAlarms: Array<null>;
   transactionRollbacks: number;
+  transactionCalls: number;
 }
 
-function makeAlarmFixture() {
+interface AlarmFixtureOptions {
+  readonly afterCommit?: () => Promise<void>;
+  readonly afterSetAlarm?: () => Promise<void>;
+}
+
+function makeAlarmFixture(options: AlarmFixtureOptions = {}) {
   const rows = new Map<string, StoredAlarmRow>();
+  const jobs = new Map<string, string>();
   const tracker: AlarmFixtureTracker = {
     setAlarms: [],
     deletedAlarms: [],
     transactionRollbacks: 0,
+    transactionCalls: 0,
   };
   let currentAlarm: number | null = null;
   let rejectNextSetAlarm = false;
+  let rejectNextDeleteAlarm = false;
+  let inTransaction = false;
 
-  const sql = makeSqlStorage(rows);
+  const sql = makeSqlStorage(rows, jobs);
   const rawStorageImplementation = {
     get: async () => undefined,
     put: async () => undefined,
@@ -523,19 +859,31 @@ function makeAlarmFixture() {
 
       currentAlarm = scheduledTime instanceof Date ? scheduledTime.getTime() : scheduledTime;
       tracker.setAlarms.push(currentAlarm);
+      await options.afterSetAlarm?.();
     },
     deleteAlarm: async () => {
+      if (rejectNextDeleteAlarm) {
+        rejectNextDeleteAlarm = false;
+        throw new Error("deleteAlarm failed");
+      }
       currentAlarm = null;
       tracker.deletedAlarms.push(null);
     },
     transaction: async <T>(closure: (txn: globalThis.DurableObjectTransaction) => Promise<T>) => {
+      tracker.transactionCalls += 1;
+      if (inTransaction) {
+        throw new Error("Nested transactions are not supported");
+      }
+      inTransaction = true;
       const rowsSnapshot = cloneRows(rows);
+      const jobsSnapshot = new Map(jobs);
       const alarmSnapshot = currentAlarm;
       const setAlarmsLength = tracker.setAlarms.length;
       const deletedAlarmsLength = tracker.deletedAlarms.length;
+      let result: T;
 
       try {
-        return await closure(
+        result = await closure(
           makePartialTestDouble<globalThis.DurableObjectTransaction>({ rollback: () => {} }),
         );
       } catch (error) {
@@ -543,12 +891,22 @@ function makeAlarmFixture() {
         for (const [key, value] of rowsSnapshot) {
           rows.set(key, value);
         }
+        jobs.clear();
+        for (const [key, value] of jobsSnapshot) {
+          jobs.set(key, value);
+        }
         currentAlarm = alarmSnapshot;
         tracker.setAlarms.length = setAlarmsLength;
         tracker.deletedAlarms.length = deletedAlarmsLength;
         tracker.transactionRollbacks += 1;
         throw error;
+      } finally {
+        inTransaction = false;
       }
+      // Commit is complete. A failed or interrupted reply cannot roll it back.
+      await options.afterCommit?.();
+
+      return result;
     },
     transactionSync: <T>(closure: () => T) => closure(),
     sync: async () => undefined,
@@ -592,10 +950,15 @@ function makeAlarmFixture() {
 
   return {
     state,
+    storage: DurableObjectStorage.fromDurableObjectStorage(rawStorage),
     tracker,
+    job: (id: string) => jobs.get(id),
     currentAlarm: () => currentAlarm,
     failNextSetAlarm: () => {
       rejectNextSetAlarm = true;
+    },
+    failNextDeleteAlarm: () => {
+      rejectNextDeleteAlarm = true;
     },
     row: (tag: string, id: string) => rows.get(storageId(tag, id)),
     run: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect.pipe(Effect.provide(layer)),
@@ -604,13 +967,26 @@ function makeAlarmFixture() {
   };
 }
 
-function makeSqlStorage(rows: Map<string, StoredAlarmRow>): globalThis.SqlStorage {
+function makeSqlStorage(
+  rows: Map<string, StoredAlarmRow>,
+  jobs: Map<string, string>,
+): globalThis.SqlStorage {
   const implementation = {
     exec: (query: string, ...bindings: Array<globalThis.SqlStorageValue>) => {
       const normalized = query.replaceAll(/\s+/g, " ").trim();
 
       if (normalized.startsWith("CREATE TABLE")) {
         return cursor([], 0);
+      }
+
+      if (normalized.startsWith("INSERT OR REPLACE INTO application_jobs")) {
+        const [id, status] = Schema.decodeUnknownSync(Schema.Tuple([Schema.String, Schema.String]))(
+          bindings,
+        );
+
+        jobs.set(id, status);
+
+        return cursor([], 1);
       }
 
       if (normalized.startsWith("SELECT run_at FROM")) {

--- a/packages/effect-cf/tests/DurableObjectAlarm.test.ts
+++ b/packages/effect-cf/tests/DurableObjectAlarm.test.ts
@@ -244,9 +244,7 @@ it.effect.each(["lost reply", "interruption"] as const)(
           Effect.runPromise(
             Deferred.succeed(committed, undefined).pipe(
               Effect.andThen(Deferred.await(releaseReply)),
-              Effect.andThen(
-                kind === "lost reply" ? Effect.fail(new Error("reply lost")) : Effect.void,
-              ),
+              Effect.andThen(kind === "lost reply" ? Effect.fail("reply lost") : Effect.void),
             ),
           ),
       });

--- a/packages/effect-cf/tests/DurableObjectAlarm.worker.test.ts
+++ b/packages/effect-cf/tests/DurableObjectAlarm.worker.test.ts
@@ -1,0 +1,170 @@
+import { env } from "cloudflare:workers";
+import { assert, it } from "@effect/vitest";
+import { DateTime, Deferred, Effect, Exit, Fiber, Layer } from "effect";
+import { TestClock } from "effect/testing";
+import { SqlClient } from "effect/unstable/sql";
+
+import { DurableObjectAlarm, DurableObjectSqlite } from "../src/index";
+import * as PoolWorkers from "../src/Vitest";
+
+const services = Layer.merge(
+  DurableObjectAlarm.DurableObjectAlarm.layer,
+  DurableObjectSqlite.layer(),
+);
+// Far-future native deadlines keep these tests independent of the wall clock.
+const deadline = 4_000_000_000_000;
+const alarm = (id: string, offset: number): DurableObjectAlarm.ScheduleAlarmInput => ({
+  tag: "job",
+  id,
+  runAt: DateTime.makeUnsafe(deadline + offset),
+  payload: null,
+});
+
+it.effect("commits application SQL and mixed alarms together in workerd", () => {
+  const stub = env.TEST_COUNTER_DO!.getByName(crypto.randomUUID());
+
+  return PoolWorkers.runInDurableObject(stub, (_instance, state) =>
+    Effect.gen(function* () {
+      const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`CREATE TABLE jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL)`;
+      const result = yield* alarms.transaction((tx) =>
+        Effect.gen(function* () {
+          yield* sql`INSERT INTO jobs VALUES ('sql-client', 'ready')`;
+          yield* state.storage.sql.exec("INSERT INTO jobs VALUES (?, ?)", "storage", "ready");
+          yield* state.storage.put("version", 1);
+          yield* tx.scheduleAlarm(alarm("a", 2_000));
+          yield* tx.scheduleAlarm(alarm("b", 1_000));
+          yield* tx.scheduleAlarm(alarm("a", 3_000));
+          yield* tx.scheduleAlarm({ ...alarm("a", 4_000), tag: "other" });
+          yield* tx.cancelAlarm({ tag: "job", id: "b" });
+
+          return "committed";
+        }),
+      );
+
+      assert.strictEqual(result, "committed");
+      assert.deepStrictEqual(yield* sql`SELECT * FROM jobs ORDER BY id`, [
+        { id: "sql-client", status: "ready" },
+        { id: "storage", status: "ready" },
+      ]);
+      assert.strictEqual(yield* state.storage.get("version"), 1);
+      assert.strictEqual(yield* state.storage.getAlarm(), deadline + 3_000);
+      assert.deepStrictEqual(
+        yield* sql`SELECT tag, alarm_id, run_at FROM effect_cf_scheduled_alarms ORDER BY run_at`,
+        [
+          { tag: "job", alarm_id: "a", run_at: deadline + 3_000 },
+          { tag: "other", alarm_id: "a", run_at: deadline + 4_000 },
+        ],
+      );
+
+      yield* alarms.transaction((tx) =>
+        Effect.gen(function* () {
+          yield* sql`UPDATE jobs SET status = 'cancelled'`;
+          yield* tx.cancelAlarm({ tag: "job", id: "a" });
+          yield* tx.cancelAlarm({ tag: "other", id: "a" });
+        }),
+      );
+
+      assert.deepStrictEqual(yield* sql`SELECT DISTINCT status FROM jobs`, [
+        { status: "cancelled" },
+      ]);
+      assert.deepStrictEqual(yield* sql`SELECT * FROM effect_cf_scheduled_alarms`, []);
+      assert.isNull(yield* state.storage.getAlarm());
+    }).pipe(Effect.provide(services)),
+  );
+});
+
+it.effect.each(["typed failure", "defect", "interruption"] as const)(
+  "rolls back application SQL and alarms on %s in workerd",
+  (kind) => {
+    const stub = env.TEST_COUNTER_DO!.getByName(crypto.randomUUID());
+
+    return PoolWorkers.runInDurableObject(stub, (_instance, state) =>
+      Effect.gen(function* () {
+        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+        const sql = yield* SqlClient.SqlClient;
+        const started = yield* Deferred.make<void>();
+
+        yield* sql`CREATE TABLE jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL)`;
+        yield* sql`INSERT INTO jobs VALUES ('job', 'before')`;
+        yield* alarms.scheduleAlarm(alarm("a", 2_000));
+        const fiber = yield* Effect.forkChild(
+          alarms.transaction((tx) =>
+            Effect.gen(function* () {
+              yield* sql`UPDATE jobs SET status = 'during'`;
+              yield* state.storage.put("uncommitted", true);
+              yield* tx.cancelAlarm({ tag: "job", id: "a" });
+              yield* tx.scheduleAlarm(alarm("b", 1_000));
+              yield* Deferred.succeed(started, undefined);
+
+              if (kind === "interruption") {
+                return yield* Effect.never;
+              }
+
+              return yield* kind === "typed failure" ? Effect.fail("abort") : Effect.die("abort");
+            }),
+          ),
+        );
+
+        yield* Deferred.await(started);
+        if (kind === "interruption") {
+          fiber.interruptUnsafe();
+        }
+        const [exit] = yield* Fiber.awaitAll([fiber]);
+
+        assert.isTrue(Exit.isFailure(exit!));
+        assert.deepStrictEqual(yield* sql`SELECT * FROM jobs`, [{ id: "job", status: "before" }]);
+        assert.isUndefined(yield* state.storage.get("uncommitted"));
+        assert.deepStrictEqual(
+          yield* sql`SELECT alarm_id, run_at FROM effect_cf_scheduled_alarms`,
+          [{ alarm_id: "a", run_at: deadline + 2_000 }],
+        );
+        assert.strictEqual(yield* state.storage.getAlarm(), deadline + 2_000);
+      }).pipe(Effect.provide(services)),
+    );
+  },
+);
+
+it.effect.each([undefined, "10 seconds"] as const)(
+  "preserves a handler's transactional replacement after acknowledgement, repeat %s",
+  (repeatEvery) => {
+    const stub = env.TEST_COUNTER_DO!.getByName(crypto.randomUUID());
+
+    return PoolWorkers.runInDurableObject(stub, (_instance, state) =>
+      Effect.gen(function* () {
+        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+        const sql = yield* SqlClient.SqlClient;
+
+        yield* sql`CREATE TABLE jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL)`;
+        yield* alarms.scheduleAlarm({ ...alarm("a", 0), repeatEvery });
+        yield* TestClock.setTime(deadline);
+        const result = yield* alarms.processDueAlarms((event) =>
+          alarms.transaction((tx) =>
+            Effect.gen(function* () {
+              yield* sql`INSERT INTO jobs VALUES (${event.id}, 'handled')`;
+              yield* tx.scheduleAlarm({ ...alarm(event.id, 60_000), payload: "replacement" });
+            }),
+          ),
+        );
+
+        assert.strictEqual(result.handled.length, 1);
+        assert.deepStrictEqual(result.failed, []);
+        assert.deepStrictEqual(yield* sql`SELECT * FROM jobs`, [{ id: "a", status: "handled" }]);
+        assert.deepStrictEqual(
+          yield* sql`SELECT alarm_id, run_at, repeat_every_ms, payload FROM effect_cf_scheduled_alarms`,
+          [
+            {
+              alarm_id: "a",
+              run_at: deadline + 60_000,
+              repeat_every_ms: null,
+              payload: '"replacement"',
+            },
+          ],
+        );
+        assert.strictEqual(yield* state.storage.getAlarm(), deadline + 60_000);
+      }).pipe(Effect.provide(services)),
+    );
+  },
+);

--- a/packages/effect-cf/tests/durable-alarm.test-d.ts
+++ b/packages/effect-cf/tests/durable-alarm.test-d.ts
@@ -1,0 +1,55 @@
+import { expectTypeOf } from "vitest";
+import { Context, DateTime, Effect, Schema } from "effect";
+import { SqlClient, type SqlError } from "effect/unstable/sql";
+
+import { DurableObjectAlarm, DurableObjectState, DurableObjectStorage } from "../src/index";
+
+class Application extends Context.Service<Application, { readonly id: string }>()("Application") {}
+class ApplicationError extends Schema.TaggedError<ApplicationError>()("ApplicationError", {}) {}
+
+declare const alarms: DurableObjectAlarm.AlarmScheduler;
+declare const application: Effect.Effect<number, ApplicationError, Application>;
+
+expectTypeOf(alarms.transaction(() => application)).toEqualTypeOf<
+  Effect.Effect<number, ApplicationError | DurableObjectStorage.StorageOperationError, Application>
+>();
+
+const composed = alarms.transaction((tx) =>
+  Effect.gen(function* () {
+    const app = yield* Application;
+    const sql = yield* SqlClient.SqlClient;
+    const state = yield* DurableObjectState.DurableObjectState;
+
+    yield* sql`INSERT INTO application_jobs (id) VALUES (${app.id})`;
+    yield* state.storage.put("last-job", app.id);
+    yield* tx.scheduleAlarm({
+      tag: "job",
+      id: app.id,
+      payload: null,
+      runAt: DateTime.makeUnsafe(1),
+    });
+    yield* tx.cancelAlarm({ tag: "obsolete", id: app.id });
+
+    return yield* application;
+  }),
+);
+
+expectTypeOf(composed).toEqualTypeOf<
+  Effect.Effect<
+    number,
+    | ApplicationError
+    | SqlError.SqlError
+    | DurableObjectStorage.StorageOperationError
+    | DurableObjectAlarm.InvalidAlarmRefError
+    | DurableObjectAlarm.InvalidAlarmPayloadError
+    | DurableObjectAlarm.InvalidRepeatEveryError,
+    Application | SqlClient.SqlClient | DurableObjectState.DurableObjectState
+  >
+>();
+
+declare const tx: DurableObjectAlarm.AlarmTransaction;
+
+// @ts-expect-error The callback only exposes mutations, not another transaction boundary.
+tx.transaction(() => Effect.void);
+// @ts-expect-error Dispatch and external handler work do not belong in the transaction.
+tx.processDueAlarms(() => Effect.void);

--- a/packages/effect-cf/tests/fixtures/alarm-transaction-consumer.ts
+++ b/packages/effect-cf/tests/fixtures/alarm-transaction-consumer.ts
@@ -1,0 +1,24 @@
+import { DateTime, Effect, Layer } from "effect";
+import { SqlClient } from "effect/unstable/sql";
+import { DurableObjectAlarm, DurableObjectSqlite } from "effect-cf";
+
+export const AlarmStorageLive = Layer.merge(
+  DurableObjectAlarm.DurableObjectAlarm.layer,
+  DurableObjectSqlite.layer(),
+);
+
+export const scheduleJob = Effect.fn("scheduleJob")(function* (id: string, runAt: DateTime.Utc) {
+  const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`CREATE TABLE IF NOT EXISTS jobs (id TEXT PRIMARY KEY, run_at INTEGER NOT NULL)`;
+
+  return yield* alarms.transaction((tx) =>
+    Effect.gen(function* () {
+      yield* sql`INSERT OR REPLACE INTO jobs (id, run_at) VALUES (${id}, ${DateTime.toEpochMillis(runAt)})`;
+      yield* tx.scheduleAlarm({ tag: "job", id, runAt, payload: null });
+
+      return id;
+    }),
+  );
+});


### PR DESCRIPTION
## Summary

Applications can now commit their storage rows and logical alarm changes in one native SQLite Durable Object transaction. Previously, every standalone schedule or cancel opened its own transaction, leaving no supported way to commit an application obligation and its wake together.

The new [`alarms.transaction(tx => effect)` boundary](https://github.com/danieljvdm/effect-cf/blob/772ed00abfe5b5d49dc1cde571a48d4d949cc15e/packages/effect-cf/src/DurableObjectAlarm.ts#L573) reuses the existing storage transaction and preserves the caller's success value, typed errors, and service requirements. Its schedule and cancel methods run in the callback's fiber and reject escaped or forked use. Standalone methods share the same mutation rules, and the boundary reconciles the native alarm once before commit to the earliest remaining deadline. Conditional acknowledgement still preserves a handler's replacement.

Application queries can use the existing storage wrapper or `@effect/sql-sqlite-do`'s `SqlClient` backed by the same object. The [compiling consumer example](https://github.com/danieljvdm/effect-cf/blob/772ed00abfe5b5d49dc1cde571a48d4d949cc15e/packages/effect-cf/tests/fixtures/alarm-transaction-consumer.ts) and documentation show the composition. Failures before commit roll back application rows, logical alarms, and native alarm changes together; interruption or a lost reply after commit does not undo committed state. External effects remain outside the transaction, and consumers still need to durably pre-arm a later wake before fallible external work.

Includes a minor changeset. Publication is pending; no released package version contains this API yet.

Closes #134. Related to danieljvdm/effect-agent#211.

## Validation

- `vp check` passed.
- `vp test` passed with 430 tests passing and 3 existing skips. The [six workerd cases](https://github.com/danieljvdm/effect-cf/blob/772ed00abfe5b5d49dc1cde571a48d4d949cc15e/packages/effect-cf/tests/DurableObjectAlarm.worker.test.ts) cover both application storage adapters, mixed alarm operations, rollback on typed failure, defect and interruption, and acknowledgement preserving one-shot and repeating handler replacements.
- `vp run ready` passed, including formatting, linting, tests, typechecks, package builds, and the example Worker's deployment dry run.
- `vp run --no-cache effect-cf#typecheck` passed, including the public type contract and consumer example.

Deterministic tests also cover native `setAlarm` and `deleteAlarm` failures, rejection of escaped transaction handles, and committed state surviving a lost reply or interruption after commit.
