### PR TITLE
ci: pin npm 11 for Changesets publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,11 @@ jobs:
       # emits different declarations and needs an undeclared dependency.
       - run: vp run effect-cf#build
       - run: vp run effect-webtransport#build
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+      # Changesets 2.x expects an object from `npm info --json`; npm 12
+      # returns an array and makes already-published versions look unpublished.
+      # npm 11.19.0 supports trusted publishing and preserves that object format.
+      - name: Install npm for trusted publishing
+        run: npm install -g npm@11.19.0
       - name: Create GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
## Summary

Pin the [release workflow's npm install](https://github.com/danieljvdm/effect-cf/blob/dan/fix-actions-job-failure/.github/workflows/release.yml#L41) to 11.19.0 so Changesets recognizes versions that are already published. This version supports npm trusted publishing.

## What went wrong

The workflow installed `npm@latest`, currently 12.0.2. Its `npm info <package> --json` response is an array, but Changesets 2.31.0 reads `response.versions` from an object. The missing property becomes an empty version list, so Changesets attempts to publish every package.

In [the failed release](https://github.com/danieljvdm/effect-cf/actions/runs/33447595714/job/99670074359), `effect-cf@0.38.0` published successfully, but the attempt to republish `effect-webtransport@0.3.0` failed the job. Pinning npm restores the response shape Changesets expects without adding a publish wrapper or suppressing failures.

## Validation

- Reproduced the exact registry query with npm 11.19.0 and 12.0.2. Both responses contain `0.3.0`; npm 11 returns an object with `.versions`, while npm 12 returns an array with `.[0].versions`.
- Confirmed `effect-cf@0.38.0` exists on npm and its GitHub release exists.
- `vp check` and `git diff --check` passed.
- Package tests and a live publish were skipped because this only changes the CI npm version. No changeset is needed.
