### PR TITLE
feat(effect-cf): send Effect spans to Cloudflare Observability

### DIFF
--- a/.changeset/native-cloudflare-spans.md
+++ b/.changeset/native-cloudflare-spans.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Add `CloudflareTracer.layer` to send existing Effect spans to Cloudflare Workers Observability. Provide it per invocation through `Worker.make`'s `eventLayer` and enable tracing in Wrangler to see Effect operations alongside automatic platform spans, with context preserved across concurrent fibers.

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
     },
     "packages/effect-cf": {
       "name": "effect-cf",
-      "version": "0.35.0",
+      "version": "0.37.0",
       "devDependencies": {
         "@cloudflare/computer": "0.2.0",
         "@cloudflare/containers": "catalog:",
@@ -56,6 +56,7 @@
         "@platformatic/vfs": "^0.4.0",
         "effect": "catalog:",
         "esbuild": "^0.28.1",
+        "miniflare": "catalog:",
         "vite-plus": "catalog:",
         "vitest": "catalog:",
       },

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -49,6 +49,51 @@ The [counter example](https://github.com/danieljvdm/effect-cf/tree/main/examples
 
 For atomic application writes and alarm changes, see the [alarm transaction example](tests/fixtures/alarm-transaction-consumer.ts) and [API contract](src/DurableObjectAlarm.ts).
 
+## Cloudflare Observability traces
+
+`CloudflareTracer.layer` sends existing `Effect.withSpan` and named `Effect.fn`
+spans to Cloudflare's trace waterfall, alongside automatic platform spans.
+
+```ts
+import { Effect, Layer } from "effect";
+import { CloudflareTracer, Worker } from "effect-cf";
+
+export default Worker.make(Layer.empty, {
+  eventLayer: CloudflareTracer.layer,
+  fetch: Effect.sync(() => new Response("Hello")).pipe(Effect.withSpan("greet")),
+});
+```
+
+Enable tracing in `wrangler.jsonc`:
+
+```jsonc
+{
+  "compatibility_date": "2026-08-25",
+  "observability": {
+    "traces": { "enabled": true },
+  },
+}
+```
+
+Build the layer per invocation with `eventLayer`. It captures the current
+Cloudflare async context, so do not put it in a runtime layer cached across
+requests. Standalone Effect programs can provide it around each invocation.
+Nested spans, concurrent fibers, and resumed work restore the appropriate span
+context. Cloudflare handles sampling and export; no exporter endpoint or flush
+is needed.
+
+String, number, and boolean attributes are forwarded. Other attributes, span
+events, and links remain Effect-local. Completion is recorded as `effect.exit`
+with `success`, `failure`, or `interrupted`; Cloudflare does not expose a setter
+for native outcome status. Effect IDs remain separate from Cloudflare's opaque
+trace/span IDs. Explicit external parents cannot join a Cloudflare trace by ID,
+and `root: true` starts under the invocation's captured context.
+
+This layer replaces the active Effect tracer. When combining it with
+`CloudflareOtlp`, select only `logs` and/or `metrics` in the OTLP layer. See
+[Cloudflare's custom span API](https://developers.cloudflare.com/workers/observability/traces/custom-spans/)
+for platform limitations.
+
 ## Native RPC tracing
 
 `call()`, `scopedCall()`, and definition methods create one CLIENT span named `binding/method`, covering argument encoding, the native RPC wait, and success decoding. Raw `rpc()` retains Cloudflare's pipelined result without creating a span. Wrap its complete lifetime with `RpcTracing.withRpcClientSpan` when tracing raw calls.

--- a/packages/effect-cf/package.json
+++ b/packages/effect-cf/package.json
@@ -85,6 +85,7 @@
     "@platformatic/vfs": "^0.4.0",
     "effect": "catalog:",
     "esbuild": "^0.28.1",
+    "miniflare": "catalog:",
     "vite-plus": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/effect-cf/src/CloudflareTracer.ts
+++ b/packages/effect-cf/src/CloudflareTracer.ts
@@ -1,0 +1,92 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { tracing } from "cloudflare:workers";
+import { Cause, Effect, Exit, Layer, Option, Predicate, Tracer } from "effect";
+
+type SpanOptions = Parameters<Tracer.Tracer["span"]>[0];
+type RunInContext = ReturnType<typeof AsyncLocalStorage.snapshot>;
+type CloudflareSpan = Parameters<Parameters<typeof tracing.startActiveSpan>[1]>[0];
+
+class Span extends Tracer.NativeSpan {
+  constructor(
+    options: SpanOptions,
+    readonly runInContext: RunInContext,
+    readonly cloudflareSpan?: CloudflareSpan,
+  ) {
+    super({ ...options, sampled: options.sampled && (cloudflareSpan?.isTraced ?? false) });
+  }
+
+  // Effect's tracer contract accepts arbitrary attributes; only CF-supported scalars cross the boundary.
+  // oxlint-disable-next-line anti-slop/no-unknown-parameters
+  override attribute(key: string, value: unknown): void {
+    super.attribute(key, value);
+
+    if (Predicate.isString(value) || Predicate.isNumber(value) || Predicate.isBoolean(value)) {
+      this.cloudflareSpan?.setAttribute(key, value);
+    }
+  }
+
+  override end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {
+    if (this.status._tag === "Ended") return;
+
+    super.end(endTime, exit);
+    this.cloudflareSpan?.setAttribute(
+      "effect.exit",
+      Exit.isSuccess(exit)
+        ? "success"
+        : Cause.hasInterruptsOnly(exit.cause)
+          ? "interrupted"
+          : "failure",
+    );
+    this.cloudflareSpan?.end();
+  }
+}
+
+/**
+ * Sends Effect spans to Cloudflare Workers Observability using the runtime's
+ * custom span API. Build this layer inside each invocation, for example with
+ * `Worker.make(Services, { eventLayer: CloudflareTracer.layer, fetch })`.
+ * It captures the invocation's async context and must not be cached across requests.
+ *
+ * Enable `observability.traces.enabled` in Wrangler. Cloudflare owns sampling
+ * and export; no OTLP exporter or flush is required. Scalar attributes are
+ * forwarded; other attributes, events, and links remain Effect-local. Completion
+ * is recorded as `effect.exit`, since Cloudflare has no outcome-setting API.
+ * Effect trace/span IDs remain independent of Cloudflare's opaque IDs. External
+ * parents and `root: true` cannot override the invocation's Cloudflare trace.
+ */
+export const layer: Layer.Layer<never> = Layer.effect(
+  Tracer.Tracer,
+  Effect.sync(() => {
+    const invocationContext = AsyncLocalStorage.snapshot();
+    const contextFor = (span: Tracer.AnySpan | undefined): RunInContext => {
+      while (span?._tag === "Span") {
+        if (span instanceof Span) return span.runInContext;
+
+        // Effect can install a no-op span while tracing is locally disabled.
+        span = Option.getOrUndefined(span.parent);
+      }
+
+      return invocationContext;
+    };
+
+    return Tracer.make({
+      span(options) {
+        const parentContext = options.root
+          ? invocationContext
+          : contextFor(Option.getOrUndefined(options.parent));
+
+        if (!options.sampled) return new Span(options, parentContext);
+
+        return parentContext(() =>
+          tracing.startActiveSpan(
+            options.name,
+            (span) => new Span(options, AsyncLocalStorage.snapshot(), span),
+          ),
+        );
+      },
+      context(primitive, fiber) {
+        return contextFor(fiber.currentSpan)(() => primitive["~effect/Effect/evaluate"](fiber));
+      },
+    });
+  }),
+);

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -5,6 +5,7 @@ export * as Binding from "./Binding";
 export * as BrowserRendering from "./BrowserRendering";
 export * as Cache from "./Cache";
 export * as CloudflareOtlp from "./CloudflareOtlp";
+export * as CloudflareTracer from "./CloudflareTracer";
 export * as ContainerNamespace from "./ContainerNamespace";
 export * as D1 from "./D1";
 export * as DurableObject from "./DurableObject";

--- a/packages/effect-cf/tests/CloudflareTracer.test.ts
+++ b/packages/effect-cf/tests/CloudflareTracer.test.ts
@@ -1,0 +1,196 @@
+import { expect, it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+import { build } from "esbuild";
+import { convertV4MiniflareOptions, Miniflare } from "miniflare";
+
+const TraceEvent = Schema.Struct({
+  spanContext: Schema.Struct({ traceId: Schema.String, spanId: Schema.optional(Schema.String) }),
+  event: Schema.Struct({
+    type: Schema.String,
+    name: Schema.optional(Schema.String),
+    spanId: Schema.optional(Schema.String),
+    info: Schema.optional(Schema.Unknown),
+  }),
+});
+const decodeTrace = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Array(TraceEvent)));
+const decodeAttributes = Schema.decodeUnknownSync(
+  Schema.Array(
+    Schema.Struct({
+      name: Schema.String,
+      value: Schema.Union([Schema.String, Schema.Number, Schema.Boolean]),
+    }),
+  ),
+);
+
+const bundle = Effect.fnUntraced(function* (name: string) {
+  const result = yield* Effect.promise(() =>
+    build({
+      entryPoints: [new URL(`./fixtures/${name}.ts`, import.meta.url).pathname],
+      bundle: true,
+      external: ["cloudflare:*", "node:*"],
+      format: "esm",
+      platform: "browser",
+      write: false,
+    }),
+  );
+
+  return result.outputFiles[0]!.text;
+});
+
+it.live(
+  "records Effect spans and platform children with isolated fiber and request contexts",
+  () =>
+    Effect.gen(function* () {
+      const script = yield* bundle("cloudflare-tracer-worker");
+      const collectorScript = yield* bundle("cloudflare-tracer-collector");
+      const mf = yield* Effect.acquireRelease(
+        Effect.sync(
+          () =>
+            new Miniflare(
+              convertV4MiniflareOptions({
+                workers: [
+                  {
+                    name: "traced",
+                    modules: true,
+                    script,
+                    compatibilityDate: "2026-08-25",
+                    compatibilityFlags: ["streaming_tail_worker", "tail_worker_user_spans"],
+                    streamingTails: ["collector"],
+                    outboundService: "backend",
+                  },
+                  {
+                    name: "untraced",
+                    modules: true,
+                    script,
+                    compatibilityDate: "2026-08-25",
+                    outboundService: "backend",
+                  },
+                  {
+                    name: "collector",
+                    modules: true,
+                    script: collectorScript,
+                    compatibilityDate: "2026-08-25",
+                  },
+                  {
+                    name: "backend",
+                    modules: true,
+                    script: 'export default { fetch() { return new Response("ok"); } };',
+                    compatibilityDate: "2026-08-25",
+                  },
+                ],
+              }),
+            ),
+        ),
+        (mf) => Effect.promise(() => mf.dispose()),
+      );
+      const responses = yield* Effect.promise(() =>
+        Promise.all([
+          mf.dispatchFetch("https://worker.test/one"),
+          mf.dispatchFetch("https://worker.test/two"),
+        ]),
+      );
+
+      for (const response of responses) {
+        expect(response.status).toBe(200);
+        expect(yield* Effect.promise(() => response.json())).toEqual({
+          result: ["left", "right"],
+          sampled: true,
+        });
+      }
+
+      const collector = yield* Effect.promise(() => mf.getWorker("collector"));
+      const traces = yield* Effect.forEach([1, 2], () =>
+        Effect.promise(() => collector.fetch("https://collector.test/")).pipe(
+          Effect.flatMap((response) => Effect.promise(() => response.text())),
+          Effect.map(decodeTrace),
+        ),
+      );
+
+      expect(new Set(traces.map((trace) => trace[0]!.spanContext.traceId)).size).toBe(2);
+      const requestIds: Array<string | number | boolean | undefined> = [];
+
+      for (const trace of traces) {
+        const spans = trace.filter(({ event }) => event.type === "spanOpen");
+        const span = (name: string) => {
+          const matches = spans.filter(({ event }) => event.name === name);
+
+          expect(matches).toHaveLength(1);
+
+          return matches[0]!;
+        };
+        const attributes = (id: string) =>
+          Object.fromEntries(
+            trace
+              .filter(
+                ({ event, spanContext }) =>
+                  event.type === "attributes" && spanContext.spanId === id,
+              )
+              .flatMap(({ event }) =>
+                decodeAttributes(event.info).map(({ name, value }) => [name, value]),
+              ),
+          );
+        const operation = span("operation").event.spanId!;
+        const branches = spans.filter(({ event }) => event.name === "branch");
+
+        expect(branches).toHaveLength(2);
+        expect(span("operation").spanContext.spanId).toBe(span("http.server GET").event.spanId);
+        expect(span("http.server GET").spanContext.spanId).toBe(trace[0]!.event.spanId);
+
+        for (const branch of branches) {
+          const id = branch.event.spanId!;
+          const name = attributes(id).branch;
+
+          expect(branch.spanContext.spanId).toBe(operation);
+          expect(span(`${name}.native`).spanContext.spanId).toBe(id);
+          expect(
+            spans.filter(
+              ({ event, spanContext }) => event.name === "fetch" && spanContext.spanId === id,
+            ),
+          ).toHaveLength(1);
+        }
+
+        for (const name of ["failure", "defect", "interrupted"]) {
+          expect(span(name).spanContext.spanId).toBe(operation);
+          expect(attributes(span(name).event.spanId!)["effect.exit"]).toBe(
+            name === "interrupted" ? "interrupted" : "failure",
+          );
+        }
+
+        expect(span("root").spanContext.spanId).toBe(trace[0]!.event.spanId);
+        expect(span("root.native").spanContext.spanId).toBe(span("root").event.spanId);
+        expect(span("after.native").spanContext.spanId).toBe(operation);
+        expect(span("unsampled.native").spanContext.spanId).toBe(operation);
+        expect(spans.some(({ event }) => event.name === "unsampled")).toBe(false);
+        expect(span("disabled.native").spanContext.spanId).toBe(operation);
+        expect(spans.some(({ event }) => event.name === "disabled")).toBe(false);
+        expect(attributes(operation)).toMatchObject({
+          "scalar.number": 42,
+          "scalar.boolean": true,
+          "effect.exit": "success",
+        });
+        expect(attributes(operation)).not.toHaveProperty("unsupported");
+        requestIds.push(attributes(operation)["request.id"]);
+
+        for (const { event, spanContext } of spans) {
+          expect(spanContext.traceId).toBe(trace[0]!.spanContext.traceId);
+          expect(
+            trace.filter(
+              (entry) =>
+                entry.event.type === "spanClose" && entry.spanContext.spanId === event.spanId,
+            ),
+          ).toHaveLength(1);
+        }
+      }
+
+      expect(requestIds.toSorted()).toEqual(["/one", "/two"]);
+      const untraced = yield* Effect.promise(() => mf.getWorker("untraced"));
+      const response = yield* Effect.promise(() => untraced.fetch("https://worker.test/untraced"));
+
+      expect(response.status).toBe(200);
+      expect(yield* Effect.promise(() => response.json())).toEqual({
+        result: ["left", "right"],
+        sampled: false,
+      });
+    }).pipe(Effect.scoped),
+  { timeout: 30_000 },
+);

--- a/packages/effect-cf/tests/Packaging.test.ts
+++ b/packages/effect-cf/tests/Packaging.test.ts
@@ -1,5 +1,6 @@
+import { expect, it } from "@effect/vitest";
+import { Effect } from "effect";
 import { build, type Plugin } from "esbuild";
-import { expect, test } from "vitest";
 
 const rejectOptionalPeers: Plugin = {
   name: "reject-optional-peers",
@@ -10,16 +11,21 @@ const rejectOptionalPeers: Plugin = {
   },
 };
 
-test("the root package bundles Durable Object consumers without optional peers", async () => {
-  const result = await build({
-    entryPoints: [new URL("./fixtures/durable-object-consumer.ts", import.meta.url).pathname],
-    bundle: true,
-    external: ["cloudflare:*"],
-    format: "esm",
-    platform: "browser",
-    plugins: [rejectOptionalPeers],
-    write: false,
-  });
+it.live("the root package bundles Durable Object consumers without optional peers", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.promise(() =>
+      build({
+        entryPoints: [new URL("./fixtures/durable-object-consumer.ts", import.meta.url).pathname],
+        bundle: true,
+        // Workers provides async_hooks natively at our supported compatibility date.
+        external: ["cloudflare:*", "node:async_hooks"],
+        format: "esm",
+        platform: "browser",
+        plugins: [rejectOptionalPeers],
+        write: false,
+      }),
+    );
 
-  expect(result.outputFiles).toHaveLength(1);
-});
+    expect(result.outputFiles).toHaveLength(1);
+  }),
+);

