### PR TITLE
feat: add schema-bound Durable Object alarm scheduling

### DIFF
--- a/.changeset/typed-durable-alarms.md
+++ b/.changeset/typed-durable-alarms.md
@@ -1,0 +1,9 @@
+---
+"effect-cf": minor
+---
+
+Add schema-bound scheduling, cancellation, and transactions to `DurableObjectAlarm.define`. Scheduling checks tag/payload pairs at compile time and schema-encodes payloads before storage.
+
+Durable Object entrypoints now provide the alarm scheduler automatically to application layers and handlers. Existing explicit layers and raw scheduler methods remain supported.
+
+Unknown stored alarm tags now report `StoredAlarmDecodeError` and follow the delivery failure policy instead of being silently acknowledged. Applications intentionally retiring tags can handle them through `onFailure`.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Save a document now and archive each revision to R2 in the background. The failu
 save document → process stops → scheduling never runs
 ```
 
-`alarms.transaction` commits the document and its delivery alarm together. Before commit, neither is saved; after commit, both survive a restart. Scheduling does not need to throw for this to matter.
+`DocumentAlarms.transaction` commits the document and its delivery alarm together. Before commit, neither is saved; after commit, both survive a restart. Scheduling does not need to throw for this to matter.
 
 Here is the Durable Object from the [runnable outbox example](examples/outbox/src/index.ts). The alarm's persisted payload is the outbox entry: it keeps the exact revision to deliver, even after the document changes again.
 
 ```ts
-import { DateTime, Effect, Layer, Schema } from "effect";
+import { DateTime, Effect, Schema } from "effect";
 import { DurableObject, DurableObjectAlarm, DurableObjectState, R2 } from "effect-cf";
 
 const Snapshot = Schema.Struct({ revision: Schema.Int, body: Schema.String });
@@ -34,66 +34,63 @@ const DocumentAlarms = DurableObjectAlarm.define({
   archive: Schema.Struct({ key: Schema.String, body: Schema.String }),
 });
 
