### PR TITLE
fix: require handler registration for typed alarm scheduling

### DIFF
--- a/.changeset/typed-durable-alarms.md
+++ b/.changeset/typed-durable-alarms.md
@@ -2,8 +2,8 @@
 "effect-cf": minor
 ---
 
-Add schema-bound scheduling, cancellation, and transactions to `DurableObjectAlarm.define`. Scheduling checks tag/payload pairs at compile time and schema-encodes payloads before storage.
+Add schema-bound scheduling, cancellation, and transactions through `DurableObjectAlarm.Tag`. Register the service's complete `handlers(...)` implementation in a Durable Object's `alarms:` option, then yield the service to schedule work. Missing registration or handlers fail typechecking. Scheduling checks tag/payload pairs and schema-encodes payloads before storage.
 
-Durable Object entrypoints now provide the alarm scheduler automatically to application layers and handlers. Existing explicit layers and raw scheduler methods remain supported.
+Durable Object entrypoints provide registered alarm services to application layers and handlers. The raw scheduler is provided automatically and remains available for dynamic tags; existing explicit layers and handler-only `define(...)` calls remain supported.
 
 Unknown stored alarm tags now report `StoredAlarmDecodeError` and follow the delivery failure policy instead of being silently acknowledged. Applications intentionally retiring tags can handle them through `onFailure`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Save a document now and archive each revision to R2 in the background. The failu
 save document → process stops → scheduling never runs
 ```
 
-`DocumentAlarms.transaction` commits the document and its delivery alarm together. Before commit, neither is saved; after commit, both survive a restart. Scheduling does not need to throw for this to matter.
+`alarms.transaction` commits the document and its delivery alarm together. Before commit, neither is saved; after commit, both survive a restart. Scheduling does not need to throw for this to matter.
 
 Here is the Durable Object from the [runnable outbox example](examples/outbox/src/index.ts). The alarm's persisted payload is the outbox entry: it keeps the exact revision to deliver, even after the document changes again.
 
@@ -30,16 +30,17 @@ export class Documents extends DurableObject.Tag<Documents>()("Documents", {
 
 export class Archive extends R2.Tag<Archive>()("Archive") {}
 
-const DocumentAlarms = DurableObjectAlarm.define({
+class DocumentAlarms extends DurableObjectAlarm.Tag<DocumentAlarms>()("DocumentAlarms", {
   archive: Schema.Struct({ key: Schema.String, body: Schema.String }),
-});
+}) {}
 
 const DocumentLive = Documents.make(Archive.layer({ binding: "ARCHIVE" }), {
   rpc: {
     save: Effect.fn("Documents.save")(function* (body) {
       const state = yield* DurableObjectState.DurableObjectState;
+      const alarms = yield* DocumentAlarms;
 
-      return yield* DocumentAlarms.transaction((tx) =>
+      return yield* alarms.transaction((tx) =>
         Effect.gen(function* () {
           const previous = yield* state.storage.get<typeof Snapshot.Type>("document");
           const revision = (previous?.revision ?? 0) + 1;
@@ -70,10 +71,11 @@ const DocumentLive = Documents.make(Archive.layer({ binding: "ARCHIVE" }), {
   alarms: DocumentAlarms.handlers({
     archive: Effect.fn("Documents.archive")(function* ({ tag, id, payload }) {
       const archive = yield* Archive;
+      const alarms = yield* DocumentAlarms;
       const now = yield* DateTime.now;
 
       // Persist another wake BEFORE the external write, in case execution stops.
-      yield* DocumentAlarms.scheduleAlarm({
+      yield* alarms.scheduleAlarm({
         tag,
         id,
         runAt: DateTime.add(now, { seconds: 30 }),
@@ -82,7 +84,7 @@ const DocumentLive = Documents.make(Archive.layer({ binding: "ARCHIVE" }), {
 
       // Outside the transaction. Replays write the same key and exact content.
       yield* archive.put(payload.key, payload.body);
-      yield* DocumentAlarms.cancelAlarm({ tag, id });
+      yield* alarms.cancelAlarm({ tag, id });
     }),
   }),
 });
@@ -90,7 +92,7 @@ const DocumentLive = Documents.make(Archive.layer({ binding: "ARCHIVE" }), {
 export class DocumentDurableObject extends DocumentLive {}
 ```
 
-`Documents.make` provides the alarm scheduler automatically. `DocumentAlarms` types both scheduling and handling from the same schemas, including the transaction's `tx.scheduleAlarm`.
+Registering `DocumentAlarms.handlers(...)` on `Documents.make` provides the `DocumentAlarms` service. Scheduling and handling share the same schemas, including the transaction's `tx.scheduleAlarm`. Omitting the registration or a declared handler fails typechecking.
 
 The Worker routes `PUT /notes` and `GET /notes` through the typed `Documents` RPC binding. `GET /archive/notes/1.txt` reads R2. [Worker wiring](examples/outbox/src/index.ts) and [Wrangler bindings](examples/outbox/wrangler.jsonc) complete the application.
 

--- a/examples/outbox/README.md
+++ b/examples/outbox/README.md
@@ -4,9 +4,9 @@ A Durable Object stores the current document. Each save also queues an immutable
 
 ## Why the transaction exists
 
-Without a shared transaction, execution can stop after saving a revision but before scheduling its delivery. The saved revision survives, but nothing wakes up to archive it. `DocumentAlarms.transaction` commits the document, delivery payload, and native wake together.
+Without a shared transaction, execution can stop after saving a revision but before scheduling its delivery. The saved revision survives, but nothing wakes up to archive it. `alarms.transaction` commits the document, delivery payload, and native wake together.
 
-`Documents.make` provides the scheduler automatically. `DocumentAlarms` binds scheduling, cancellation, and handlers to the declared tags and payload schemas. Payloads are schema-encoded before storage and decoded when delivered.
+`DocumentAlarms` is a typed Effect service. Registering `DocumentAlarms.handlers(...)` on `Documents.make` provides it to application layers and handlers. Scheduling requires `yield* DocumentAlarms`; the schema declaration alone cannot schedule work. Payloads are schema-encoded before storage and decoded when delivered.
 
 The alarm handler schedules a recovery wake before writing to R2. It cancels that wake only after R2 reports success. If the response is lost or execution stops after the upload, a retry writes the same key and content. Each revision has its own key, so retrying an old revision cannot overwrite a newer one.
 