--- a/packages/effect-cf/tests/fixtures/cloudflare-tracer-collector.ts
+++ b/packages/effect-cf/tests/fixtures/cloudflare-tracer-collector.ts
@@ -1,0 +1,34 @@
+import { Predicate } from "effect";
+
+// Native tail callbacks collect the workerd events without adding instrumentation.
+const traces: Array<Array<TailStream.TailEvent<TailStream.EventType>>> = [];
+const waiters: Array<(events: Array<TailStream.TailEvent<TailStream.EventType>>) => void> = [];
+
+export default {
+  tailStream(onset) {
+    const events: Array<TailStream.TailEvent<TailStream.EventType>> = [onset];
+
+    return (event) => {
+      events.push(event);
+
+      if (event.event.type === "outcome") {
+        const resolve = waiters.shift();
+
+        if (resolve) resolve(events);
+        else traces.push(events);
+      }
+    };
+  },
+  async fetch() {
+    const events =
+      traces.shift() ??
+      (await new Promise<Array<TailStream.TailEvent<TailStream.EventType>>>((resolve) =>
+        waiters.push(resolve),
+      ));
+
+    return new Response(
+      JSON.stringify(events, (_, value) => (Predicate.isBigInt(value) ? value.toString() : value)),
+      { headers: { "content-type": "application/json" } },
+    );
+  },
+} satisfies ExportedHandler;

