### PR TITLE
fix(sqlite): keep transaction yields off blocked owner timers

### DIFF
--- a/.changeset/quiet-sqlite-gates.md
+++ b/.changeset/quiet-sqlite-gates.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": patch
+---
+
+Prevent Durable Object SQLite transactions from stalling when a blocked owner timer precedes an Effect scheduler yield. Keep transaction isolation, rollback, and the caller's scheduler after the transaction completes.

--- a/packages/effect-cf/src/DurableObjectSqlite.ts
+++ b/packages/effect-cf/src/DurableObjectSqlite.ts
@@ -1,7 +1,10 @@
 import { SqliteClient } from "@effect/sql-sqlite-do";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type { SqlClient } from "effect/unstable/sql";
+import * as Scheduler from "effect/Scheduler";
+import * as Reactivity from "effect/unstable/reactivity/Reactivity";
+import { SqlClient } from "effect/unstable/sql";
 
 import { DurableObjectState } from "./DurableObjectState";
 
@@ -10,10 +13,22 @@ export type SqliteLayerOptions = Omit<SqliteClient.SqliteClientConfig, "db" | "s
 export const layer = (
   options?: SqliteLayerOptions,
 ): Layer.Layer<SqliteClient.SqliteClient | SqlClient.SqlClient, never, DurableObjectState> =>
-  Layer.unwrap(
+  Layer.effectContext(
     Effect.gen(function* () {
       const state = yield* DurableObjectState;
+      const client = yield* SqliteClient.make({ ...options, storage: state.raw.storage });
+      const original = client.withTransaction;
+      const scheduler = new Scheduler.MixedScheduler("sync");
+      const withTransaction: SqliteClient.SqliteClient["withTransaction"] = (body) =>
+        original(body).pipe(Effect.provideService(Scheduler.Scheduler, scheduler));
 
-      return SqliteClient.layer({ ...options, storage: state.raw.storage });
+      // Native timers retain their input gate. A blocked parent timer can prevent
+      // a transaction's later timer from running, so yield through microtasks until
+      // the native transaction settles. Keep the original client and SQL permit.
+      Object.assign(client, { withTransaction });
+
+      return Context.make(SqliteClient.SqliteClient, client).pipe(
+        Context.add(SqlClient.SqlClient, client),
+      );
     }),
-  );
+  ).pipe(Layer.provide(Reactivity.layer));

