### PR TITLE
fix: preserve definition exports during module initialization

### DIFF
--- a/.changeset/fix-definition-export-initialization.md
+++ b/.changeset/fix-definition-export-initialization.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": patch
+---
+
+Fix initialization failures when importing Queue or Workflow definitions from the published ES modules. Their factory exports remain the same functions regardless of module evaluation order.

--- a/packages/effect-cf/src/Queue.ts
+++ b/packages/effect-cf/src/Queue.ts
@@ -4,7 +4,7 @@ import type { Scope } from "effect";
 
 import type { ExecutionContext, WorkerContext } from "./Worker";
 import type { WorkerEnvironment } from "./Environment";
-import * as QueueDefinition from "./QueueDefinition";
+import type * as QueueDefinition from "./QueueDefinition";
 import * as ErrorMessage from "./internal/ErrorMessage";
 
 export interface QueueMessage<Body> {
@@ -117,15 +117,7 @@ export type TagClass<
   Message extends QueueDefinition.Definition.Any["message"],
 > = QueueDefinition.TagClass<Self, Id, Message>;
 
-export const Tag: <Self>() => <
-  Id extends string,
-  Message extends QueueDefinition.Definition.Any["message"],
->(
-  id: Id,
-  definition: { readonly message: Message },
-) => TagClass<Self, Id, Message> = QueueDefinition.Tag;
-
-export const implement = QueueDefinition.implement;
+export { implement, Tag } from "./QueueDefinition";
 
 export type Handler<ROut, Self extends QueueDefinition.Definition.Any> = QueueDefinition.Handler<
   ROut,

--- a/packages/effect-cf/src/Workflow.ts
+++ b/packages/effect-cf/src/Workflow.ts
@@ -20,7 +20,7 @@ import type { ManagedRuntime, Scope } from "effect";
 
 import { WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { ExecutionContext, WorkerContext } from "./Worker";
-import * as WorkflowDefinition from "./WorkflowDefinition";
+import type * as WorkflowDefinition from "./WorkflowDefinition";
 import * as Entrypoint from "./internal/Entrypoint";
 import * as ErrorMessage from "./internal/ErrorMessage";
 import * as Runtime from "./internal/Runtime";
@@ -318,19 +318,7 @@ export type TagClass<
   Result extends WorkflowDefinition.Definition.Any["result"],
 > = WorkflowDefinition.TagClass<Self, Id, Payload, Result>;
 
-export const Tag: <Self>() => <
-  Id extends string,
-  Payload extends WorkflowDefinition.Definition.Any["payload"],
-  Result extends WorkflowDefinition.Definition.Any["result"],
->(
-  id: Id,
-  definition: {
-    readonly payload: Payload;
-    readonly result: Result;
-  },
-) => TagClass<Self, Id, Payload, Result> = WorkflowDefinition.Tag;
-
-export const implement = WorkflowDefinition.implement;
+export { implement, Tag } from "./WorkflowDefinition";
 
 export type Handler<
   ROut,

--- a/packages/effect-cf/tests/Packaging.test.ts
+++ b/packages/effect-cf/tests/Packaging.test.ts
@@ -1,6 +1,27 @@
-import { expect, it } from "@effect/vitest";
+import { beforeAll, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import { build, type Plugin } from "esbuild";
+import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
+import { fileURLToPath, URL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+beforeAll(async () => {
+  const built = await access(new URL("../dist/index.mjs", import.meta.url)).then(
+    () => true,
+    () => false,
+  );
+
+  if (!built) {
+    await execFileAsync("vp", ["run", "--concurrency-limit", "1", "effect-cf#build"], {
+      cwd: fileURLToPath(new URL("../../../", import.meta.url)),
+      timeout: 60_000,
+      maxBuffer: 1024 * 1024,
+    });
+  }
+}, 65_000);
 
 const rejectOptionalPeers: Plugin = {
   name: "reject-optional-peers",
@@ -54,4 +75,26 @@ it.live("the root package bundles KV consumers without unrelated runtime imports
     expect(imports).not.toContain("cloudflare:workflows");
     expect(imports).not.toContain("node:async_hooks");
   }),
+);
+
+// https://github.com/danieljvdm/effect-cf/commit/f6c9c9f8ff504d44ab9c5c0d0fa6fc4c47a98039
+it.live.each(["Queue", "Workflow"])(
+  "published %s factories initialize when definitions are imported first",
+  (family) =>
+    Effect.gen(function* () {
+      const result = yield* Effect.promise(() =>
+        execFileAsync(
+          process.execPath,
+          [
+            "--experimental-strip-types",
+            fileURLToPath(new URL("./fixtures/definition-initialization.mjs", import.meta.url)),
+            new URL("../dist/", import.meta.url).href,
+            family,
+          ],
+          { timeout: 4_000, maxBuffer: 64 * 1024 },
+        ),
+      );
+
+      expect(result.stdout).toBe("ok\n");
+    }),
 );

--- a/packages/effect-cf/tests/fixtures/definition-host-loader.mjs
+++ b/packages/effect-cf/tests/fixtures/definition-host-loader.mjs
@@ -1,0 +1,12 @@
+// Only the unavailable host module is substituted. Package modules use Node's
+// native ESM linker unchanged, and the fixture never executes host operations.
+export const resolve = (specifier, context, nextResolve) => {
+  if (specifier === "cloudflare:workers") {
+    return nextResolve(new URL("../cloudflare-workers.ts", import.meta.url).href, context);
+  }
+  if (specifier === "cloudflare:workflows") {
+    return nextResolve(new URL("../cloudflare-workflows.ts", import.meta.url).href, context);
+  }
+
+  return nextResolve(specifier, context);
+};

--- a/packages/effect-cf/tests/fixtures/definition-initialization.mjs
+++ b/packages/effect-cf/tests/fixtures/definition-initialization.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import * as Schema from "effect/Schema";
+
+// Native ESM must see a fresh module graph: test-runner transforms and previously
+// loaded modules can hide the published package's initialization-order failure.
+register(new URL("./definition-host-loader.mjs", import.meta.url));
+
+const packageDirectory = process.argv[2];
+const family = process.argv[3];
+const definition = await import(new URL(`${family}Definition.mjs`, packageDirectory));
+const runtime = await import(new URL(`${family}.mjs`, packageDirectory));
+
+assert.equal(runtime.Tag, definition.Tag);
+assert.equal(runtime.implement, definition.implement);
+
+const fields =
+  family === "Queue"
+    ? { message: Schema.String }
+    : { payload: Schema.String, result: Schema.String };
+const tag = runtime.Tag()(`Packaging${family}`, fields);
+
+assert.equal(tag.id, `Packaging${family}`);
+for (const [name, schema] of Object.entries(fields)) {
+  assert.equal(tag[name], schema);
+}
+process.stdout.write("ok\n");


### PR DESCRIPTION
## Summary

Published effect-cf 0.40.1 can fail during module initialization when Queue or Workflow definitions load before their runtime modules. Use live re-exports for `Tag` and `implement` so this evaluation order no longer throws a `ReferenceError`. The public factories and native entrypoint exports are unchanged; consumers can initialize their Worker bundles without this failure.

Includes a patch changeset and fresh-process ESM regressions for both definition families.

## Validation

- Reproduced the Queue failure against published 0.40.1 and the independent Workflow failure before its fix.
- `vp test packages/effect-cf/tests/Packaging.test.ts --project node --maxWorkers 1` passed all 4 tests, including with `dist` initially absent.
- `vp run --concurrency-limit 1 check` passed with task/test concurrency capped at one: 56 test files, 439 tests, and all package/example typechecks passed. The 3 existing Maple smoke tests were skipped because `MAPLE_OTLP_SMOKE` was not enabled.