--- a/packages/effect-cf/tests/fixtures/cloudflare-tracer-worker.ts
+++ b/packages/effect-cf/tests/fixtures/cloudflare-tracer-worker.ts
@@ -1,0 +1,65 @@
+import { tracing } from "cloudflare:workers";
+import { Deferred, Effect, Fiber, Layer } from "effect";
+
+import { CloudflareTracer, Worker } from "../../src/index";
+
+const branch = Effect.fn("branch")(function* (
+  name: string,
+  ready: Deferred.Deferred<void>,
+  other: Deferred.Deferred<void>,
+) {
+  yield* Effect.annotateCurrentSpan("branch", name);
+  yield* Deferred.succeed(ready, undefined);
+  yield* Deferred.await(other);
+  yield* Effect.yieldNow;
+  yield* Effect.promise(() => Promise.resolve());
+  yield* Effect.sync(() => tracing.enterSpan(`${name}.native`, () => undefined));
+  const response = yield* Effect.promise(() => fetch("https://backend.test/"));
+
+  yield* Effect.promise(() => response.text());
+
+  return name;
+});
+
+export default Worker.make(Layer.empty, {
+  eventLayer: CloudflareTracer.layer,
+  fetch: Effect.gen(function* () {
+    const request = yield* Worker.NativeRequest;
+    const id = new URL(request.url).pathname;
+
+    yield* Effect.annotateCurrentSpan("request.id", id);
+    yield* Effect.annotateCurrentSpan("scalar.number", 42);
+    yield* Effect.annotateCurrentSpan("scalar.boolean", true);
+    yield* Effect.annotateCurrentSpan("unsupported", { nested: true });
+    const left = yield* Deferred.make<void>();
+    const right = yield* Deferred.make<void>();
+    const result = yield* Effect.all([branch("left", left, right), branch("right", right, left)], {
+      concurrency: "unbounded",
+    });
+
+    yield* Effect.fail("expected").pipe(Effect.withSpan("failure"), Effect.exit);
+    yield* Effect.die("expected defect").pipe(Effect.withSpan("defect"), Effect.exit);
+    const started = yield* Deferred.make<void>();
+    const fiber = yield* Deferred.succeed(started, undefined).pipe(
+      Effect.andThen(Effect.never),
+      Effect.withSpan("interrupted"),
+      Effect.forkChild,
+    );
+
+    yield* Deferred.await(started);
+    yield* Fiber.interrupt(fiber);
+    yield* Effect.sync(() => tracing.enterSpan("root.native", () => undefined)).pipe(
+      Effect.withSpan("root", { root: true }),
+    );
+    yield* Effect.sync(() => tracing.enterSpan("after.native", () => undefined));
+    yield* Effect.sync(() => tracing.enterSpan("unsampled.native", () => undefined)).pipe(
+      Effect.withSpan("unsampled", { sampled: false }),
+    );
+    yield* Effect.sync(() => tracing.enterSpan("disabled.native", () => undefined)).pipe(
+      Effect.withSpan("disabled"),
+      Effect.withTracerEnabled(false),
+    );
+
+    return Response.json({ result, sampled: (yield* Effect.currentSpan).sampled });
+  }).pipe(Effect.withSpan("operation")),
+});