--- a/packages/effect-cf/tests/DurableObjectSqlite.worker.test.ts
+++ b/packages/effect-cf/tests/DurableObjectSqlite.worker.test.ts
@@ -1,0 +1,175 @@
+import { runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { SqliteClient } from "@effect/sql-sqlite-do";
+import { assert, it } from "@effect/vitest";
+import { Deferred, Effect, Exit, Fiber, Layer, ManagedRuntime, Scheduler } from "effect";
+import { SqlClient } from "effect/unstable/sql";
+
+import { DurableObjectSqlite, DurableObjectState } from "../src/index";
+import * as PoolWorkers from "../src/Vitest";
+
+// The native transaction blocks an earlier timer from its enclosing input gate.
+// A transaction yield must not depend on a later timer in that same owner queue.
+it.each([false, true])(
+  "yields inside SQLite with an earlier gated timer (view=%s)",
+  async (view) => {
+    const namespace = env.TEST_COUNTER_DO!;
+    const ref = crypto.randomUUID();
+    const stub = namespace.getByName(`${ref}:transaction`);
+    const result = await runInDurableObject(stub, async (_instance, raw) => {
+      const clock = namespace.getByName(`${ref}:clock`);
+      const runtime = ManagedRuntime.make(
+        DurableObjectSqlite.layer({ transformResultNames: (name) => name.toUpperCase() }).pipe(
+          Layer.provide(
+            Layer.succeed(
+              DurableObjectState.DurableObjectState,
+              DurableObjectState.fromDurableObjectState(raw),
+            ),
+          ),
+        ),
+      );
+
+      try {
+        await runtime.runPromise(Effect.void);
+
+        return await raw.blockConcurrencyWhile(async () => {
+          let outerRan = false;
+          let finished = false;
+          let finishedBeforeClear: boolean | undefined;
+          let release: Promise<void> | undefined;
+          const outer = setTimeout(() => {
+            outerRan = true;
+          }, 0);
+          const work = runtime
+            .runPromise(
+              Effect.gen(function* () {
+                const original = yield* SqlClient.SqlClient;
+                const specific = yield* SqliteClient.SqliteClient;
+                const sql = view ? original.withoutTransforms() : original;
+                const callerScheduler = yield* Scheduler.Scheduler;
+                const enteredAfterOuter = yield* sql.withTransaction(
+                  Effect.gen(function* () {
+                    const enteredAfterOuter = outerRan;
+
+                    // Register this completion inside the transaction's native gate.
+                    // A parent-gate completion would itself be blocked by the transaction.
+                    release = runInDurableObject(
+                      clock,
+                      () => new Promise<void>((resolve) => setTimeout(resolve, 100)),
+                    ).then(() => {
+                      finishedBeforeClear = finished;
+                      clearTimeout(outer);
+                    });
+                    yield* sql`SELECT 1`;
+                    yield* Effect.yieldNow;
+
+                    return enteredAfterOuter;
+                  }),
+                );
+                const restoredScheduler = yield* Scheduler.Scheduler;
+
+                return {
+                  enteredAfterOuter,
+                  sameClient: original === specific,
+                  sameTransaction: sql.withTransaction === original.withTransaction,
+                  samePermit: sql.reserve === original.reserve,
+                  sameTransactionContext: sql.transactionService === original.transactionService,
+                  restoredScheduler: restoredScheduler === callerScheduler,
+                };
+              }),
+            )
+            .then((value) => {
+              finished = true;
+
+              return value;
+            });
+
+          try {
+            const value = await work;
+
+            await release;
+
+            return { ...value, finishedBeforeClear };
+          } finally {
+            clearTimeout(outer);
+          }
+        });
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    assert.deepStrictEqual(result, {
+      enteredAfterOuter: false,
+      sameClient: true,
+      sameTransaction: true,
+      samePermit: true,
+      sameTransactionContext: true,
+      restoredScheduler: true,
+      finishedBeforeClear: true,
+    });
+  },
+);
+
+it.effect("retains rollback and the shared SQL permit after interruption", () => {
+  const stub = env.TEST_COUNTER_DO!.getByName(`sqlite-interruption-${crypto.randomUUID()}`);
+
+  return PoolWorkers.runInDurableObject(stub, () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const started = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+
+      yield* sql`CREATE TABLE values_to_commit (value TEXT NOT NULL)`;
+      const failed = yield* Effect.exit(
+        sql.withTransaction(
+          sql`INSERT INTO values_to_commit VALUES ('failed')`.pipe(
+            Effect.andThen(Effect.fail("rollback")),
+          ),
+        ),
+      );
+      const writer = yield* Effect.forkChild(
+        sql.withTransaction(
+          sql`INSERT INTO values_to_commit VALUES ('interrupted')`.pipe(
+            Effect.andThen(Deferred.succeed(started, undefined)),
+            Effect.andThen(Deferred.await(release)),
+          ),
+        ),
+      );
+
+      yield* Deferred.await(started);
+      const reader = yield* Effect.forkChild(
+        sql.withoutTransforms()`SELECT * FROM values_to_commit`,
+        { startImmediately: true },
+      );
+      const waitingForPermit = reader.pollUnsafe() === undefined;
+
+      writer.interruptUnsafe();
+      yield* Fiber.awaitAll([writer]);
+      const rowsAfterRollback = yield* Fiber.join(reader);
+
+      yield* sql.withTransaction(sql`INSERT INTO values_to_commit VALUES ('committed')`);
+      const finalRows = yield* sql.withoutTransforms()`SELECT * FROM values_to_commit`;
+
+      return {
+        failed: Exit.isFailure(failed),
+        interrupted: writer.pollUnsafe()?._tag === "Failure",
+        waitingForPermit,
+        rowsAfterRollback,
+        finalRows,
+      };
+    }).pipe(Effect.provide(DurableObjectSqlite.layer())),
+  ).pipe(
+    Effect.tap((result) =>
+      Effect.sync(() =>
+        assert.deepStrictEqual(result, {
+          failed: true,
+          interrupted: true,
+          waitingForPermit: true,
+          rowsAfterRollback: [],
+          finalRows: [{ value: "committed" }],
+        }),
+      ),
+    ),
+  );
+});


### PR DESCRIPTION
## Summary

A Durable Object SQLite transaction can deadlock when an earlier owner timer is blocked by its input gate and an Effect yield queues another timer behind it. `DurableObjectSqlite.layer` now schedules the complete transaction through microtasks and restores the caller's scheduler after native settlement. It keeps the same SQL client, transaction context, permit, and rollback implementation, including transformed client views.

The real-workerd regression failed for both normal and `withoutTransforms()` clients on `c6341cd`: neither transaction completed before an independent owner released the blocked timer. Both complete before release with this change. This is a liveness fix; hosted chat latency is measured separately by Kommunikasie.

## Validation

`vp run check` passed: 57 test files, 442 tests passed and 3 existing skips, plus typechecks, formatting, lint and package builds. The new native regression also verifies scheduler restoration, one client/permit across views, failure rollback, interruption rollback, a competing reader blocked on the SQL permit, and a successful transaction afterward. The existing native storage interruption test passed as well.
