### PR TITLE
docs: add Worker, alarm, KV, and R2 examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ const CounterLive = Counter.make(DurableObjectAlarm.DurableObjectAlarm.layer, {
       const state = yield* DurableObjectState.DurableObjectState;
       const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
 
+      // Save the count and schedule its alarm atomically: both commit or both roll back.
       return yield* alarms.transaction((tx) =>
         Effect.gen(function* () {
           const count = ((yield* state.storage.get<number>("count")) ?? 0) + 1;

--- a/README.md
+++ b/README.md
@@ -5,7 +5,110 @@ Effect services for Cloudflare Workers and Durable Objects.
 - [effect-cf](packages/effect-cf): Worker and Durable Object entrypoints, typed bindings, and storage.
 - [effect-webtransport](packages/effect-webtransport): WebTransport sessions, streams, datagrams, and Effect Socket adapters.
 
-Start with the [counter example](examples/counter). It runs a Worker and a Durable Object in one project, with no frontend or external services.
+## Worker + Durable Object
+
+Each URL path names a counter. The Worker calls its Durable Object through a typed RPC method. The object persists the count and schedules a report for 30 seconds later. Keep hitting it and the report moves back; stop and the object wakes up to log the count.
+
+```ts
+import { DateTime, Effect, Schema } from "effect";
+import { DurableObject, DurableObjectAlarm, DurableObjectState, Worker } from "effect-cf";
+
+class Counter extends DurableObject.Tag<Counter>()("Counter", {
+  increment: DurableObject.method({ success: Schema.Number }),
+}) {}
+
+const CounterAlarms = DurableObjectAlarm.define({
+  report: Schema.Struct({ count: Schema.Number }),
+});
+
+const CounterLive = Counter.make(DurableObjectAlarm.DurableObjectAlarm.layer, {
+  rpc: {
+    increment: Effect.fn("Counter.increment")(function* () {
+      const state = yield* DurableObjectState.DurableObjectState;
+      const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+
+      return yield* alarms.transaction((tx) =>
+        Effect.gen(function* () {
+          const count = ((yield* state.storage.get<number>("count")) ?? 0) + 1;
+          const now = yield* DateTime.now;
+
+          yield* state.storage.put("count", count);
+          yield* tx.scheduleAlarm({
+            tag: "report",
+            id: "idle",
+            runAt: DateTime.add(now, { seconds: 30 }),
+            payload: { count },
+          });
+
+          return count;
+        }),
+      );
+    }),
+  },
+  alarms: CounterAlarms.handlers({
+    report: ({ payload }) => Effect.log(`Counter went quiet at ${payload.count} visits`),
+  }),
+});
+
+export class CounterDurableObject extends CounterLive {}
+
+export default Worker.make(Counter.layer({ binding: "COUNTERS" }), {
+  fetch: Effect.gen(function* () {
+    const request = yield* Worker.NativeRequest;
+    const counters = yield* Counter;
+    const count = yield* counters.byName(new URL(request.url).pathname).increment();
+
+    return Response.json({ count });
+  }),
+});
+```
+
+`Counter` defines the RPC contract; `Counter.make` implements it. `Counter.layer` connects the client to the `COUNTERS` Wrangler binding. `Worker.make` owns the Effect runtime, so handlers can yield services and return native `Response` objects.
+
+`DurableObjectAlarm` stores named alarms in SQLite and manages the DO's single native alarm. Reusing `{ tag: "report", id: "idle" }` replaces the pending report. `transaction` commits the count and alarm together; `define` decodes the payload before dispatching to its typed handler. Delivery is [at least once](https://developers.cloudflare.com/durable-objects/api/alarms/), so this log can repeat on retries.
+
+This is the complete [counter example](examples/counter/src/index.ts). Its [Wrangler config](examples/counter/wrangler.jsonc) declares the binding and SQLite storage migration. Run it from this repository:
+
+```sh
+vp install
+vp run dev
+```
+
+Then run `curl http://localhost:8787/visits` in another terminal. Repeat it to increment the count, or use another path for a separate counter. Stop for 30 seconds and watch the `vp run dev` terminal for the alarm's report. No frontend or external services needed.
+
+## KV and R2
+
+Other bindings use the same service/layer pattern. Here, R2 stores a report and schema-checked KV maps its name to the object key:
+
+```ts
+import { Effect, Layer, Schema } from "effect";
+import { Kv, R2 } from "effect-cf";
+
+class ReportIndex extends Kv.Tag<ReportIndex>()("ReportIndex", {
+  key: Schema.String,
+  value: Schema.String,
+}) {}
+
+class Reports extends R2.Tag<Reports>()("Reports") {}
+
+export const ReportsLive = Layer.mergeAll(
+  ReportIndex.layer({ binding: "REPORT_INDEX" }),
+  Reports.layer({ binding: "REPORTS" }),
+);
+
+export const saveReport = Effect.fn("saveReport")(function* (name: string, csv: string) {
+  const reports = yield* Reports;
+  const index = yield* ReportIndex;
+  const key = `${name}.csv`;
+
+  yield* reports.put(key, csv);
+  yield* index.put(name, key);
+});
+```
+
+Declare `REPORT_INDEX` as a KV namespace and `REPORTS` as an R2 bucket in Wrangler, then pass `ReportsLive` to `Worker.make` to call `saveReport` from a handler. These are separate writes, not a cross-service transaction. Binding operations expose typed errors in Effect's error channel.
+
+See the [package docs](packages/effect-cf) for installation, tracing, and more APIs, including D1, Queues, Workflows, and WebSockets.
 
 ## Development
 

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,6 +1,6 @@
 # Counter
 
-One Worker, one Durable Object, one typed binding. Each URL path names a counter; each request increments its persisted value.
+One Worker, one Durable Object, one typed binding. Each URL path names a counter; each request increments its persisted value and schedules a report for 30 seconds later.
 
 From the repository root:
 
@@ -16,5 +16,7 @@ curl http://localhost:8787/visits
 ```
 
 Repeat the request to increment the count. Request another path for a separate counter. Wrangler stores local data under `.wrangler/`.
+
+Each increment replaces the pending `report/idle` alarm through `DurableObjectAlarm`, committing the count and schedule in one transaction. Stop making requests for 30 seconds and watch the dev terminal for `Counter went quiet at N visits`. The alarm handler receives a schema-decoded payload. Reports can repeat on retries; the alarm does not reset the count.
 
 [src/index.ts](src/index.ts) contains the application; [wrangler.jsonc](wrangler.jsonc) declares its binding and storage migration. `vp run counter-example#build` checks the deployment bundle without deploying it.

--- a/examples/counter/src/index.ts
+++ b/examples/counter/src/index.ts
@@ -1,21 +1,41 @@
-import { Effect, Layer, Schema } from "effect";
-import { DurableObject, DurableObjectState, Worker } from "effect-cf";
+import { DateTime, Effect, Schema } from "effect";
+import { DurableObject, DurableObjectAlarm, DurableObjectState, Worker } from "effect-cf";
 
 class Counter extends DurableObject.Tag<Counter>()("Counter", {
   increment: DurableObject.method({ success: Schema.Number }),
 }) {}
 
-const CounterLive = Counter.make(Layer.empty, {
+const CounterAlarms = DurableObjectAlarm.define({
+  report: Schema.Struct({ count: Schema.Number }),
+});
+
+const CounterLive = Counter.make(DurableObjectAlarm.DurableObjectAlarm.layer, {
   rpc: {
     increment: Effect.fn("Counter.increment")(function* () {
       const state = yield* DurableObjectState.DurableObjectState;
-      const count = (yield* state.storage.get<number>("count")) ?? 0;
+      const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
 
-      yield* state.storage.put("count", count + 1);
+      return yield* alarms.transaction((tx) =>
+        Effect.gen(function* () {
+          const count = ((yield* state.storage.get<number>("count")) ?? 0) + 1;
+          const now = yield* DateTime.now;
 
-      return count + 1;
+          yield* state.storage.put("count", count);
+          yield* tx.scheduleAlarm({
+            tag: "report",
+            id: "idle",
+            runAt: DateTime.add(now, { seconds: 30 }),
+            payload: { count },
+          });
+
+          return count;
+        }),
+      );
     }),
   },
+  alarms: CounterAlarms.handlers({
+    report: ({ payload }) => Effect.log(`Counter went quiet at ${payload.count} visits`),
+  }),
 });
 
 export class CounterDurableObject extends CounterLive {}

--- a/examples/counter/src/index.ts
+++ b/examples/counter/src/index.ts
@@ -15,6 +15,7 @@ const CounterLive = Counter.make(DurableObjectAlarm.DurableObjectAlarm.layer, {
       const state = yield* DurableObjectState.DurableObjectState;
       const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
 
+      // Save the count and schedule its alarm atomically: both commit or both roll back.
       return yield* alarms.transaction((tx) =>
         Effect.gen(function* () {
           const count = ((yield* state.storage.get<number>("count")) ?? 0) + 1;


### PR DESCRIPTION
## Summary

- Expand the [README](https://github.com/danieljvdm/effect-cf/blob/298205cc45cf7752d5afae84180a7c22f10a39a5/README.md) with a complete Worker + Durable Object example, typed RPC, persistent storage, and a compact KV/R2 example.
- Update the [runnable counter](https://github.com/danieljvdm/effect-cf/blob/298205cc45cf7752d5afae84180a7c22f10a39a5/examples/counter/src/index.ts) to demonstrate `DurableObjectAlarm`: each increment atomically saves the count and replaces a named report alarm due 30 seconds later. The handler receives a schema-decoded payload and logs the count. Document at-least-once delivery and local run instructions.
- No published package changes or changeset.

## Validation

- `vp check` passed with one existing unused-variable warning in `DurableObjectRpcWebSocket.ts`.
- `vp run counter-example#typecheck` and focused formatting/lint checks passed. Both README snippets were typechecked; the final counter snippet matches the runnable source exactly.
- `vp test packages/effect-cf/tests/DurableObjectAlarm.test.ts --project node`: 21 tests passed. The full suite was not run; this changes docs and an example, not package implementation.
- Local workerd smoke check via `vp run dev`: two requests to `/readme-alarm-smoke` returned `{"count":1}` and `{"count":2}`. After requests stopped, the alarm logged:

  ```text
  [19:25:54.055] INFO (#46): Counter went quiet at 2 visits
  ```