### PR DESCRIPTION
## Summary

Add an opt-in `CloudflareTracer.layer` that makes existing `Effect.withSpan` and named `Effect.fn` spans visible in Cloudflare Workers Observability, with automatic platform spans nested under the Effect operation that started them.

Cloudflare already traces operations such as `fetch`, but those spans do not explain which Effect application operation performed the work. This layer supplies that application context. No changes to Effect itself are required.

For concurrent Effect operations, the trace changes like this:

```diff
 Cloudflare request
-├── fetch
-└── fetch
+└── http.server GET
+    └── operation
+        ├── branch [left]
+        │   └── fetch
+        └── branch [right]
+            └── fetch
```

### Usage

Provide the tracer per invocation through `eventLayer`; existing application instrumentation can stay as it is:

```ts
import { Effect, Layer } from "effect";
import { CloudflareTracer, Worker } from "effect-cf";

export default Worker.make(Layer.empty, {
  eventLayer: CloudflareTracer.layer,
  fetch: Effect.sync(() => new Response("Hello")).pipe(
    Effect.withSpan("greet"),
  ),
});
```

Enable tracing in `wrangler.jsonc`:

```jsonc
{
  "compatibility_date": "2026-08-25",
  "observability": {
    "traces": { "enabled": true },
  },
}
```