-const DocumentLive = Documents.make(
-  Layer.merge(DurableObjectAlarm.DurableObjectAlarm.layer, Archive.layer({ binding: "ARCHIVE" })),
-  {
-    rpc: {
-      save: Effect.fn("Documents.save")(function* (body) {
-        const state = yield* DurableObjectState.DurableObjectState;
-        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+const DocumentLive = Documents.make(Archive.layer({ binding: "ARCHIVE" }), {
+  rpc: {
+    save: Effect.fn("Documents.save")(function* (body) {
+      const state = yield* DurableObjectState.DurableObjectState;
 
-        return yield* alarms.transaction((tx) =>
-          Effect.gen(function* () {
-            const previous = yield* state.storage.get<typeof Snapshot.Type>("document");
-            const revision = (previous?.revision ?? 0) + 1;
-            const name = state.id.name ?? state.id.toString();
-            const key = `${name}/${revision}.txt`;
-            const now = yield* DateTime.now;
+      return yield* DocumentAlarms.transaction((tx) =>
+        Effect.gen(function* () {
+          const previous = yield* state.storage.get<typeof Snapshot.Type>("document");
+          const revision = (previous?.revision ?? 0) + 1;
+          const name = state.id.name ?? state.id.toString();
+          const key = `${name}/${revision}.txt`;
+          const now = yield* DateTime.now;
 
-            // A restart cannot leave a saved revision with no delivery alarm.
-            yield* state.storage.put("document", { revision, body });
-            yield* tx.scheduleAlarm({
-              tag: "archive",
-              id: key,
-              // The demo leaves time to stop Wrangler before delivery.
-              runAt: DateTime.add(now, { seconds: 30 }),
-              payload: { key, body },
-            });
+          // A restart cannot leave a saved revision with no delivery alarm.
+          yield* state.storage.put("document", { revision, body });
+          yield* tx.scheduleAlarm({
+            tag: "archive",
+            id: key,
+            // The demo leaves time to stop Wrangler before delivery.
+            runAt: DateTime.add(now, { seconds: 30 }),
+            payload: { key, body },
+          });
 
-            return key;
-          }),
-        );
-      }),
-      read: Effect.fn("Documents.read")(function* () {
-        const state = yield* DurableObjectState.DurableObjectState;
+          return key;
+        }),
+      );
+    }),
+    read: Effect.fn("Documents.read")(function* () {
+      const state = yield* DurableObjectState.DurableObjectState;
 
-        return (yield* state.storage.get<typeof Snapshot.Type>("document")) ?? null;
-      }),
-    },
-    alarms: DocumentAlarms.handlers({
-      archive: Effect.fn("Documents.archive")(function* ({ tag, id, payload }) {
-        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
-        const archive = yield* Archive;
-        const now = yield* DateTime.now;
-
-        // Persist another wake BEFORE the external write, in case execution stops.
-        yield* alarms.scheduleAlarm({
-          tag,
-          id,
-          runAt: DateTime.add(now, { seconds: 30 }),
-          payload,
-        });
-
-        // Outside the transaction. Replays write the same key and exact content.
-        yield* archive.put(payload.key, payload.body);
-        yield* alarms.cancelAlarm({ tag, id });
-      }),
+      return (yield* state.storage.get<typeof Snapshot.Type>("document")) ?? null;
     }),
   },
-);
+  alarms: DocumentAlarms.handlers({
+    archive: Effect.fn("Documents.archive")(function* ({ tag, id, payload }) {
+      const archive = yield* Archive;
+      const now = yield* DateTime.now;
+
+      // Persist another wake BEFORE the external write, in case execution stops.
+      yield* DocumentAlarms.scheduleAlarm({
+        tag,
+        id,
+        runAt: DateTime.add(now, { seconds: 30 }),
+        payload,
+      });
+
+      // Outside the transaction. Replays write the same key and exact content.
+      yield* archive.put(payload.key, payload.body);
+      yield* DocumentAlarms.cancelAlarm({ tag, id });
+    }),
+  }),
+});
 
 export class DocumentDurableObject extends DocumentLive {}
 ```
+
+`Documents.make` provides the alarm scheduler automatically. `DocumentAlarms` types both scheduling and handling from the same schemas, including the transaction's `tx.scheduleAlarm`.
 
 The Worker routes `PUT /notes` and `GET /notes` through the typed `Documents` RPC binding. `GET /archive/notes/1.txt` reads R2. [Worker wiring](examples/outbox/src/index.ts) and [Wrangler bindings](examples/outbox/wrangler.jsonc) complete the application.
 

--- a/examples/outbox/README.md
+++ b/examples/outbox/README.md
@@ -4,7 +4,9 @@ A Durable Object stores the current document. Each save also queues an immutable
 
 ## Why the transaction exists
 
-Without a shared transaction, execution can stop after saving a revision but before scheduling its delivery. The saved revision survives, but nothing wakes up to archive it. `alarms.transaction` commits the document, delivery payload, and native wake together.
+Without a shared transaction, execution can stop after saving a revision but before scheduling its delivery. The saved revision survives, but nothing wakes up to archive it. `DocumentAlarms.transaction` commits the document, delivery payload, and native wake together.
+
+`Documents.make` provides the scheduler automatically. `DocumentAlarms` binds scheduling, cancellation, and handlers to the declared tags and payload schemas. Payloads are schema-encoded before storage and decoded when delivered.
 
 The alarm handler schedules a recovery wake before writing to R2. It cancels that wake only after R2 reports success. If the response is lost or execution stops after the upload, a retry writes the same key and content. Each revision has its own key, so retrying an old revision cannot overwrite a newer one.
 

--- a/examples/outbox/src/document.ts
+++ b/examples/outbox/src/document.ts
@@ -1,4 +1,4 @@
-import { DateTime, Effect, Layer, Schema } from "effect";
+import { DateTime, Effect, Schema } from "effect";
 import { DurableObject, DurableObjectAlarm, DurableObjectState, R2 } from "effect-cf";
 
 const Snapshot = Schema.Struct({ revision: Schema.Int, body: Schema.String });
@@ -14,62 +14,57 @@ const DocumentAlarms = DurableObjectAlarm.define({
   archive: Schema.Struct({ key: Schema.String, body: Schema.String }),
 });
 
-const DocumentLive = Documents.make(
-  Layer.merge(DurableObjectAlarm.DurableObjectAlarm.layer, Archive.layer({ binding: "ARCHIVE" })),
-  {
-    rpc: {
-      save: Effect.fn("Documents.save")(function* (body) {
-        const state = yield* DurableObjectState.DurableObjectState;
-        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+const DocumentLive = Documents.make(Archive.layer({ binding: "ARCHIVE" }), {
+  rpc: {
+    save: Effect.fn("Documents.save")(function* (body) {
+      const state = yield* DurableObjectState.DurableObjectState;
 
-        return yield* alarms.transaction((tx) =>
-          Effect.gen(function* () {
-            const previous = yield* state.storage.get<typeof Snapshot.Type>("document");
-            const revision = (previous?.revision ?? 0) + 1;
-            const name = state.id.name ?? state.id.toString();
-            const key = `${name}/${revision}.txt`;
-            const now = yield* DateTime.now;
+      return yield* DocumentAlarms.transaction((tx) =>
+        Effect.gen(function* () {
+          const previous = yield* state.storage.get<typeof Snapshot.Type>("document");
+          const revision = (previous?.revision ?? 0) + 1;
+          const name = state.id.name ?? state.id.toString();
+          const key = `${name}/${revision}.txt`;
+          const now = yield* DateTime.now;
 
-            // A restart cannot leave a saved revision with no delivery alarm.
-            yield* state.storage.put("document", { revision, body });
-            yield* tx.scheduleAlarm({
-              tag: "archive",
-              id: key,
-              // The demo leaves time to stop Wrangler before delivery.
-              runAt: DateTime.add(now, { seconds: 30 }),
-              payload: { key, body },
-            });
+          // A restart cannot leave a saved revision with no delivery alarm.
+          yield* state.storage.put("document", { revision, body });
+          yield* tx.scheduleAlarm({
+            tag: "archive",
+            id: key,
+            // The demo leaves time to stop Wrangler before delivery.
+            runAt: DateTime.add(now, { seconds: 30 }),
+            payload: { key, body },
+          });
 
-            return key;
-          }),
-        );
-      }),
-      read: Effect.fn("Documents.read")(function* () {
-        const state = yield* DurableObjectState.DurableObjectState;
+          return key;
+        }),
+      );
+    }),
+    read: Effect.fn("Documents.read")(function* () {
+      const state = yield* DurableObjectState.DurableObjectState;
 
-        return (yield* state.storage.get<typeof Snapshot.Type>("document")) ?? null;
-      }),
-    },
-    alarms: DocumentAlarms.handlers({
-      archive: Effect.fn("Documents.archive")(function* ({ tag, id, payload }) {
-        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
-        const archive = yield* Archive;
-        const now = yield* DateTime.now;
-
-        // Persist another wake BEFORE the external write, in case execution stops.
-        yield* alarms.scheduleAlarm({
-          tag,
-          id,
-          runAt: DateTime.add(now, { seconds: 30 }),
-          payload,
-        });
-
-        // Outside the transaction. Replays write the same key and exact content.
-        yield* archive.put(payload.key, payload.body);
-        yield* alarms.cancelAlarm({ tag, id });
-      }),
+      return (yield* state.storage.get<typeof Snapshot.Type>("document")) ?? null;
     }),
   },
-);
+  alarms: DocumentAlarms.handlers({
+    archive: Effect.fn("Documents.archive")(function* ({ tag, id, payload }) {
+      const archive = yield* Archive;
+      const now = yield* DateTime.now;
+
+      // Persist another wake BEFORE the external write, in case execution stops.
+      yield* DocumentAlarms.scheduleAlarm({
+        tag,
+        id,
+        runAt: DateTime.add(now, { seconds: 30 }),
+        payload,
+      });
+
+      // Outside the transaction. Replays write the same key and exact content.
+      yield* archive.put(payload.key, payload.body);
+      yield* DocumentAlarms.cancelAlarm({ tag, id });
+    }),
+  }),
+});
 
 export class DocumentDurableObject extends DocumentLive {}

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -49,6 +49,12 @@ The [document outbox example](https://github.com/danieljvdm/effect-cf/tree/main/
 
 For atomic application writes and alarm changes, see the [alarm transaction example](tests/fixtures/alarm-transaction-consumer.ts) and [API contract](src/DurableObjectAlarm.ts).
 
+`DurableObject.make` and tagged definitions' `.make` provide the alarm scheduler automatically, including to application layers. No alarm tables or native alarms are created until the scheduler is used. Outside these entrypoints, provide `DurableObjectAlarm.DurableObjectAlarm.layer` explicitly.
+
+Use `DurableObjectAlarm.define({ ... })` for schema-bound `scheduleAlarm`, `cancelAlarm`, `transaction`, and `handlers`. Scheduling accepts decoded payloads, encodes them with the declared schema, and checks that the result is JSON before storage. Transaction callbacks expose the same typed mutations and retain the raw scheduler's rollback and callback-lifetime rules. The raw service remains available for dynamic tags and JSON payloads.
+
+Unknown stored tags produce `StoredAlarmDecodeError` and follow the configured delivery failure policy rather than being acknowledged silently. Use the raw scheduler's `cancelAlarm` to remove retired tags, including repeating alarms.
+
 ## Cloudflare Observability traces
 
 `CloudflareTracer.layer` sends existing `Effect.withSpan` and named `Effect.fn`

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -4,6 +4,7 @@ import { Effect, Layer, type ManagedRuntime, type Scope, Tracer } from "effect";
 import { NativeRequest } from "./Worker";
 import { WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { DurableObjectState, fromDurableObjectState } from "./DurableObjectState";
+import { DurableObjectAlarm } from "./DurableObjectAlarm";
 import { fromWebSocket, type DurableWebSocket } from "./DurableObjectWebSocket";
 import * as RpcDefinition from "./RpcDefinition";
 import * as Entrypoint from "./internal/Entrypoint";
@@ -13,7 +14,11 @@ import type { ReceiverOptions, RpcInvocationInfo } from "./RpcTracing";
 
 const reservedMethodNames: ReadonlySet<string> = RpcDefinition.reservedMethodNames;
 
-type RuntimeContext<ROut> = DurableObjectState | WorkerEnvironment | ROut;
+export type RuntimeContext<ROut> =
+  | DurableObjectState
+  | DurableObjectAlarm
+  | WorkerEnvironment
+  | ROut;
 
 type HandlerContext<ROut> = RuntimeContext<ROut> | Scope.Scope;
 
@@ -93,11 +98,7 @@ export interface DurableObjectOptions<
    * event effect completes. It is not applied to `initialize`, which is an
    * instance-load lifecycle hook rather than a platform event.
    */
-  readonly eventLayer?: Layer.Layer<
-    REvent,
-    EventLayerError,
-    DurableObjectState | WorkerEnvironment | RRuntime
-  >;
+  readonly eventLayer?: Layer.Layer<REvent, EventLayerError, RuntimeContext<RRuntime>>;
   /**
    * Effect run when Cloudflare loads this Durable Object instance into memory.
    *
@@ -120,6 +121,7 @@ export interface DurableObjectOptions<
   readonly rpcTracing?: ReceiverOptions;
   readonly fetch?: Effect.Effect<Response, unknown, FetchContext<RRuntime | REvent>>;
 
+  /** The logical alarm scheduler is provided automatically, as it is for other handlers. */
   readonly alarms?: Effect.Effect<unknown, unknown, HandlerContext<RRuntime | REvent>>;
   /**
    * Optional raw alarm handler.
@@ -175,7 +177,7 @@ export const make = <
   EventLayerError = never,
   const Rpc extends DurableObjectRpc<ROut | REvent> = Record<never, never>,
 >(
-  layer: Layer.Layer<ROut, LayerError, DurableObjectState | WorkerEnvironment>,
+  layer: Layer.Layer<ROut, LayerError, RuntimeContext<never>>,
   options: DurableObjectOptions<ROut, REvent, EventLayerError, Rpc> = {},
 ): DurableObjectClass<Rpc, ROut | REvent> => {
   class EffectDurableObject extends CloudflareDurableObject<WorkerEnv> {
@@ -184,11 +186,15 @@ export const make = <
     constructor(state: globalThis.DurableObjectState, env: WorkerEnv) {
       super(state, env);
 
-      this.runtime = Runtime.makeEntrypointRuntime<ROut, LayerError, DurableObjectState>(
-        layer,
-        env,
-        Layer.succeed(DurableObjectState, fromDurableObjectState(state)),
+      const services = DurableObjectAlarm.layer.pipe(
+        Layer.provideMerge(Layer.succeed(DurableObjectState, fromDurableObjectState(state))),
       );
+
+      this.runtime = Runtime.makeEntrypointRuntime<
+        ROut,
+        LayerError,
+        DurableObjectState | DurableObjectAlarm
+      >(layer, env, services);
 
       const initialize = options.initialize;
 

--- a/packages/effect-cf/src/DurableObjectAlarm.ts
+++ b/packages/effect-cf/src/DurableObjectAlarm.ts
@@ -368,6 +368,22 @@ export type DefinedAlarmHandlers<Definitions extends AlarmDefinitions, R = never
   ) => Effect.Effect<void, E, R>;
 };
 
+/** A discriminated union keeps each tag paired with its decoded payload type. */
+export type DefinedScheduleAlarmInput<Definitions extends AlarmDefinitions> = {
+  readonly [Tag in keyof Definitions & string]: Omit<ScheduleAlarmInput<Tag>, "payload"> & {
+    readonly payload: AlarmDefinitionPayload<Definitions[Tag]>;
+  };
+}[keyof Definitions & string];
+
+export interface DefinedAlarmTransaction<Definitions extends AlarmDefinitions> {
+  readonly scheduleAlarm: (
+    input: DefinedScheduleAlarmInput<Definitions>,
+  ) => ReturnType<AlarmScheduler["scheduleAlarm"]>;
+  readonly cancelAlarm: (
+    input: AlarmRef<keyof Definitions & string>,
+  ) => ReturnType<AlarmScheduler["cancelAlarm"]>;
+}
+
 const isAlarmDefinitionConfig = (
   definition: AlarmDefinitionEntry,
 ): definition is AlarmDefinitionConfig => Predicate.isObject(definition) && "payload" in definition;
@@ -391,54 +407,121 @@ const getAlarmDefinitionFailureAction = (
     : { mode: definition.failure };
 };
 
-export const define = <const Definitions extends AlarmDefinitions>(definitions: Definitions) => ({
-  handlers: <R = never, E = never>(
-    handlers: DefinedAlarmHandlers<Definitions, R, E>,
-    options?: ProcessDueAlarmsOptions<R, E>,
-  ) =>
-    processDue(
-      (event) =>
-        Effect.gen(function* () {
-          const definition = definitions[event.tag];
+export const define = <const Definitions extends AlarmDefinitions>(definitions: Definitions) => {
+  const definitionFor = (tag: string) =>
+    Object.hasOwn(definitions, tag) ? definitions[tag] : undefined;
 
-          if (definition === undefined) {
-            return;
-          }
+  const bind = (mutations: AlarmTransaction): DefinedAlarmTransaction<Definitions> => ({
+    scheduleAlarm: Effect.fn("DefinedAlarms.scheduleAlarm")(function* (
+      input: DefinedScheduleAlarmInput<Definitions>,
+    ) {
+      const definition = definitionFor(input.tag);
 
-          const schema = getAlarmDefinitionSchema(definition);
-          // SAFETY: schema is selected from the same tagged definition used to select its handler.
-          const payload = yield* (
-            S.decodeUnknownEffect(schema)(event.payload) as Effect.Effect<
-              AlarmDefinitionPayload<Definitions[keyof Definitions & string]>,
-              unknown
-            >
-          ).pipe(
-            Effect.mapError(
-              (cause) =>
+      if (definition === undefined) {
+        return yield* Effect.fail(
+          new InvalidAlarmRefError({
+            cause: new Error(`Unknown alarm tag "${input.tag}"`),
+          }),
+        );
+      }
+      const payload = yield* S.encodeEffect(getAlarmDefinitionSchema(definition))(
+        input.payload,
+      ).pipe(
+        Effect.flatMap(S.decodeUnknownEffect(S.Json)),
+        Effect.mapError((cause) => new InvalidAlarmPayloadError({ cause })),
+      );
+
+      yield* mutations.scheduleAlarm({ ...input, payload });
+    }),
+    cancelAlarm: Effect.fn("DefinedAlarms.cancelAlarm")(function* (
+      input: AlarmRef<keyof Definitions & string>,
+    ) {
+      if (definitionFor(input.tag) === undefined) {
+        return yield* Effect.fail(
+          new InvalidAlarmRefError({
+            cause: new Error(`Unknown alarm tag "${input.tag}"`),
+          }),
+        );
+      }
+
+      yield* mutations.cancelAlarm(input);
+    }),
+  });
+
+  return {
+    /** Encodes and validates the payload before persisting it. */
+    scheduleAlarm: Effect.fn("DefinedAlarms.scheduleAlarm")(function* (
+      input: DefinedScheduleAlarmInput<Definitions>,
+    ) {
+      const alarms = yield* DurableObjectAlarm;
+
+      yield* bind(alarms).scheduleAlarm(input);
+    }),
+    cancelAlarm: Effect.fn("DefinedAlarms.cancelAlarm")(function* (
+      input: AlarmRef<keyof Definitions & string>,
+    ) {
+      const alarms = yield* DurableObjectAlarm;
+
+      yield* bind(alarms).cancelAlarm(input);
+    }),
+    /** Uses the same callback-owned transaction as the raw scheduler. */
+    transaction: <A, E, R>(
+      closure: (alarms: DefinedAlarmTransaction<Definitions>) => Effect.Effect<A, E, R>,
+    ): Effect.Effect<A, E | StorageOperationError, R | DurableObjectAlarm> =>
+      Effect.flatMap(DurableObjectAlarm, (alarms) => alarms.transaction((tx) => closure(bind(tx)))),
+    handlers: <R = never, E = never>(
+      handlers: DefinedAlarmHandlers<Definitions, R, E>,
+      options?: ProcessDueAlarmsOptions<R, E>,
+    ) =>
+      processDue(
+        (event) =>
+          Effect.gen(function* () {
+            const definition = definitionFor(event.tag);
+
+            if (definition === undefined) {
+              return yield* Effect.fail(
                 new StoredAlarmDecodeError({
-                  cause,
+                  cause: new Error(`Unknown alarm tag "${event.tag}"`),
                   storageId: getScheduledEventId(event),
                 }),
-            ),
-          );
-          const handler = handlers[event.tag];
+              );
+            }
 
-          // SAFETY: event.tag indexes the matching definition and handler, whose payload schema was decoded above.
-          yield* handler({ ...event, payload } as never);
-        }),
-      {
-        ...options,
-        onFailure: (failure) =>
-          Effect.gen(function* () {
-            const action = getAlarmDefinitionFailureAction(definitions[failure.tag]);
-            const optionAction =
-              options?.onFailure === undefined ? undefined : yield* options.onFailure(failure);
+            const schema = getAlarmDefinitionSchema(definition);
+            // SAFETY: schema is selected from the same tagged definition used to select its handler.
+            const payload = yield* (
+              S.decodeUnknownEffect(schema)(event.payload) as Effect.Effect<
+                AlarmDefinitionPayload<Definitions[keyof Definitions & string]>,
+                unknown
+              >
+            ).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new StoredAlarmDecodeError({
+                    cause,
+                    storageId: getScheduledEventId(event),
+                  }),
+              ),
+            );
+            const handler = handlers[event.tag];
 
-            return action ?? optionAction;
+            // SAFETY: event.tag indexes the matching definition and handler, whose payload schema was decoded above.
+            yield* handler({ ...event, payload } as never);
           }),
-      },
-    ),
-});
+        {
+          ...options,
+          onFailure: (failure) =>
+            Effect.gen(function* () {
+              const action = getAlarmDefinitionFailureAction(definitionFor(failure.tag));
+              const optionAction =
+                options?.onFailure === undefined ? undefined : yield* options.onFailure(failure);
+
+              return action ?? optionAction;
+            }),
+        },
+      ),
+  };
+};
 
 export class DurableObjectAlarm extends Context.Service<DurableObjectAlarm, AlarmScheduler>()(
   "effect-cf/DurableObjectAlarm",
@@ -723,6 +806,6 @@ export class DurableObjectAlarm extends Context.Service<DurableObjectAlarm, Alar
         scheduleAlarm: (input) => transaction((alarms) => alarms.scheduleAlarm(input)),
         transaction,
       });
-    }).pipe(Effect.withSpan("DurableObjectAlarm.layer")),
+    }),
   );
 }

--- a/packages/effect-cf/src/DurableObjectDefinition.ts
+++ b/packages/effect-cf/src/DurableObjectDefinition.ts
@@ -4,7 +4,6 @@ import type * as Binding from "./Binding";
 import * as DurableObjectEntrypoint from "./DurableObject";
 import type { DurableObjectHandler } from "./DurableObject";
 import * as DurableObjectNamespace from "./DurableObjectNamespace";
-import type { DurableObjectState } from "./DurableObjectState";
 import type * as Rpc from "./Rpc";
 import * as RpcDefinition from "./RpcDefinition";
 import { recordDecodedArgs } from "./internal/RpcInvocation";
@@ -160,7 +159,7 @@ export type TagClass<
     readonly id: Id;
     readonly methods: MethodDefinitions;
     readonly make: <ROut, LayerError, REvent = never, EventLayerError = never>(
-      layer: Layer.Layer<ROut, LayerError, DurableObjectState | WorkerEnvironment>,
+      layer: Layer.Layer<ROut, LayerError, DurableObjectEntrypoint.RuntimeContext<never>>,
       options: Options<ROut, Definition<Id, MethodDefinitions>, REvent, EventLayerError>,
     ) => DurableObjectEntrypoint.DurableObjectClass<
       Handlers<ROut | REvent, Definition<Id, MethodDefinitions>>,
@@ -202,7 +201,7 @@ const makeDefinition = <Id extends string, const MethodDefinitions extends Metho
 
   return Object.assign(definition, {
     make: <ROut, LayerError, REvent = never, EventLayerError = never>(
-      layer: Layer.Layer<ROut, LayerError, DurableObjectState | WorkerEnvironment>,
+      layer: Layer.Layer<ROut, LayerError, DurableObjectEntrypoint.RuntimeContext<never>>,
       options: Options<ROut, SelfDefinition, REvent, EventLayerError>,
     ) =>
       DurableObjectEntrypoint.make(layer, {

--- a/packages/effect-cf/tests/DurableObjectAlarm.test.ts
+++ b/packages/effect-cf/tests/DurableObjectAlarm.test.ts
@@ -640,31 +640,97 @@ it.effect("routes typed logical alarm definitions through decoded payload handle
       reconnectGrace: Schema.Struct({
         connectionId: Schema.String,
         userId: Schema.String,
+        revision: Schema.FiniteFromString,
       }),
     });
     const handled: Array<string> = [];
 
     yield* fixture.run(
       Effect.gen(function* () {
-        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
-
-        yield* alarms.scheduleAlarm({
+        yield* roomAlarms.scheduleAlarm({
           tag: "reconnectGrace",
           id: "connection-1",
           runAt: atMillis(0),
-          payload: { connectionId: "connection-1", userId: "user-1" },
+          payload: { connectionId: "connection-1", userId: "user-1", revision: 2 },
         });
+
+        assert.strictEqual(
+          fixture.row("reconnectGrace", "connection-1")?.payload,
+          '{"connectionId":"connection-1","userId":"user-1","revision":"2"}',
+        );
 
         yield* roomAlarms.handlers({
           reconnectGrace: ({ payload }) =>
             Effect.sync(() => {
-              handled.push(`${payload.userId}:${payload.connectionId}`);
+              handled.push(`${payload.userId}:${payload.connectionId}:${payload.revision + 1}`);
             }),
         });
       }),
     );
 
-    assert.deepStrictEqual(handled, ["user-1:connection-1"]);
+    assert.deepStrictEqual(handled, ["user-1:connection-1:3"]);
+  }),
+);
+
+it.effect(
+  "rolls back application writes and typed alarm mutations when payload validation fails",
+  () =>
+    Effect.gen(function* () {
+      const fixture = makeAlarmFixture();
+      const JobAlarms = DurableObjectAlarm.define({ job: Schema.NonEmptyString });
+
+      yield* fixture.run(
+        Effect.gen(function* () {
+          yield* JobAlarms.scheduleAlarm({
+            tag: "job",
+            id: "a",
+            runAt: atMillis(2_000),
+            payload: "before",
+          });
+          yield* writeJob(fixture.storage, "before");
+          const exit = yield* JobAlarms.transaction((tx) =>
+            Effect.gen(function* () {
+              yield* writeJob(fixture.storage, "during");
+              yield* tx.cancelAlarm({ tag: "job", id: "a" });
+              yield* tx.scheduleAlarm({ tag: "job", id: "b", runAt: atMillis(1_000), payload: "" });
+            }),
+          ).pipe(Effect.exit);
+
+          assert.isTrue(Exit.isFailure(exit));
+          if (Exit.isFailure(exit)) {
+            assert.instanceOf(
+              Cause.squash(exit.cause),
+              DurableObjectAlarm.InvalidAlarmPayloadError,
+            );
+          }
+          assert.strictEqual(fixture.job("job"), "before");
+          assert.strictEqual(fixture.row("job", "a")?.payload, '"before"');
+          assert.isUndefined(fixture.row("job", "b"));
+          assert.strictEqual(fixture.currentAlarm(), 2_000);
+        }),
+      );
+    }),
+);
+
+it.effect("reports unknown stored tags without acknowledging their alarms", () =>
+  Effect.gen(function* () {
+    const fixture = makeAlarmFixture();
+    const JobAlarms = DurableObjectAlarm.define({ job: Schema.Null });
+    const result = yield* fixture.run(
+      Effect.gen(function* () {
+        const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
+
+        yield* alarms.scheduleAlarm({ tag: "unknown", id: "a", runAt: atMillis(0), payload: null });
+
+        return yield* JobAlarms.handlers({ job: () => Effect.void });
+      }),
+    );
+
+    assert.deepStrictEqual(result.handled, []);
+    assert.strictEqual(result.failed.length, 1);
+    assert.strictEqual(result.failed[0]?.tag, "unknown");
+    assert.isDefined(fixture.row("unknown", "a"));
+    assert.ok((fixture.currentAlarm() ?? 0) > 0);
   }),
 );
 
@@ -771,10 +837,15 @@ it.effect("supports per-tag ordered failure policies", () =>
   }),
 );
 
-test("DurableObject.make composes logical alarms before raw alarm hook", async () => {
+test("DurableObject.make provides the scheduler to RPC and alarm handlers", async () => {
   const fixture = makeAlarmFixture();
   const calls: Array<string> = [];
-  const Live = DurableObject.make(DurableObjectAlarm.DurableObjectAlarm.layer, {
+  const JobAlarms = DurableObjectAlarm.define({ jobs: Schema.Null });
+  const Live = DurableObject.make(Layer.empty, {
+    rpc: {
+      schedule: () =>
+        JobAlarms.scheduleAlarm({ tag: "jobs", id: "a", runAt: atMillis(0), payload: null }),
+    },
     alarms: DurableObjectAlarm.processDue((event) =>
       Effect.sync(() => {
         calls.push(`logical:${event.id}`);
@@ -786,15 +857,9 @@ test("DurableObject.make composes logical alarms before raw alarm hook", async (
       }),
   });
 
-  await fixture.runPromise(
-    Effect.gen(function* () {
-      const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
-
-      yield* alarms.scheduleAlarm({ tag: "jobs", id: "a", runAt: atMillis(0), payload: null });
-    }),
-  );
-
   const instance = new Live(fixture.state, makePartialTestDouble<Cloudflare.Env>({}));
+
+  await instance.schedule();
 
   interface AlarmHandler {
     alarm(): Promise<void> | void;
@@ -960,8 +1025,6 @@ function makeAlarmFixture(options: AlarmFixtureOptions = {}) {
     },
     row: (tag: string, id: string) => rows.get(storageId(tag, id)),
     run: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect.pipe(Effect.provide(layer)),
-    runPromise: <A, E>(effect: Effect.Effect<A, E, DurableObjectAlarm.DurableObjectAlarm>) =>
-      Effect.runPromise(effect.pipe(Effect.provide(layer))),
   };
 }
 

--- a/packages/effect-cf/tests/DurableObjectAlarm.worker.test.ts
+++ b/packages/effect-cf/tests/DurableObjectAlarm.worker.test.ts
@@ -1,6 +1,6 @@
 import { env } from "cloudflare:workers";
 import { assert, it } from "@effect/vitest";
-import { DateTime, Deferred, Effect, Exit, Fiber, Layer } from "effect";
+import { DateTime, Deferred, Effect, Exit, Fiber, Layer, Schema } from "effect";
 import { TestClock } from "effect/testing";
 import { SqlClient } from "effect/unstable/sql";
 
@@ -13,23 +13,24 @@ const services = Layer.merge(
 );
 // Far-future native deadlines keep these tests independent of the wall clock.
 const deadline = 4_000_000_000_000;
-const alarm = (id: string, offset: number): DurableObjectAlarm.ScheduleAlarmInput => ({
-  tag: "job",
-  id,
-  runAt: DateTime.makeUnsafe(deadline + offset),
-  payload: null,
-});
+const alarm = (id: string, offset: number) =>
+  ({
+    tag: "job",
+    id,
+    runAt: DateTime.makeUnsafe(deadline + offset),
+    payload: null,
+  }) satisfies DurableObjectAlarm.ScheduleAlarmInput<"job">;
 
 it.effect("commits application SQL and mixed alarms together in workerd", () => {
   const stub = env.TEST_COUNTER_DO!.getByName(crypto.randomUUID());
+  const JobAlarms = DurableObjectAlarm.define({ job: Schema.Null, other: Schema.Null });
 
   return PoolWorkers.runInDurableObject(stub, (_instance, state) =>
     Effect.gen(function* () {
-      const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
       const sql = yield* SqlClient.SqlClient;
 
       yield* sql`CREATE TABLE jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL)`;
-      const result = yield* alarms.transaction((tx) =>
+      const result = yield* JobAlarms.transaction((tx) =>
         Effect.gen(function* () {
           yield* sql`INSERT INTO jobs VALUES ('sql-client', 'ready')`;
           yield* state.storage.sql.exec("INSERT INTO jobs VALUES (?, ?)", "storage", "ready");
@@ -59,7 +60,7 @@ it.effect("commits application SQL and mixed alarms together in workerd", () => 
         ],
       );
 
-      yield* alarms.transaction((tx) =>
+      yield* JobAlarms.transaction((tx) =>
         Effect.gen(function* () {
           yield* sql`UPDATE jobs SET status = 'cancelled'`;
           yield* tx.cancelAlarm({ tag: "job", id: "a" });

--- a/packages/effect-cf/tests/durable-alarm.test-d.ts
+++ b/packages/effect-cf/tests/durable-alarm.test-d.ts
@@ -1,8 +1,13 @@
 import { expectTypeOf } from "vitest";
-import { Context, DateTime, Effect, Schema } from "effect";
+import { Context, DateTime, Effect, Layer, Schema } from "effect";
 import { SqlClient, type SqlError } from "effect/unstable/sql";
 
-import { DurableObjectAlarm, DurableObjectState, DurableObjectStorage } from "../src/index";
+import {
+  DurableObject,
+  DurableObjectAlarm,
+  DurableObjectState,
+  DurableObjectStorage,
+} from "../src/index";
 
 class Application extends Context.Service<Application, { readonly id: string }>()("Application") {}
 class ApplicationError extends Schema.TaggedError<ApplicationError>()("ApplicationError", {}) {}
@@ -53,3 +58,61 @@ declare const tx: DurableObjectAlarm.AlarmTransaction;
 tx.transaction(() => Effect.void);
 // @ts-expect-error Dispatch and external handler work do not belong in the transaction.
 tx.processDueAlarms(() => Effect.void);
+
+const DocumentAlarms = DurableObjectAlarm.define({
+  archive: Schema.Struct({ key: Schema.String, revision: Schema.FiniteFromString }),
+  cleanup: { payload: Schema.Null, failure: "retry" },
+});
+const runAt = DateTime.makeUnsafe(1);
+const archiveInput = {
+  tag: "archive",
+  id: "a",
+  runAt,
+  payload: { key: "a", revision: 1 },
+} as const;
+
+void DocumentAlarms.scheduleAlarm(archiveInput);
+// @ts-expect-error The tag must belong to this definition.
+void DocumentAlarms.scheduleAlarm({ ...archiveInput, tag: "archvie" });
+// @ts-expect-error Scheduling accepts the decoded type, not its wire encoding.
+void DocumentAlarms.scheduleAlarm({ ...archiveInput, payload: { key: "a", revision: "1" } });
+// @ts-expect-error A known tag cannot be paired with another tag's payload.
+void DocumentAlarms.scheduleAlarm({ ...archiveInput, tag: "cleanup" });
+// @ts-expect-error Cancellation uses the same defined tags.
+void DocumentAlarms.cancelAlarm({ tag: "archvie", id: "a" });
+
+expectTypeOf(DocumentAlarms.transaction(() => application)).toEqualTypeOf<
+  Effect.Effect<
+    number,
+    ApplicationError | DurableObjectStorage.StorageOperationError,
+    Application | DurableObjectAlarm.DurableObjectAlarm
+  >
+>();
+
+void DocumentAlarms.transaction((typedTx) => {
+  void typedTx.scheduleAlarm(archiveInput);
+  void typedTx.cancelAlarm({ tag: "cleanup", id: "a" });
+  // @ts-expect-error Transactional scheduling is definition-bound too.
+  void typedTx.scheduleAlarm({ ...archiveInput, tag: "archvie" });
+  // @ts-expect-error Transactional scheduling keeps tag and payload correlated.
+  void typedTx.scheduleAlarm({ ...archiveInput, tag: "cleanup" });
+  // @ts-expect-error A transaction handle cannot open nested transactions.
+  void typedTx.transaction(() => Effect.void);
+
+  return application;
+});
+
+// The default scheduler is available to construction layers as well as handlers.
+const scheduled = Context.Service<{ readonly ready: boolean }>("test/Scheduled");
+
+DurableObject.make(
+  Layer.effect(
+    scheduled,
+    DocumentAlarms.scheduleAlarm(archiveInput).pipe(Effect.as({ ready: true })),
+  ),
+  {
+    initialize: DocumentAlarms.scheduleAlarm(archiveInput),
+    alarms: DocumentAlarms.handlers({ archive: () => Effect.void, cleanup: () => Effect.void }),
+    rpc: { schedule: () => DocumentAlarms.scheduleAlarm(archiveInput) },
+  },
+);

--- a/packages/effect-cf/tests/fixtures/alarm-transaction-consumer.ts
+++ b/packages/effect-cf/tests/fixtures/alarm-transaction-consumer.ts
@@ -1,19 +1,17 @@
-import { DateTime, Effect, Layer } from "effect";
+import { DateTime, Effect, Schema } from "effect";
 import { SqlClient } from "effect/unstable/sql";
 import { DurableObjectAlarm, DurableObjectSqlite } from "effect-cf";
 
-export const AlarmStorageLive = Layer.merge(
-  DurableObjectAlarm.DurableObjectAlarm.layer,
-  DurableObjectSqlite.layer(),
-);
+// DurableObject.make provides the alarm scheduler automatically.
+export const AlarmStorageLive = DurableObjectSqlite.layer();
+const JobAlarms = DurableObjectAlarm.define({ job: Schema.Null });
 
 export const scheduleJob = Effect.fn("scheduleJob")(function* (id: string, runAt: DateTime.Utc) {
-  const alarms = yield* DurableObjectAlarm.DurableObjectAlarm;
   const sql = yield* SqlClient.SqlClient;
 
   yield* sql`CREATE TABLE IF NOT EXISTS jobs (id TEXT PRIMARY KEY, run_at INTEGER NOT NULL)`;
 
-  return yield* alarms.transaction((tx) =>
+  return yield* JobAlarms.transaction((tx) =>
     Effect.gen(function* () {
       yield* sql`INSERT OR REPLACE INTO jobs (id, run_at) VALUES (${id}, ${DateTime.toEpochMillis(runAt)})`;
       yield* tx.scheduleAlarm({ tag: "job", id, runAt, payload: null });


### PR DESCRIPTION
Bind alarm scheduling to the same definitions as handlers, and provide the scheduler automatically in Durable Objects. The outbox example no longer needs an explicit alarm layer or raw scheduler service.

```ts
const DocumentAlarms = DurableObjectAlarm.define({
  archive: Schema.Struct({ key: Schema.String, body: Schema.String }),
});

yield* DocumentAlarms.transaction((tx) =>
  tx.scheduleAlarm({
    tag: "archive",
    id: "notes/1",
    runAt: now,
    payload: { key: "notes/1.txt", body: "First draft" },
  }),
);
```

Unknown tags and mismatched payloads fail typechecking. Payload validation failures roll back the transaction. The raw API remains supported; unknown stored tags now follow the failure policy instead of being silently discarded.

Verified outbox delivery after stopping and restarting Wrangler without another save. Follow-up to #145.