--- a/examples/outbox/src/document.ts
+++ b/examples/outbox/src/document.ts
@@ -10,16 +10,17 @@ export class Documents extends DurableObject.Tag<Documents>()("Documents", {
 
 export class Archive extends R2.Tag<Archive>()("Archive") {}
 
-const DocumentAlarms = DurableObjectAlarm.define({
+class DocumentAlarms extends DurableObjectAlarm.Tag<DocumentAlarms>()("DocumentAlarms", {
   archive: Schema.Struct({ key: Schema.String, body: Schema.String }),
-});
+}) {}
 
 const DocumentLive = Documents.make(Archive.layer({ binding: "ARCHIVE" }), {
   rpc: {
     save: Effect.fn("Documents.save")(function* (body) {
       const state = yield* DurableObjectState.DurableObjectState;
+      const alarms = yield* DocumentAlarms;
 
-      return yield* DocumentAlarms.transaction((tx) =>
+      return yield* alarms.transaction((tx) =>
         Effect.gen(function* () {
           const previous = yield* state.storage.get<typeof Snapshot.Type>("document");
           const revision = (previous?.revision ?? 0) + 1;
@@ -50,10 +51,11 @@ const DocumentLive = Documents.make(Archive.layer({ binding: "ARCHIVE" }), {
   alarms: DocumentAlarms.handlers({
     archive: Effect.fn("Documents.archive")(function* ({ tag, id, payload }) {
       const archive = yield* Archive;
+      const alarms = yield* DocumentAlarms;
       const now = yield* DateTime.now;
 
       // Persist another wake BEFORE the external write, in case execution stops.
-      yield* DocumentAlarms.scheduleAlarm({
+      yield* alarms.scheduleAlarm({
         tag,
         id,
         runAt: DateTime.add(now, { seconds: 30 }),
@@ -62,7 +64,7 @@ const DocumentLive = Documents.make(Archive.layer({ binding: "ARCHIVE" }), {
 
       // Outside the transaction. Replays write the same key and exact content.
       yield* archive.put(payload.key, payload.body);
-      yield* DocumentAlarms.cancelAlarm({ tag, id });
+      yield* alarms.cancelAlarm({ tag, id });
     }),
   }),
 });

--- a/packages/effect-cf/README.md
+++ b/packages/effect-cf/README.md
@@ -49,9 +49,11 @@ The [document outbox example](https://github.com/danieljvdm/effect-cf/tree/main/
 
 For atomic application writes and alarm changes, see the [alarm transaction example](tests/fixtures/alarm-transaction-consumer.ts) and [API contract](src/DurableObjectAlarm.ts).
 
-`DurableObject.make` and tagged definitions' `.make` provide the alarm scheduler automatically, including to application layers. No alarm tables or native alarms are created until the scheduler is used. Outside these entrypoints, provide `DurableObjectAlarm.DurableObjectAlarm.layer` explicitly.
+Define a typed alarm service with `class Alarms extends DurableObjectAlarm.Tag<Alarms>()("Alarms", { ...schemas }) {}`. Pass `Alarms.handlers({ ...implementations })` to the DO's `alarms:` option, then `yield* Alarms` to schedule or cancel alarms and open transactions. All declared handlers are required. The registration provides the service to application layers, initialization, and event handlers; declaring schemas alone does not provide a scheduler.
 
-Use `DurableObjectAlarm.define({ ... })` for schema-bound `scheduleAlarm`, `cancelAlarm`, `transaction`, and `handlers`. Scheduling accepts decoded payloads, encodes them with the declared schema, and checks that the result is JSON before storage. Transaction callbacks expose the same typed mutations and retain the raw scheduler's rollback and callback-lifetime rules. The raw service remains available for dynamic tags and JSON payloads.
+Scheduling accepts decoded payloads, encodes them with the declared schema, and checks that the result is JSON before storage. Transaction callbacks expose the same typed mutations and retain the raw scheduler's rollback and callback-lifetime rules.
+
+`DurableObject.make` and tagged definitions' `.make` still provide the raw `DurableObjectAlarm` service automatically for dynamic tags and JSON payloads. `DurableObjectAlarm.define({ ... }).handlers(...)` remains a handler-only helper for raw scheduling. No alarm tables or native alarms are created until the scheduler is used. Outside these entrypoints, provide the raw scheduler layer explicitly. A typed registration exposes `layer` and `run` for custom runtimes and tests; custom runtimes must install both.
 
 Unknown stored tags produce `StoredAlarmDecodeError` and follow the configured delivery failure policy rather than being acknowledged silently. Use the raw scheduler's `cancelAlarm` to remove retired tags, including repeating alarms.
 

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -4,7 +4,11 @@ import { Effect, Layer, type ManagedRuntime, type Scope, Tracer } from "effect";
 import { NativeRequest } from "./Worker";
 import { WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { DurableObjectState, fromDurableObjectState } from "./DurableObjectState";
-import { DurableObjectAlarm, type AlarmRegistration } from "./DurableObjectAlarm";
+import {
+  DurableObjectAlarm,
+  type AlarmRegistration,
+  type AlarmService,
+} from "./DurableObjectAlarm";
 import { fromWebSocket, type DurableWebSocket } from "./DurableObjectWebSocket";
 import * as RpcDefinition from "./RpcDefinition";
 import * as Entrypoint from "./internal/Entrypoint";
@@ -165,6 +169,13 @@ interface DurableObjectOptionsBase<
   ) => Effect.Effect<void, unknown, HandlerContext<NoInfer<RRuntime> | REvent | NoInfer<RAlarm>>>;
 }
 
+// Providing a scheduler through an ordinary layer does not install its dispatcher.
+type CheckAlarmRegistration<RProvided, RAlarm> = [
+  Exclude<Extract<NoInfer<RProvided>, AlarmService>, NoInfer<RAlarm>>,
+] extends [never]
+  ? unknown
+  : never;
+
 /** A declared event or alarm service must have its corresponding provider. */
 export type DurableObjectOptions<
   RRuntime,
@@ -173,6 +184,7 @@ export type DurableObjectOptions<
   Rpc extends DurableObjectRpc<RRuntime | REvent | RAlarm> = Record<never, never>,
   RAlarm = never,
 > = DurableObjectOptionsBase<RRuntime, REvent, EventLayerError, Rpc, RAlarm> &
+  CheckAlarmRegistration<RRuntime | REvent, RAlarm> &
   ([Exclude<REvent, RuntimeContext<RRuntime | RAlarm> | Scope.Scope>] extends [never]
     ? unknown
     : {
@@ -213,7 +225,7 @@ export type DurableObjectClass<Rpc extends DurableObjectRpc<ROut>, ROut> = new (
  * release in `eventLayer`, whose scope closes after each handled event.
  */
 export function make<ROut, LayerError>(
-  layer: Layer.Layer<ROut, LayerError, RuntimeContext<never>>,
+  layer: Layer.Layer<ROut, LayerError, RuntimeContext<never>> & CheckAlarmRegistration<ROut, never>,
 ): DurableObjectClass<Record<never, never>, ROut>;
 export function make<
   ROut,

--- a/packages/effect-cf/src/DurableObject.ts
+++ b/packages/effect-cf/src/DurableObject.ts
@@ -4,7 +4,7 @@ import { Effect, Layer, type ManagedRuntime, type Scope, Tracer } from "effect";
 import { NativeRequest } from "./Worker";
 import { WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { DurableObjectState, fromDurableObjectState } from "./DurableObjectState";
-import { DurableObjectAlarm } from "./DurableObjectAlarm";
+import { DurableObjectAlarm, type AlarmRegistration } from "./DurableObjectAlarm";
 import { fromWebSocket, type DurableWebSocket } from "./DurableObjectWebSocket";
 import * as RpcDefinition from "./RpcDefinition";
 import * as Entrypoint from "./internal/Entrypoint";
@@ -85,11 +85,12 @@ export type RpcHandlers<ROut, Api> = {
     : never;
 };
 
-export interface DurableObjectOptions<
+interface DurableObjectOptionsBase<
   RRuntime,
   REvent = never,
   EventLayerError = never,
-  Rpc extends DurableObjectRpc<RRuntime | REvent> = Record<never, never>,
+  Rpc extends DurableObjectRpc<RRuntime | REvent | RAlarm> = Record<never, never>,
+  RAlarm = never,
 > {
   /**
    * Layer provided around each Cloudflare event handled by this Durable Object.
@@ -98,7 +99,11 @@ export interface DurableObjectOptions<
    * event effect completes. It is not applied to `initialize`, which is an
    * instance-load lifecycle hook rather than a platform event.
    */
-  readonly eventLayer?: Layer.Layer<REvent, EventLayerError, RuntimeContext<RRuntime>>;
+  readonly eventLayer?: Layer.Layer<
+    REvent,
+    EventLayerError,
+    RuntimeContext<NoInfer<RRuntime | RAlarm>>
+  >;
   /**
    * Effect run when Cloudflare loads this Durable Object instance into memory.
    *
@@ -107,7 +112,7 @@ export interface DurableObjectOptions<
    * the same Durable Object id again after eviction or restart; use Durable
    * Object storage if work must happen only once per id.
    */
-  readonly initialize?: Effect.Effect<void, unknown, HandlerContext<RRuntime>>;
+  readonly initialize?: Effect.Effect<void, unknown, HandlerContext<NoInfer<RRuntime | RAlarm>>>;
   /**
    * Optional RPC methods exposed as Durable Object instance methods.
    *
@@ -119,10 +124,20 @@ export interface DurableObjectOptions<
   readonly rpc?: Rpc;
   /** Accept live native trace metadata. The client must also enable rpcTracing. */
   readonly rpcTracing?: ReceiverOptions;
-  readonly fetch?: Effect.Effect<Response, unknown, FetchContext<RRuntime | REvent>>;
+  readonly fetch?: Effect.Effect<
+    Response,
+    unknown,
+    FetchContext<NoInfer<RRuntime | REvent | RAlarm>>
+  >;
 
-  /** The logical alarm scheduler is provided automatically, as it is for other handlers. */
-  readonly alarms?: Effect.Effect<unknown, unknown, HandlerContext<RRuntime | REvent>>;
+  /** Register handlers to provide their typed scheduler to application layers and all DO events. */
+  readonly alarms?:
+    | Effect.Effect<unknown, unknown, HandlerContext<NoInfer<RRuntime> | REvent | NoInfer<RAlarm>>>
+    | AlarmRegistration<
+        RAlarm,
+        HandlerContext<NoInfer<RRuntime> | REvent | NoInfer<RAlarm>>,
+        unknown
+      >;
   /**
    * Optional raw alarm handler.
    *
@@ -133,22 +148,49 @@ export interface DurableObjectOptions<
    */
   readonly alarm?: (
     alarmInfo?: globalThis.AlarmInvocationInfo,
-  ) => Effect.Effect<void, unknown, HandlerContext<RRuntime | REvent>>;
+  ) => Effect.Effect<void, unknown, HandlerContext<NoInfer<RRuntime> | REvent | NoInfer<RAlarm>>>;
   readonly webSocketMessage?: (
     socket: DurableWebSocket,
     message: string | ArrayBuffer,
-  ) => Effect.Effect<void, unknown, HandlerContext<RRuntime | REvent>>;
+  ) => Effect.Effect<void, unknown, HandlerContext<NoInfer<RRuntime> | REvent | NoInfer<RAlarm>>>;
   readonly webSocketClose?: (
     socket: DurableWebSocket,
     code: number,
     reason: string,
     wasClean: boolean,
-  ) => Effect.Effect<void, unknown, HandlerContext<RRuntime | REvent>>;
+  ) => Effect.Effect<void, unknown, HandlerContext<NoInfer<RRuntime> | REvent | NoInfer<RAlarm>>>;
   readonly webSocketError?: (
     socket: DurableWebSocket,
     cause: unknown,
-  ) => Effect.Effect<void, unknown, HandlerContext<RRuntime | REvent>>;
+  ) => Effect.Effect<void, unknown, HandlerContext<NoInfer<RRuntime> | REvent | NoInfer<RAlarm>>>;
 }
+
+/** A declared event or alarm service must have its corresponding provider. */
+export type DurableObjectOptions<
+  RRuntime,
+  REvent = never,
+  EventLayerError = never,
+  Rpc extends DurableObjectRpc<RRuntime | REvent | RAlarm> = Record<never, never>,
+  RAlarm = never,
+> = DurableObjectOptionsBase<RRuntime, REvent, EventLayerError, Rpc, RAlarm> &
+  ([Exclude<REvent, RuntimeContext<RRuntime | RAlarm> | Scope.Scope>] extends [never]
+    ? unknown
+    : {
+        readonly eventLayer: Layer.Layer<
+          REvent,
+          EventLayerError,
+          RuntimeContext<NoInfer<RRuntime | RAlarm>>
+        >;
+      }) &
+  ([RAlarm] extends [never]
+    ? unknown
+    : {
+        readonly alarms: AlarmRegistration<
+          RAlarm,
+          HandlerContext<NoInfer<RRuntime> | REvent | NoInfer<RAlarm>>,
+          unknown
+        >;
+      });
 
 /**
  * Cloudflare `DurableObject` constructor produced by {@link make}.
@@ -170,30 +212,61 @@ export type DurableObjectClass<Rpc extends DurableObjectRpc<ROut>, ROut> = new (
  * that layer are not guaranteed to run. Put resources that require timely
  * release in `eventLayer`, whose scope closes after each handled event.
  */
-export const make = <
+export function make<ROut, LayerError>(
+  layer: Layer.Layer<ROut, LayerError, RuntimeContext<never>>,
+): DurableObjectClass<Record<never, never>, ROut>;
+export function make<
   ROut,
   LayerError,
   REvent = never,
   EventLayerError = never,
-  const Rpc extends DurableObjectRpc<ROut | REvent> = Record<never, never>,
+  const Rpc extends DurableObjectRpc<NoInfer<ROut> | REvent | NoInfer<RAlarm>> = Record<
+    never,
+    never
+  >,
+  RAlarm = never,
 >(
-  layer: Layer.Layer<ROut, LayerError, RuntimeContext<never>>,
-  options: DurableObjectOptions<ROut, REvent, EventLayerError, Rpc> = {},
-): DurableObjectClass<Rpc, ROut | REvent> => {
+  layer: Layer.Layer<ROut, LayerError, RuntimeContext<NoInfer<RAlarm>>>,
+  options: DurableObjectOptions<ROut, REvent, EventLayerError, Rpc, RAlarm>,
+): DurableObjectClass<Rpc, ROut | REvent | RAlarm>;
+export function make<
+  ROut,
+  LayerError,
+  REvent = never,
+  EventLayerError = never,
+  const Rpc extends DurableObjectRpc<NoInfer<ROut> | REvent | NoInfer<RAlarm>> = Record<
+    never,
+    never
+  >,
+  RAlarm = never,
+>(
+  layer: Layer.Layer<ROut, LayerError, RuntimeContext<NoInfer<RAlarm>>>,
+  options: DurableObjectOptionsBase<ROut, REvent, EventLayerError, Rpc, RAlarm> = {},
+): DurableObjectClass<Rpc, ROut | REvent | RAlarm> {
+  const registration =
+    options.alarms !== undefined && !Effect.isEffect(options.alarms) ? options.alarms : undefined;
+  const logicalAlarms = (
+    registration?.run ?? (Effect.isEffect(options.alarms) ? options.alarms : undefined)
+  )?.pipe(Effect.asVoid);
+
   class EffectDurableObject extends CloudflareDurableObject<WorkerEnv> {
-    readonly runtime: ManagedRuntime.ManagedRuntime<RuntimeContext<ROut>, LayerError>;
+    readonly runtime: ManagedRuntime.ManagedRuntime<RuntimeContext<ROut | RAlarm>, LayerError>;
 
     constructor(state: globalThis.DurableObjectState, env: WorkerEnv) {
       super(state, env);
 
-      const services = DurableObjectAlarm.layer.pipe(
+      const baseServices = DurableObjectAlarm.layer.pipe(
         Layer.provideMerge(Layer.succeed(DurableObjectState, fromDurableObjectState(state))),
       );
+      // SAFETY: RAlarm is inferred only from the registration's layer; without a registration it is never.
+      const services = (registration?.layer ?? Layer.empty).pipe(
+        Layer.provideMerge(baseServices),
+      ) as Layer.Layer<DurableObjectState | DurableObjectAlarm | RAlarm>;
 
       this.runtime = Runtime.makeEntrypointRuntime<
         ROut,
         LayerError,
-        DurableObjectState | DurableObjectAlarm
+        DurableObjectState | DurableObjectAlarm | RAlarm
       >(layer, env, services);
 
       const initialize = options.initialize;
@@ -204,7 +277,7 @@ export const make = <
     }
 
     [RunSymbol]<A, E>(
-      effect: Effect.Effect<A, E, HandlerContext<ROut | REvent>>,
+      effect: Effect.Effect<A, E, HandlerContext<ROut | REvent | RAlarm>>,
       runOptions: RunOptions = {},
     ): Promise<A> {
       const eventLayer = runOptions.eventLayer === false ? undefined : options.eventLayer;
@@ -212,11 +285,11 @@ export const make = <
       const parentSpan = parent === undefined ? undefined : Tracer.externalSpan(parent);
 
       if (eventLayer === undefined) {
-        // SAFETY: event-layer bypass is used only for initialize; otherwise an absent layer means REvent is never.
+        // SAFETY: initialize cannot require event services; without an event layer, all requirements are already provided.
         return Runtime.runEventPromise(
           this.runtime,
           // @effect-diagnostics-next-line unsafeEffectTypeAssertion:off
-          effect as Effect.Effect<A, E, HandlerContext<ROut>>,
+          effect as Effect.Effect<A, E, HandlerContext<ROut | RAlarm>>,
           undefined,
           parentSpan,
         );
@@ -225,7 +298,7 @@ export const make = <
       return Runtime.runEventPromise<
         A,
         E,
-        RuntimeContext<ROut>,
+        RuntimeContext<ROut | RAlarm>,
         REvent,
         EventLayerError,
         LayerError
@@ -245,7 +318,6 @@ export const make = <
     }
 
     alarm(alarmInfo?: globalThis.AlarmInvocationInfo): Promise<void> | void {
-      const logicalAlarms = options.alarms?.pipe(Effect.asVoid);
       const rawAlarm = options.alarm?.(alarmInfo);
       const alarmEffect =
         logicalAlarms !== undefined && rawAlarm !== undefined
@@ -303,10 +375,10 @@ export const make = <
     options.rpcTracing,
   );
 
-  return Entrypoint.assumeEntrypointClass<DurableObjectClass<Rpc, ROut | REvent>>(
+  return Entrypoint.assumeEntrypointClass<DurableObjectClass<Rpc, ROut | REvent | RAlarm>>(
     EffectDurableObject,
   );
-};
+}
 
 export type {
   Api,

--- a/packages/effect-cf/src/DurableObjectAlarm.ts
+++ b/packages/effect-cf/src/DurableObjectAlarm.ts
@@ -384,6 +384,35 @@ export interface DefinedAlarmTransaction<Definitions extends AlarmDefinitions> {
   ) => ReturnType<AlarmScheduler["cancelAlarm"]>;
 }
 
+export interface DefinedAlarmScheduler<
+  Definitions extends AlarmDefinitions,
+> extends DefinedAlarmTransaction<Definitions> {
+  readonly transaction: <A, E, R>(
+    closure: (alarms: DefinedAlarmTransaction<Definitions>) => Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E | StorageOperationError, R>;
+}
+
+/** Registers a dispatcher and the service authorized to schedule its alarms. */
+export interface AlarmRegistration<Self, R = never, E = never> {
+  readonly layer: Layer.Layer<Self, never, DurableObjectAlarm>;
+  readonly run: Effect.Effect<
+    ProcessDueAlarmsResult,
+    E | DurableObjectAlarmError,
+    R | DurableObjectAlarm
+  >;
+}
+
+export interface AlarmTagClass<
+  Self,
+  Id extends string,
+  Definitions extends AlarmDefinitions,
+> extends Context.ServiceClass<Self, Id, DefinedAlarmScheduler<Definitions>> {
+  readonly handlers: <R = never, E = never>(
+    handlers: DefinedAlarmHandlers<Definitions, R, E>,
+    options?: ProcessDueAlarmsOptions<R, E>,
+  ) => AlarmRegistration<Self, R, E>;
+}
+
 const isAlarmDefinitionConfig = (
   definition: AlarmDefinitionEntry,
 ): definition is AlarmDefinitionConfig => Predicate.isObject(definition) && "payload" in definition;
@@ -407,7 +436,7 @@ const getAlarmDefinitionFailureAction = (
     : { mode: definition.failure };
 };
 
-export const define = <const Definitions extends AlarmDefinitions>(definitions: Definitions) => {
+const makeDefinition = <const Definitions extends AlarmDefinitions>(definitions: Definitions) => {
   const definitionFor = (tag: string) =>
     Object.hasOwn(definitions, tag) ? definitions[tag] : undefined;
 
@@ -449,26 +478,10 @@ export const define = <const Definitions extends AlarmDefinitions>(definitions: 
   });
 
   return {
-    /** Encodes and validates the payload before persisting it. */
-    scheduleAlarm: Effect.fn("DefinedAlarms.scheduleAlarm")(function* (
-      input: DefinedScheduleAlarmInput<Definitions>,
-    ) {
-      const alarms = yield* DurableObjectAlarm;
-
-      yield* bind(alarms).scheduleAlarm(input);
+    make: (alarms: AlarmScheduler): DefinedAlarmScheduler<Definitions> => ({
+      ...bind(alarms),
+      transaction: (closure) => alarms.transaction((tx) => closure(bind(tx))),
     }),
-    cancelAlarm: Effect.fn("DefinedAlarms.cancelAlarm")(function* (
-      input: AlarmRef<keyof Definitions & string>,
-    ) {
-      const alarms = yield* DurableObjectAlarm;
-
-      yield* bind(alarms).cancelAlarm(input);
-    }),
-    /** Uses the same callback-owned transaction as the raw scheduler. */
-    transaction: <A, E, R>(
-      closure: (alarms: DefinedAlarmTransaction<Definitions>) => Effect.Effect<A, E, R>,
-    ): Effect.Effect<A, E | StorageOperationError, R | DurableObjectAlarm> =>
-      Effect.flatMap(DurableObjectAlarm, (alarms) => alarms.transaction((tx) => closure(bind(tx)))),
     handlers: <R = never, E = never>(
       handlers: DefinedAlarmHandlers<Definitions, R, E>,
       options?: ProcessDueAlarmsOptions<R, E>,
@@ -522,6 +535,32 @@ export const define = <const Definitions extends AlarmDefinitions>(definitions: 
       ),
   };
 };
+
+/** Handler-only definitions for applications using the raw scheduler. Prefer Tag for typed scheduling. */
+export const define = <const Definitions extends AlarmDefinitions>(definitions: Definitions) => ({
+  handlers: makeDefinition(definitions).handlers,
+});
+
+/** The typed scheduler becomes available when its handlers are registered on a Durable Object. */
+export const Tag =
+  <Self>() =>
+  <const Id extends string, const Definitions extends AlarmDefinitions>(
+    id: Id,
+    definitions: Definitions,
+  ): AlarmTagClass<Self, Id, Definitions> => {
+    const tag = Context.Service<Self, DefinedAlarmScheduler<Definitions>>()(id);
+    const definition = makeDefinition(definitions);
+
+    return Object.assign(tag, {
+      handlers: <R = never, E = never>(
+        handlers: DefinedAlarmHandlers<Definitions, R, E>,
+        options?: ProcessDueAlarmsOptions<R, E>,
+      ): AlarmRegistration<Self, R, E> => ({
+        layer: Layer.effect(tag, Effect.map(DurableObjectAlarm, definition.make)),
+        run: definition.handlers(handlers, options),
+      }),
+    });
+  };
 
 export class DurableObjectAlarm extends Context.Service<DurableObjectAlarm, AlarmScheduler>()(
   "effect-cf/DurableObjectAlarm",

--- a/packages/effect-cf/src/DurableObjectAlarm.ts
+++ b/packages/effect-cf/src/DurableObjectAlarm.ts
@@ -384,9 +384,21 @@ export interface DefinedAlarmTransaction<Definitions extends AlarmDefinitions> {
   ) => ReturnType<AlarmScheduler["cancelAlarm"]>;
 }
 
+const TypedAlarmSchedulerTypeId: unique symbol = Symbol.for(
+  "effect-cf/DurableObjectAlarm/TypedScheduler",
+);
+
+/** Identifies service requirements whose scheduler needs a registered dispatcher. */
+export interface AlarmService {
+  readonly Service: {
+    readonly [TypedAlarmSchedulerTypeId]: typeof TypedAlarmSchedulerTypeId;
+  };
+}
+
 export interface DefinedAlarmScheduler<
   Definitions extends AlarmDefinitions,
 > extends DefinedAlarmTransaction<Definitions> {
+  readonly [TypedAlarmSchedulerTypeId]: typeof TypedAlarmSchedulerTypeId;
   readonly transaction: <A, E, R>(
     closure: (alarms: DefinedAlarmTransaction<Definitions>) => Effect.Effect<A, E, R>,
   ) => Effect.Effect<A, E | StorageOperationError, R>;
@@ -479,6 +491,7 @@ const makeDefinition = <const Definitions extends AlarmDefinitions>(definitions:
 
   return {
     make: (alarms: AlarmScheduler): DefinedAlarmScheduler<Definitions> => ({
+      [TypedAlarmSchedulerTypeId]: TypedAlarmSchedulerTypeId,
       ...bind(alarms),
       transaction: (closure) => alarms.transaction((tx) => closure(bind(tx))),
     }),

--- a/packages/effect-cf/src/DurableObjectDefinition.ts
+++ b/packages/effect-cf/src/DurableObjectDefinition.ts
@@ -117,22 +117,21 @@ type MutableBoundaryHandlers<ROut, Self extends Definition.Any> = {
 /**
  * Durable Object constructor options for a specific RPC definition.
  */
-export interface Options<
+export type Options<
   ROut,
   Self extends Definition.Any,
   REvent = never,
   EventLayerError = never,
-> extends Omit<
-  DurableObjectEntrypoint.DurableObjectOptions<
-    ROut,
-    REvent,
-    EventLayerError,
-    Handlers<ROut | REvent, Self>
-  >,
-  "rpc"
-> {
-  readonly rpc: Handlers<ROut | REvent, Self>;
-}
+  RAlarm = never,
+> = DurableObjectEntrypoint.DurableObjectOptions<
+  ROut,
+  REvent,
+  EventLayerError,
+  Handlers<NoInfer<ROut> | REvent | NoInfer<RAlarm>, Self>,
+  RAlarm
+> & {
+  readonly rpc: Handlers<NoInfer<ROut> | REvent | NoInfer<RAlarm>, Self>;
+};
 
 export type LayerOptions = {
   readonly binding: string;
@@ -158,12 +157,12 @@ export type TagClass<
   > & {
     readonly id: Id;
     readonly methods: MethodDefinitions;
-    readonly make: <ROut, LayerError, REvent = never, EventLayerError = never>(
-      layer: Layer.Layer<ROut, LayerError, DurableObjectEntrypoint.RuntimeContext<never>>,
-      options: Options<ROut, Definition<Id, MethodDefinitions>, REvent, EventLayerError>,
+    readonly make: <ROut, LayerError, REvent = never, EventLayerError = never, RAlarm = never>(
+      layer: Layer.Layer<ROut, LayerError, DurableObjectEntrypoint.RuntimeContext<NoInfer<RAlarm>>>,
+      options: Options<ROut, Definition<Id, MethodDefinitions>, REvent, EventLayerError, RAlarm>,
     ) => DurableObjectEntrypoint.DurableObjectClass<
-      Handlers<ROut | REvent, Definition<Id, MethodDefinitions>>,
-      ROut | REvent
+      Handlers<ROut | REvent | RAlarm, Definition<Id, MethodDefinitions>>,
+      ROut | REvent | RAlarm
     >;
     readonly layer: (
       options: LayerOptions,
@@ -200,9 +199,9 @@ const makeDefinition = <Id extends string, const MethodDefinitions extends Metho
   const definition: SelfDefinition = RpcDefinition.make(id, methods);
 
   return Object.assign(definition, {
-    make: <ROut, LayerError, REvent = never, EventLayerError = never>(
-      layer: Layer.Layer<ROut, LayerError, DurableObjectEntrypoint.RuntimeContext<never>>,
-      options: Options<ROut, SelfDefinition, REvent, EventLayerError>,
+    make: <ROut, LayerError, REvent = never, EventLayerError = never, RAlarm = never>(
+      layer: Layer.Layer<ROut, LayerError, DurableObjectEntrypoint.RuntimeContext<NoInfer<RAlarm>>>,
+      options: Options<ROut, SelfDefinition, REvent, EventLayerError, RAlarm>,
     ) =>
       DurableObjectEntrypoint.make(layer, {
         ...options,

--- a/packages/effect-cf/tests/DurableObjectAlarm.test.ts
+++ b/packages/effect-cf/tests/DurableObjectAlarm.test.ts
@@ -636,17 +636,26 @@ it.effect("surfaces invalid input as typed scheduler errors", () =>
 it.effect("routes typed logical alarm definitions through decoded payload handlers", () =>
   Effect.gen(function* () {
     const fixture = makeAlarmFixture();
-    const roomAlarms = DurableObjectAlarm.define({
+
+    class RoomAlarms extends DurableObjectAlarm.Tag<RoomAlarms>()("RoomAlarms", {
       reconnectGrace: Schema.Struct({
         connectionId: Schema.String,
         userId: Schema.String,
         revision: Schema.FiniteFromString,
       }),
-    });
+    }) {}
     const handled: Array<string> = [];
+    const registration = RoomAlarms.handlers({
+      reconnectGrace: ({ payload }) =>
+        Effect.sync(() => {
+          handled.push(`${payload.userId}:${payload.connectionId}:${payload.revision + 1}`);
+        }),
+    });
 
     yield* fixture.run(
       Effect.gen(function* () {
+        const roomAlarms = yield* RoomAlarms;
+
         yield* roomAlarms.scheduleAlarm({
           tag: "reconnectGrace",
           id: "connection-1",
@@ -659,13 +668,8 @@ it.effect("routes typed logical alarm definitions through decoded payload handle
           '{"connectionId":"connection-1","userId":"user-1","revision":"2"}',
         );
 
-        yield* roomAlarms.handlers({
-          reconnectGrace: ({ payload }) =>
-            Effect.sync(() => {
-              handled.push(`${payload.userId}:${payload.connectionId}:${payload.revision + 1}`);
-            }),
-        });
-      }),
+        yield* registration.run;
+      }).pipe(Effect.provide(registration.layer)),
     );
 
     assert.deepStrictEqual(handled, ["user-1:connection-1:3"]);
@@ -677,24 +681,37 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const fixture = makeAlarmFixture();
-      const JobAlarms = DurableObjectAlarm.define({ job: Schema.NonEmptyString });
+
+      class JobAlarms extends DurableObjectAlarm.Tag<JobAlarms>()("JobAlarms", {
+        job: Schema.NonEmptyString,
+      }) {}
+      const registration = JobAlarms.handlers({ job: () => Effect.void });
 
       yield* fixture.run(
         Effect.gen(function* () {
-          yield* JobAlarms.scheduleAlarm({
+          const alarms = yield* JobAlarms;
+
+          yield* alarms.scheduleAlarm({
             tag: "job",
             id: "a",
             runAt: atMillis(2_000),
             payload: "before",
           });
           yield* writeJob(fixture.storage, "before");
-          const exit = yield* JobAlarms.transaction((tx) =>
-            Effect.gen(function* () {
-              yield* writeJob(fixture.storage, "during");
-              yield* tx.cancelAlarm({ tag: "job", id: "a" });
-              yield* tx.scheduleAlarm({ tag: "job", id: "b", runAt: atMillis(1_000), payload: "" });
-            }),
-          ).pipe(Effect.exit);
+          const exit = yield* alarms
+            .transaction((tx) =>
+              Effect.gen(function* () {
+                yield* writeJob(fixture.storage, "during");
+                yield* tx.cancelAlarm({ tag: "job", id: "a" });
+                yield* tx.scheduleAlarm({
+                  tag: "job",
+                  id: "b",
+                  runAt: atMillis(1_000),
+                  payload: "",
+                });
+              }),
+            )
+            .pipe(Effect.exit);
 
           assert.isTrue(Exit.isFailure(exit));
           if (Exit.isFailure(exit)) {
@@ -707,7 +724,7 @@ it.effect(
           assert.strictEqual(fixture.row("job", "a")?.payload, '"before"');
           assert.isUndefined(fixture.row("job", "b"));
           assert.strictEqual(fixture.currentAlarm(), 2_000);
-        }),
+        }).pipe(Effect.provide(registration.layer)),
       );
     }),
 );
@@ -837,20 +854,37 @@ it.effect("supports per-tag ordered failure policies", () =>
   }),
 );
 
-test("DurableObject.make provides the scheduler to RPC and alarm handlers", async () => {
+test("DurableObject.make registers the typed scheduler for application layers, RPC and alarm handlers", async () => {
   const fixture = makeAlarmFixture();
   const calls: Array<string> = [];
-  const JobAlarms = DurableObjectAlarm.define({ jobs: Schema.Null });
-  const Live = DurableObject.make(Layer.empty, {
+
+  class JobAlarms extends DurableObjectAlarm.Tag<JobAlarms>()("JobAlarms", { jobs: Schema.Null }) {}
+  const applicationLayer = Layer.effect(
+    Application,
+    Effect.gen(function* () {
+      const alarms = yield* JobAlarms;
+
+      yield* alarms.scheduleAlarm({ tag: "jobs", id: "0", runAt: atMillis(0), payload: null });
+
+      return { result: 42 };
+    }),
+  );
+  const Live = DurableObject.make(applicationLayer, {
     rpc: {
-      schedule: () =>
-        JobAlarms.scheduleAlarm({ tag: "jobs", id: "a", runAt: atMillis(0), payload: null }),
+      schedule: Effect.fn("schedule")(function* () {
+        const alarms = yield* JobAlarms;
+
+        yield* alarms.scheduleAlarm({ tag: "jobs", id: "a", runAt: atMillis(0), payload: null });
+      }),
     },
-    alarms: DurableObjectAlarm.processDue((event) =>
-      Effect.sync(() => {
+    alarms: JobAlarms.handlers({
+      jobs: Effect.fn("jobs")(function* (event) {
+        const alarms = yield* JobAlarms;
+
+        yield* alarms.cancelAlarm(event);
         calls.push(`logical:${event.id}`);
       }),
-    ),
+    }),
     alarm: () =>
       Effect.sync(() => {
         calls.push("raw");
@@ -867,7 +901,7 @@ test("DurableObject.make provides the scheduler to RPC and alarm handlers", asyn
 
   await makePartialTestDouble<AlarmHandler>(instance).alarm();
 
-  expect(calls).toEqual(["logical:a", "raw"]);
+  expect(calls).toEqual(["logical:0", "logical:a", "raw"]);
 });
 
 type SqlFixtureRow = Record<string, globalThis.SqlStorageValue>;

--- a/packages/effect-cf/tests/DurableObjectAlarm.worker.test.ts
+++ b/packages/effect-cf/tests/DurableObjectAlarm.worker.test.ts
@@ -23,14 +23,20 @@ const alarm = (id: string, offset: number) =>
 
 it.effect("commits application SQL and mixed alarms together in workerd", () => {
   const stub = env.TEST_COUNTER_DO!.getByName(crypto.randomUUID());
-  const JobAlarms = DurableObjectAlarm.define({ job: Schema.Null, other: Schema.Null });
+
+  class JobAlarms extends DurableObjectAlarm.Tag<JobAlarms>()("JobAlarms", {
+    job: Schema.Null,
+    other: Schema.Null,
+  }) {}
+  const registration = JobAlarms.handlers({ job: () => Effect.void, other: () => Effect.void });
 
   return PoolWorkers.runInDurableObject(stub, (_instance, state) =>
     Effect.gen(function* () {
+      const alarms = yield* JobAlarms;
       const sql = yield* SqlClient.SqlClient;
 
       yield* sql`CREATE TABLE jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL)`;
-      const result = yield* JobAlarms.transaction((tx) =>
+      const result = yield* alarms.transaction((tx) =>
         Effect.gen(function* () {
           yield* sql`INSERT INTO jobs VALUES ('sql-client', 'ready')`;
           yield* state.storage.sql.exec("INSERT INTO jobs VALUES (?, ?)", "storage", "ready");
@@ -60,7 +66,7 @@ it.effect("commits application SQL and mixed alarms together in workerd", () => 
         ],
       );
 
-      yield* JobAlarms.transaction((tx) =>
+      yield* alarms.transaction((tx) =>
         Effect.gen(function* () {
           yield* sql`UPDATE jobs SET status = 'cancelled'`;
           yield* tx.cancelAlarm({ tag: "job", id: "a" });
@@ -73,7 +79,7 @@ it.effect("commits application SQL and mixed alarms together in workerd", () => 
       ]);
       assert.deepStrictEqual(yield* sql`SELECT * FROM effect_cf_scheduled_alarms`, []);
       assert.isNull(yield* state.storage.getAlarm());
-    }).pipe(Effect.provide(services)),
+    }).pipe(Effect.provide(registration.layer.pipe(Layer.provideMerge(services)))),
   );
 });
 

--- a/packages/effect-cf/tests/durable-alarm.test-d.ts
+++ b/packages/effect-cf/tests/durable-alarm.test-d.ts
@@ -147,6 +147,31 @@ Documents.make(Layer.empty, { alarms: registration, rpc: { save: schedule } });
 // @ts-expect-error Tagged DOs must register the service too.
 Documents.make(Layer.empty, { rpc: { save: schedule } });
 
+const scheduleRpc = { save: schedule };
+const runtimeOnly = { rpc: scheduleRpc };
+const eventOnly = { eventLayer: registration.layer, rpc: scheduleRpc };
+const otherRegistration = OtherAlarms.handlers({
+  archive: () => Effect.void,
+  cleanup: () => Effect.void,
+});
+const wrongRegistration = { alarms: otherRegistration, rpc: scheduleRpc };
+
+// @ts-expect-error Installing the service layer alone does not install its dispatcher.
+DurableObject.make(registration.layer, runtimeOnly);
+// @ts-expect-error A layer can schedule work during construction even without RPC methods.
+DurableObject.make(registration.layer);
+// @ts-expect-error An event layer cannot substitute for handler registration.
+DurableObject.make(Layer.empty, eventOnly);
+// @ts-expect-error Tagged DOs cannot bypass registration through application outputs.
+Documents.make(registration.layer, runtimeOnly);
+// @ts-expect-error Tagged DOs cannot bypass registration through event outputs.
+Documents.make(Layer.empty, eventOnly);
+// @ts-expect-error A different dispatcher does not cover the service in the application layer.
+DurableObject.make(registration.layer, wrongRegistration);
+
+DurableObject.make(registration.layer, { alarms: registration, rpc: scheduleRpc });
+Documents.make(Layer.empty, { ...eventOnly, alarms: registration });
+
 const scheduled = Context.Service<{ readonly ready: boolean }>("test/Scheduled");
 const applicationLayer = Layer.effect(scheduled, schedule().pipe(Effect.as({ ready: true })));
 

--- a/packages/effect-cf/tests/durable-alarm.test-d.ts
+++ b/packages/effect-cf/tests/durable-alarm.test-d.ts
@@ -59,10 +59,15 @@ tx.transaction(() => Effect.void);
 // @ts-expect-error Dispatch and external handler work do not belong in the transaction.
 tx.processDueAlarms(() => Effect.void);
 
-const DocumentAlarms = DurableObjectAlarm.define({
+class DocumentAlarms extends DurableObjectAlarm.Tag<DocumentAlarms>()("DocumentAlarms", {
   archive: Schema.Struct({ key: Schema.String, revision: Schema.FiniteFromString }),
   cleanup: { payload: Schema.Null, failure: "retry" },
-});
+}) {}
+class OtherAlarms extends DurableObjectAlarm.Tag<OtherAlarms>()("OtherAlarms", {
+  archive: Schema.Struct({ key: Schema.String, revision: Schema.FiniteFromString }),
+  cleanup: { payload: Schema.Null, failure: "retry" },
+}) {}
+declare const documentAlarms: DocumentAlarms["Service"];
 const runAt = DateTime.makeUnsafe(1);
 const archiveInput = {
   tag: "archive",
@@ -71,25 +76,23 @@ const archiveInput = {
   payload: { key: "a", revision: 1 },
 } as const;
 
+void documentAlarms.scheduleAlarm(archiveInput);
+// @ts-expect-error A schema definition alone does not provide scheduling.
 void DocumentAlarms.scheduleAlarm(archiveInput);
 // @ts-expect-error The tag must belong to this definition.
-void DocumentAlarms.scheduleAlarm({ ...archiveInput, tag: "archvie" });
+void documentAlarms.scheduleAlarm({ ...archiveInput, tag: "archvie" });
 // @ts-expect-error Scheduling accepts the decoded type, not its wire encoding.
-void DocumentAlarms.scheduleAlarm({ ...archiveInput, payload: { key: "a", revision: "1" } });
+void documentAlarms.scheduleAlarm({ ...archiveInput, payload: { key: "a", revision: "1" } });
 // @ts-expect-error A known tag cannot be paired with another tag's payload.
-void DocumentAlarms.scheduleAlarm({ ...archiveInput, tag: "cleanup" });
+void documentAlarms.scheduleAlarm({ ...archiveInput, tag: "cleanup" });
 // @ts-expect-error Cancellation uses the same defined tags.
-void DocumentAlarms.cancelAlarm({ tag: "archvie", id: "a" });
+void documentAlarms.cancelAlarm({ tag: "archvie", id: "a" });
 
-expectTypeOf(DocumentAlarms.transaction(() => application)).toEqualTypeOf<
-  Effect.Effect<
-    number,
-    ApplicationError | DurableObjectStorage.StorageOperationError,
-    Application | DurableObjectAlarm.DurableObjectAlarm
-  >
+expectTypeOf(documentAlarms.transaction(() => application)).toEqualTypeOf<
+  Effect.Effect<number, ApplicationError | DurableObjectStorage.StorageOperationError, Application>
 >();
 
-void DocumentAlarms.transaction((typedTx) => {
+void documentAlarms.transaction((typedTx) => {
   void typedTx.scheduleAlarm(archiveInput);
   void typedTx.cancelAlarm({ tag: "cleanup", id: "a" });
   // @ts-expect-error Transactional scheduling is definition-bound too.
@@ -102,17 +105,57 @@ void DocumentAlarms.transaction((typedTx) => {
   return application;
 });
 
-// The default scheduler is available to construction layers as well as handlers.
-const scheduled = Context.Service<{ readonly ready: boolean }>("test/Scheduled");
+const schedule = Effect.fn("schedule")(function* () {
+  const alarms = yield* DocumentAlarms;
 
-DurableObject.make(
-  Layer.effect(
-    scheduled,
-    DocumentAlarms.scheduleAlarm(archiveInput).pipe(Effect.as({ ready: true })),
-  ),
-  {
-    initialize: DocumentAlarms.scheduleAlarm(archiveInput),
-    alarms: DocumentAlarms.handlers({ archive: () => Effect.void, cleanup: () => Effect.void }),
-    rpc: { schedule: () => DocumentAlarms.scheduleAlarm(archiveInput) },
-  },
-);
+  yield* alarms.scheduleAlarm(archiveInput);
+
+  return "saved";
+});
+const handlers = {
+  archive: Effect.fn("archive")(function* ({ id }: { readonly id: string }) {
+    const alarms = yield* DocumentAlarms;
+
+    yield* alarms.cancelAlarm({ tag: "archive", id });
+  }),
+  cleanup: () => Effect.void,
+};
+const registration = DocumentAlarms.handlers(handlers);
+
+// @ts-expect-error All declared alarms need handlers.
+DocumentAlarms.handlers({ archive: handlers.archive });
+
+DurableObject.make(Layer.empty, { alarms: registration, rpc: { save: schedule } });
+// @ts-expect-error Removing the registration leaves DocumentAlarms unsatisfied.
+// @effect-diagnostics-next-line missingEffectContext:off
+DurableObject.make(Layer.empty, { rpc: { save: schedule } });
+// @ts-expect-error A raw alarm hook cannot provide the typed scheduler.
+// @effect-diagnostics-next-line missingEffectContext:off
+DurableObject.make(Layer.empty, { alarms: Effect.void, rpc: { save: schedule } });
+// Another service with identical payloads cannot satisfy DocumentAlarms.
+DurableObject.make(Layer.empty, {
+  alarms: OtherAlarms.handlers({ archive: () => Effect.void, cleanup: () => Effect.void }),
+  // @ts-expect-error The registered service does not satisfy schedule's dependency.
+  // @effect-diagnostics-next-line missingEffectContext:off
+  rpc: { save: schedule },
+});
+
+class Documents extends DurableObject.Tag<Documents>()("Documents", {
+  save: DurableObject.method({ success: Schema.String }),
+}) {}
+Documents.make(Layer.empty, { alarms: registration, rpc: { save: schedule } });
+// @ts-expect-error Tagged DOs must register the service too.
+Documents.make(Layer.empty, { rpc: { save: schedule } });
+
+const scheduled = Context.Service<{ readonly ready: boolean }>("test/Scheduled");
+const applicationLayer = Layer.effect(scheduled, schedule().pipe(Effect.as({ ready: true })));
+
+DurableObject.make(applicationLayer, {
+  alarms: registration,
+  initialize: schedule().pipe(Effect.asVoid),
+  eventLayer: Layer.effect(scheduled, schedule().pipe(Effect.as({ ready: true }))),
+  rpc: { save: schedule },
+});
+// @ts-expect-error Application layers cannot use an unregistered alarm service.
+// @effect-diagnostics-next-line missingLayerContext:off
+DurableObject.make(applicationLayer);

--- a/packages/effect-cf/tests/fixtures/alarm-transaction-consumer.ts
+++ b/packages/effect-cf/tests/fixtures/alarm-transaction-consumer.ts
@@ -2,16 +2,19 @@ import { DateTime, Effect, Schema } from "effect";
 import { SqlClient } from "effect/unstable/sql";
 import { DurableObjectAlarm, DurableObjectSqlite } from "effect-cf";
 
-// DurableObject.make provides the alarm scheduler automatically.
+// Register JobAlarms.handlers(...) on the DO that uses this application layer.
 export const AlarmStorageLive = DurableObjectSqlite.layer();
-const JobAlarms = DurableObjectAlarm.define({ job: Schema.Null });
+export class JobAlarms extends DurableObjectAlarm.Tag<JobAlarms>()("JobAlarms", {
+  job: Schema.Null,
+}) {}
 
 export const scheduleJob = Effect.fn("scheduleJob")(function* (id: string, runAt: DateTime.Utc) {
+  const alarms = yield* JobAlarms;
   const sql = yield* SqlClient.SqlClient;
 
   yield* sql`CREATE TABLE IF NOT EXISTS jobs (id TEXT PRIMARY KEY, run_at INTEGER NOT NULL)`;
 
-  return yield* JobAlarms.transaction((tx) =>
+  return yield* alarms.transaction((tx) =>
     Effect.gen(function* () {
       yield* sql`INSERT OR REPLACE INTO jobs (id, run_at) VALUES (${id}, ${DateTime.toEpochMillis(runAt)})`;
       yield* tx.scheduleAlarm({ tag: "job", id, runAt, payload: null });


### PR DESCRIPTION
Typed alarm scheduling now requires the service supplied by its handler registration. Declaring schemas alone no longer lets an application enqueue jobs with no dispatcher.

```diff
-const Alarms = DurableObjectAlarm.define(schemas);
+class Alarms extends DurableObjectAlarm.Tag<Alarms>()("Alarms", schemas) {}

 // In DurableObject.make:
 alarms: Alarms.handlers({ archive: archiveRevision })

 // In a handler:
-yield* Alarms.transaction(...);
+const alarms = yield* Alarms;
+yield* alarms.transaction(...);
```

`alarms:` installs both the typed service and its dispatcher. Missing handlers or registration fail typechecking, including tagged DOs and application layers. Raw scheduling and handler-only `define(...)` remain supported.

The outbox example uses the registered service; delivery still survives stopping and restarting Wrangler. This revises the unreleased API from #146 and its pending release note.