### Context and lifecycle

The [tracer adapter](https://github.com/danieljvdm/effect-cf/blob/31f1f07aabf6fbfe182e4615c8efade91473a686/packages/effect-cf/src/CloudflareTracer.ts) creates a native span with `tracing.startActiveSpan`, captures its async context, and restores that context through Effect's existing tracer execution hook:

```text
Effect starts span  → create CF span + capture async context
Fiber runs/resumes → restore that span's CF context
fetch starts       → CF attaches it to the active span
Effect finishes    → record effect.exit + end CF span
```

The layer captures the invocation context, so it must not be cached in a runtime shared across requests. Cloudflare owns sampling and export; the adapter adds no exporter dependency or flush loop. The existing pinned Miniflare becomes a direct development dependency for the runtime integration test.

Scalar attributes are forwarded. Other attributes, span events, and links remain Effect-local. Completion is recorded as `effect.exit`; native outcome status and Cloudflare trace/span IDs are not exposed by the custom-span API. Explicit external parents cannot join a Cloudflare trace by ID.

Effect has one active tracer. Combining this layer with an OTLP trace layer replaces one tracer with the other. Use `CloudflareOtlp` for logs/metrics only, or configure [Cloudflare's OTLP export](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/) to send the combined native trace to an external destination. See the [usage and limitations](https://github.com/danieljvdm/effect-cf/blob/31f1f07aabf6fbfe182e4615c8efade91473a686/packages/effect-cf/README.md#cloudflare-observability-traces).

## Validation

- The [workerd integration test](https://github.com/danieljvdm/effect-cf/blob/31f1f07aabf6fbfe182e4615c8efade91473a686/packages/effect-cf/tests/CloudflareTracer.test.ts) captures actual streaming trace events and checks parent IDs for concurrent fibers and separate requests, native custom spans, automatic fetch children, scalar attributes, sampling/disabled tracing, root spans, failure/defect/interruption, and exactly one close event per span.
- `vp run check` passed: 431 tests passed, 3 existing skips, plus build, formatting, lint, and typechecks. `vp check` and the focused tracer/package-consumer tests also passed.
- A temporary deployed Worker returned `{"result":[200,200],"sampled":true}` after concurrent fetches and a handled Effect failure. **Dashboard persistence remains unverified:** the Observability API returned HTTP 403 with the configured credential. The hosted streaming-tail inspection flags were rejected as experimental; they are only used in the local test, not required by the adapter. All temporary Workers and collector storage were deleted.
