### PR TITLE
ci: update Effect Agent PR review to action-v1

### DIFF
--- a/.github/workflows/effect-agent-pr-review.yml
+++ b/.github/workflows/effect-agent-pr-review.yml
@@ -54,7 +54,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Review the pull request
-        uses: danieljvdm/effect-agent/action@a098b8714389c17f5fe76776ac6c99c66185fa72 # action-v0.1.0
+        uses: danieljvdm/effect-agent/action@action-v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Update the [PR review action](https://github.com/danieljvdm/effect-cf/blob/dan/update-pr-action/.github/workflows/effect-agent-pr-review.yml#L57) from the pinned `action-v0.1.0` commit to `danieljvdm/effect-agent/action@action-v1`.

## Validation

- `git diff --check` passed.
- `vp check` passed formatting but failed on an existing unused `_` parameter in `DurableObjectRpcWebSocket.ts:395` and missing `@cloudflare/workers-types` definitions.
- `vp env doctor` passed, with warnings about existing nvm and Volta environment variables.
- Package tests skipped because this only changes a GitHub Action reference. The workflow has not been run locally.
