### PR TITLE
fix: retain RPC targets within each invocation

### DIFF
--- a/.changeset/steady-rpc-channels.md
+++ b/.changeset/steady-rpc-channels.md
@@ -1,0 +1,5 @@
+---
+"effect-cf": minor
+---
+
+Reuse Durable Object RPC targets within each invocation so callbacks cannot grow a new subrequest chain on every call. Incoming requests and durable retries retain separate target lifetimes. Expose RpcTargets for native RPC adapters sharing the same invocation boundary.

--- a/packages/effect-cf/src/DurableObjectNamespace.ts
+++ b/packages/effect-cf/src/DurableObjectNamespace.ts
@@ -11,6 +11,7 @@ import * as RpcDefinition from "./RpcDefinition";
 import * as ErrorMessage from "./internal/ErrorMessage";
 import * as RpcInvocation from "./internal/RpcInvocation";
 import * as RpcTracing from "./RpcTracing";
+import * as RpcTargets from "./RpcTargets";
 
 const expectedDurableObjectNamespace =
   "Durable Object namespace binding with getByName(), get(), idFromName(), idFromString(), newUniqueId(), and jurisdiction()";
@@ -348,12 +349,18 @@ export const makeClient = <
     const get = (
       id: globalThis.DurableObjectId,
       options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
-    ) => Effect.sync(() => namespace.get(id, options));
+    ) =>
+      RpcTargets.get(namespace, JSON.stringify(["id", id.toString(), options]), () =>
+        namespace.get(id, options),
+      ).pipe(Effect.orDie);
 
     const getByName = (
       name: string,
       options?: globalThis.DurableObjectNamespaceGetDurableObjectOptions,
-    ) => Effect.sync(() => namespace.getByName(name, options));
+    ) =>
+      RpcTargets.get(namespace, JSON.stringify(["name", name, options]), () =>
+        namespace.getByName(name, options),
+      ).pipe(Effect.orDie);
 
     const jurisdiction = (value: globalThis.DurableObjectJurisdiction) =>
       Effect.sync(() => namespace.jurisdiction(value));
@@ -377,7 +384,7 @@ export const makeClient = <
           });
         },
         catch: (cause) => new DurableObjectFetchError({ binding: definition.binding, cause }),
-      });
+      }).pipe(Effect.tapCause(() => RpcTargets.invalidate(stub)));
 
     const rpc = Effect.fnUntraced(function* <Method extends StubMethodKey<Api>>(
       stub: StubClient,
@@ -419,7 +426,7 @@ export const makeClient = <
             method: methodName,
             cause,
           }),
-      );
+      ).pipe(Effect.tapCause(() => RpcTargets.invalidate(stub)));
     });
 
     const decodeSuccess = Effect.fnUntraced(function* <Method extends StubMethodKey<Api>>(
@@ -459,6 +466,7 @@ export const makeClient = <
       ): Effect.fn.Return<StubMethodSuccess<Api, Method>, DurableObjectRpcError> {
         const methodName = String(method);
         const value = yield* CloudflareRpc.resolve(yield* rpc(stub, method, ...args)).pipe(
+          Effect.tapCause(() => RpcTargets.invalidate(stub)),
           Effect.mapError(
             (cause) =>
               new DurableObjectRpcError({
@@ -484,6 +492,7 @@ export const makeClient = <
         const methodName = String(method);
         const result = yield* rpc(stub, method, ...args);
         const value = yield* CloudflareRpc.scoped(result).pipe(
+          Effect.tapCause(() => RpcTargets.invalidate(stub)),
           Effect.mapError(
             (cause) =>
               new DurableObjectRpcError({

--- a/packages/effect-cf/src/RpcTargets.ts
+++ b/packages/effect-cf/src/RpcTargets.ts
@@ -1,6 +1,13 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Data from "effect/Data";
+import type * as Scope from "effect/Scope";
 import * as Option from "effect/Option";
+
+/** A native RPC target could not be constructed. */
+export class RpcTargetError extends Data.TaggedError("RpcTargetError")<{
+  readonly cause: unknown;
+}> {}
 
 interface Targets {
   get<A extends object, Owner extends object>(owner: Owner, address: string, create: () => A): A;
@@ -26,7 +33,7 @@ export const get = <A extends object, Owner extends object>(
   Effect.flatMap(Effect.serviceOption(CurrentTargets), (targets) =>
     Effect.try({
       try: () => (Option.isSome(targets) ? targets.value.get(owner, address, create) : create()),
-      catch: (cause) => cause,
+      catch: (cause) => new RpcTargetError({ cause }),
     }),
   );
 
@@ -37,11 +44,13 @@ export const invalidate = <Target extends object>(target: Target): Effect.Effect
   });
 
 /**
- * Own RPC targets for one live invocation, never across incoming requests or
- * durable retries. effect-cf entrypoints install this boundary automatically.
+ * Own RPC targets in the current Scope, including a transferred response stream,
+ * never across incoming requests or durable retries. effect-cf entrypoints install this boundary automatically.
  */
-export const withScope = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-  Effect.suspend(() => {
+export const withScope = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R | Scope.Scope> =>
+  Effect.gen(function* () {
     let active = true;
     let owners = new WeakMap<object, Map<string, object>>();
     let addresses = new WeakMap<object, { entries: Map<string, object>; address: string }>();
@@ -79,14 +88,13 @@ export const withScope = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effec
       },
     };
 
-    return effect.pipe(
-      Effect.provideService(CurrentTargets, targets),
-      Effect.ensuring(
-        Effect.sync(() => {
-          active = false;
-          owners = new WeakMap();
-          addresses = new WeakMap();
-        }),
-      ),
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        active = false;
+        owners = new WeakMap();
+        addresses = new WeakMap();
+      }),
     );
+
+    return yield* effect.pipe(Effect.provideService(CurrentTargets, targets));
   });

--- a/packages/effect-cf/src/RpcTargets.ts
+++ b/packages/effect-cf/src/RpcTargets.ts
@@ -1,0 +1,92 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+interface Targets {
+  get<A extends object, Owner extends object>(owner: Owner, address: string, create: () => A): A;
+  invalidate<Target extends object>(target: Target): void;
+}
+
+class CurrentTargets extends Context.Service<CurrentTargets, Targets>()("effect-cf/RpcTargets") {}
+
+/**
+ * Reuse a native RPC target within the current invocation. Native Durable Object
+ * stubs capture the calling request's channel when created. Recreating a stub
+ * after a callback can extend that callback's call chain until Cloudflare's
+ * subrequest depth limit is reached, even when an alarm owns the work.
+ *
+ * The owner and address must identify one target and its construction options.
+ * Outside an effect-cf invocation (or withScope), each lookup constructs a target.
+ */
+export const get = <A extends object, Owner extends object>(
+  owner: Owner,
+  address: string,
+  create: () => A,
+) =>
+  Effect.flatMap(Effect.serviceOption(CurrentTargets), (targets) =>
+    Effect.try({
+      try: () => (Option.isSome(targets) ? targets.value.get(owner, address, create) : create()),
+      catch: (cause) => cause,
+    }),
+  );
+
+/** Discard a failed native target so a subsequent call can acquire a fresh channel. */
+export const invalidate = <Target extends object>(target: Target): Effect.Effect<void> =>
+  Effect.map(Effect.serviceOption(CurrentTargets), (targets) => {
+    if (Option.isSome(targets)) targets.value.invalidate(target);
+  });
+
+/**
+ * Own RPC targets for one live invocation, never across incoming requests or
+ * durable retries. effect-cf entrypoints install this boundary automatically.
+ */
+export const withScope = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+  Effect.suspend(() => {
+    let active = true;
+    let owners = new WeakMap<object, Map<string, object>>();
+    let addresses = new WeakMap<object, { entries: Map<string, object>; address: string }>();
+    const targets: Targets = {
+      get: <T extends object, Owner extends object>(
+        owner: Owner,
+        address: string,
+        create: () => T,
+      ): T => {
+        if (!active) return create();
+        let entries = owners.get(owner);
+
+        if (entries === undefined) {
+          entries = new Map();
+          owners.set(owner, entries);
+        }
+        const existing = entries.get(address);
+
+        if (existing !== undefined) {
+          // SAFETY: the caller's owner/address identifies the same native target type.
+          return existing as T;
+        }
+        const target = create();
+
+        entries.set(address, target);
+        addresses.set(target, { entries, address });
+
+        return target;
+      },
+      invalidate: (target) => {
+        const entry = addresses.get(target);
+
+        if (entry?.entries.get(entry.address) === target) entry.entries.delete(entry.address);
+        addresses.delete(target);
+      },
+    };
+
+    return effect.pipe(
+      Effect.provideService(CurrentTargets, targets),
+      Effect.ensuring(
+        Effect.sync(() => {
+          active = false;
+          owners = new WeakMap();
+          addresses = new WeakMap();
+        }),
+      ),
+    );
+  });

--- a/packages/effect-cf/src/Worker.ts
+++ b/packages/effect-cf/src/Worker.ts
@@ -13,6 +13,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { WorkerEnvironment, type WorkerEnv } from "./Environment";
 import { fromMessage, fromMessageBatch, type QueueHandler } from "./Queue";
 import * as RpcDefinition from "./RpcDefinition";
+import * as RpcTargets from "./RpcTargets";
 import type { ReceiverOptions, RpcInvocationInfo } from "./RpcTracing";
 import * as Entrypoint from "./internal/Entrypoint";
 import * as Runtime from "./internal/Runtime";
@@ -273,11 +274,13 @@ const renderFetchSuccess = <E, R, REvent, EventLayerError, EventLayerRequirement
             });
           });
     const telemetryMiddleware = HttpMiddleware.make((self) =>
-      Effect.gen(function* () {
-        yield* Effect.addFinalizer(() => scheduleTelemetryFlush);
+      RpcTargets.withScope(
+        Effect.gen(function* () {
+          yield* Effect.addFinalizer(() => scheduleTelemetryFlush);
 
-        return yield* self;
-      }),
+          return yield* self;
+        }),
+      ),
     );
     const handled =
       eventLayer === undefined
@@ -287,24 +290,26 @@ const renderFetchSuccess = <E, R, REvent, EventLayerError, EventLayerRequirement
               httpApp,
               handleResponse,
               HttpMiddleware.make((self) =>
-                Effect.provideService(
-                  Effect.gen(function* () {
-                    const context = yield* Layer.build(Layer.fresh(eventLayer));
+                RpcTargets.withScope(
+                  Effect.provideService(
+                    Effect.gen(function* () {
+                      const context = yield* Layer.build(Layer.fresh(eventLayer));
 
-                    yield* Effect.addFinalizer(() =>
-                      Effect.provideContext(scheduleTelemetryFlush, context),
-                    );
+                      yield* Effect.addFinalizer(() =>
+                        Effect.provideContext(scheduleTelemetryFlush, context),
+                      );
 
-                    return yield* HttpMiddleware.tracer(self).pipe(
-                      // The tracer schedules span completion. Let it publish on
-                      // every exit with event references still installed, before
-                      // the exporter scope finalizes.
-                      Effect.onExit(() => Effect.yieldNow),
-                      Effect.provideContext(context),
-                    );
-                  }),
-                  References.TracerEnabled,
-                  tracerEnabled,
+                      return yield* HttpMiddleware.tracer(self).pipe(
+                        // The tracer schedules span completion. Let it publish on
+                        // every exit with event references still installed, before
+                        // the exporter scope finalizes.
+                        Effect.onExit(() => Effect.yieldNow),
+                        Effect.provideContext(context),
+                      );
+                    }),
+                    References.TracerEnabled,
+                    tracerEnabled,
+                  ),
                 ),
               ),
             ).pipe(Effect.withTracerEnabled(false)),

--- a/packages/effect-cf/src/Workflow.ts
+++ b/packages/effect-cf/src/Workflow.ts
@@ -1,3 +1,4 @@
+import * as RpcTargets from "./RpcTargets";
 import {
   WorkflowEntrypoint as CloudflareWorkflowEntrypoint,
   type WorkflowEvent as CloudflareWorkflowEvent,
@@ -151,7 +152,11 @@ const fromWorkflowStep = (step: CloudflareWorkflowStep): WorkflowStepService => 
                   A,
                   E,
                   Exclude<R, WorkflowStepContext>
-                > = Effect.scoped(Effect.provideService(effect, WorkflowStepContext, stepContext));
+                > = Effect.scoped(
+                  RpcTargets.withScope(
+                    Effect.provideService(effect, WorkflowStepContext, stepContext),
+                  ),
+                );
 
                 return runPromise(
                   exposeCloudflareNonRetryableError(Effect.provideContext(stepEffect, context)),

--- a/packages/effect-cf/src/index.ts
+++ b/packages/effect-cf/src/index.ts
@@ -29,6 +29,7 @@ export * as R2 from "./R2";
 export * as Rpc from "./Rpc";
 export * as RpcDefinition from "./RpcDefinition";
 export * as RpcTracing from "./RpcTracing";
+export * as RpcTargets from "./RpcTargets";
 export * as ServiceBinding from "./ServiceBinding";
 export * as Vectorize from "./Vectorize";
 export * as WebTransport from "./WebTransport";

--- a/packages/effect-cf/src/internal/Runtime.ts
+++ b/packages/effect-cf/src/internal/Runtime.ts
@@ -62,13 +62,13 @@ export function runEventPromise<A, E, R, REvent, EventLayerError, LayerError>(
   const [runtime, effect, eventLayer, parent] = args;
 
   if (eventLayer === undefined) {
-    const event = RpcTargets.withScope(Effect.scoped(effect));
+    const event = Effect.scoped(RpcTargets.withScope(effect));
 
     return runtime.runPromise(parent === undefined ? event : Effect.withParentSpan(event, parent));
   }
 
-  const event = RpcTargets.withScope(
-    Effect.scoped(effect.pipe(Effect.provide(eventLayer, { local: true }))),
+  const event = Effect.scoped(
+    RpcTargets.withScope(effect.pipe(Effect.provide(eventLayer, { local: true }))),
   );
 
   return runtime.runPromise(parent === undefined ? event : Effect.withParentSpan(event, parent));

--- a/packages/effect-cf/src/internal/Runtime.ts
+++ b/packages/effect-cf/src/internal/Runtime.ts
@@ -5,6 +5,7 @@ import * as ManagedRuntime from "effect/ManagedRuntime";
 import type { Scope, Tracer } from "effect";
 
 import { WorkerConfig, WorkerEnvironment, type WorkerEnv } from "../Environment";
+import * as RpcTargets from "../RpcTargets";
 import { provideEntrypointServices } from "./Entrypoint";
 
 /**
@@ -61,12 +62,14 @@ export function runEventPromise<A, E, R, REvent, EventLayerError, LayerError>(
   const [runtime, effect, eventLayer, parent] = args;
 
   if (eventLayer === undefined) {
-    const event = Effect.scoped(effect);
+    const event = RpcTargets.withScope(Effect.scoped(effect));
 
     return runtime.runPromise(parent === undefined ? event : Effect.withParentSpan(event, parent));
   }
 
-  const event = Effect.scoped(effect.pipe(Effect.provide(eventLayer, { local: true })));
+  const event = RpcTargets.withScope(
+    Effect.scoped(effect.pipe(Effect.provide(eventLayer, { local: true }))),
+  );
 
   return runtime.runPromise(parent === undefined ? event : Effect.withParentSpan(event, parent));
 }

--- a/packages/effect-cf/tests/RpcTargets.test.ts
+++ b/packages/effect-cf/tests/RpcTargets.test.ts
@@ -1,7 +1,12 @@
 import { assert, it } from "@effect/vitest";
-import { Effect, Layer } from "effect";
+import type {
+  WorkflowStep as NativeStep,
+  WorkflowStepContext as NativeStepContext,
+} from "cloudflare:workers";
+import { Effect, Layer, Stream } from "effect";
+import { HttpServerResponse } from "effect/unstable/http";
 
-import { DurableObject, DurableObjectNamespace } from "../src/index";
+import { DurableObject, DurableObjectNamespace, Worker, Workflow } from "../src/index";
 import { makePartialTestDouble } from "./TestDoubles";
 
 // https://github.com/danieljvdm/effect-cf/commit/37b4883de9790df151ddbb16f2fd432b2d4348b5
@@ -66,5 +71,90 @@ it.effect("reuses RPC targets per invocation and replaces failed channels", () =
     yield* Effect.promise(() => Promise.resolve(object.alarm?.()));
     assert.deepStrictEqual(observed, [1, 2, 3, 4]);
     assert.strictEqual(constructed, 4);
+
+    const executionContext = makePartialTestDouble<ExecutionContext>({
+      waitUntil: () => undefined,
+      passThroughOnException: () => undefined,
+    });
+
+    for (const eventLayer of [undefined, Layer.empty]) {
+      const Streaming = Worker.make(Layer.empty, {
+        eventLayer,
+        fetch: Effect.gen(function* () {
+          const first = yield* ping;
+
+          return HttpServerResponse.stream(
+            Stream.fromEffect(
+              Effect.gen(function* () {
+                assert.strictEqual(yield* ping, first);
+                assert.strictEqual(yield* ping, first);
+
+                return String(first);
+              }),
+            ).pipe(Stream.encodeText),
+          );
+        }),
+      });
+      const worker = new Streaming(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+      const response = yield* Effect.promise(() =>
+        worker.fetch(new Request("https://worker.test/rpc-stream")),
+      );
+
+      assert.strictEqual(
+        yield* Effect.promise(() => response.text()),
+        eventLayer === undefined ? "5" : "6",
+      );
+    }
+
+    const retried: number[] = [];
+    const Retrying = Workflow.make(Layer.empty, {
+      run: () =>
+        Workflow.step(
+          "retry",
+          Effect.gen(function* () {
+            const step = yield* Workflow.WorkflowStepContext;
+            const target = yield* ping;
+
+            assert.strictEqual(yield* ping, target);
+            retried.push(target);
+            if (step.attempt === 1)
+              return yield* Effect.fail(new Error("retry after successful RPC"));
+
+            return target;
+          }),
+        ),
+    });
+    const step = {
+      do: async (name: string, callback: (context: NativeStepContext) => Promise<number>) => {
+        let rejected = false;
+
+        try {
+          await callback({ step: { name, count: 1 }, attempt: 1, config: {} });
+        } catch {
+          rejected = true;
+        }
+        assert.isTrue(rejected);
+
+        return callback({ step: { name, count: 1 }, attempt: 2, config: {} });
+      },
+    };
+    const workflow = new Retrying(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
+
+    // SAFETY: this fixture implements exactly the step.do callback overload exercised above.
+    const nativeStep = step as NativeStep;
+
+    yield* Effect.promise(() =>
+      workflow.run(
+        {
+          payload: undefined,
+          timestamp: new Date(0),
+          instanceId: "rpc-target-retry",
+          workflowName: "Retrying",
+        },
+        nativeStep,
+      ),
+    );
+    assert.deepStrictEqual(retried, [7, 8]);
+    assert.strictEqual(constructed, 8);
   }),
 );

--- a/packages/effect-cf/tests/RpcTargets.test.ts
+++ b/packages/effect-cf/tests/RpcTargets.test.ts
@@ -3,11 +3,13 @@ import type {
   WorkflowStep as NativeStep,
   WorkflowStepContext as NativeStepContext,
 } from "cloudflare:workers";
-import { Effect, Layer, Stream } from "effect";
+import { Data, Effect, Layer, Stream } from "effect";
 import { HttpServerResponse } from "effect/unstable/http";
 
 import { DurableObject, DurableObjectNamespace, Worker, Workflow } from "../src/index";
 import { makePartialTestDouble } from "./TestDoubles";
+
+class RetryFailure extends Data.TaggedError("RetryFailure") {}
 
 // https://github.com/danieljvdm/effect-cf/commit/37b4883de9790df151ddbb16f2fd432b2d4348b5
 // A remote two-Worker alarm probe fails after eight fresh-stub callback cycles;
@@ -117,8 +119,7 @@ it.effect("reuses RPC targets per invocation and replaces failed channels", () =
 
             assert.strictEqual(yield* ping, target);
             retried.push(target);
-            if (step.attempt === 1)
-              return yield* Effect.fail(new Error("retry after successful RPC"));
+            if (step.attempt === 1) return yield* Effect.fail(new RetryFailure());
 
             return target;
           }),

--- a/packages/effect-cf/tests/RpcTargets.test.ts
+++ b/packages/effect-cf/tests/RpcTargets.test.ts
@@ -96,7 +96,7 @@ it.effect("reuses RPC targets per invocation and replaces failed channels", () =
         }),
       });
       const worker = new Streaming(executionContext, makePartialTestDouble<Cloudflare.Env>({}));
-      const response = yield* Effect.promise(() =>
+      const response = yield* Effect.promise(async () =>
         worker.fetch(new Request("https://worker.test/rpc-stream")),
       );
 
@@ -146,7 +146,7 @@ it.effect("reuses RPC targets per invocation and replaces failed channels", () =
     yield* Effect.promise(() =>
       workflow.run(
         {
-          payload: undefined,
+          payload: {},
           timestamp: new Date(0),
           instanceId: "rpc-target-retry",
           workflowName: "Retrying",

--- a/packages/effect-cf/tests/RpcTargets.test.ts
+++ b/packages/effect-cf/tests/RpcTargets.test.ts
@@ -1,0 +1,70 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import { DurableObject, DurableObjectNamespace } from "../src/index";
+import { makePartialTestDouble } from "./TestDoubles";
+
+// https://github.com/danieljvdm/effect-cf/commit/37b4883de9790df151ddbb16f2fd432b2d4348b5
+// A remote two-Worker alarm probe fails after eight fresh-stub callback cycles;
+// retaining the target completes all 100. Exercise the automatic event boundary here.
+it.effect("reuses RPC targets per invocation and replaces failed channels", () =>
+  Effect.gen(function* () {
+    let constructed = 0;
+    let fail = false;
+    const transportFailure = new Error("disconnected RPC channel");
+
+    type Api = { ping(): Promise<number> };
+    const namespace = makePartialTestDouble<
+      DurableObjectNamespace.DurableObjectNamespaceClient<Api>
+    >({
+      getByName: () => {
+        const identity = ++constructed;
+
+        return makePartialTestDouble<DurableObjectNamespace.DurableObjectStubClient<Api>>({
+          ping: async () => {
+            if (fail) throw transportFailure;
+
+            return identity;
+          },
+        });
+      },
+    });
+    const client = DurableObjectNamespace.makeClient<Api>({ binding: "PEER" })(namespace);
+    const ping = Effect.gen(function* () {
+      const stub = yield* client.getByName("peer");
+
+      return yield* client.call(stub, "ping");
+    });
+    const observed: number[] = [];
+    const Live = DurableObject.make(Layer.empty, {
+      alarm: () =>
+        Effect.gen(function* () {
+          const first = yield* ping;
+
+          for (let i = 0; i < 100; i++) assert.strictEqual(yield* ping, first);
+          fail = true;
+          const error = yield* Effect.flip(ping);
+
+          assert.strictEqual(error.cause, transportFailure);
+          fail = false;
+          const replacement = yield* ping;
+
+          assert.notStrictEqual(replacement, first);
+          assert.strictEqual(yield* ping, replacement);
+          observed.push(first, replacement);
+        }),
+    });
+    const state = makePartialTestDouble<globalThis.DurableObjectState>({
+      id: makePartialTestDouble<globalThis.DurableObjectId>({ toString: () => "rpc-target-owner" }),
+      storage: makePartialTestDouble<globalThis.DurableObjectStorage>({}),
+      waitUntil: () => undefined,
+      blockConcurrencyWhile: async <A>(run: () => Promise<A>) => run(),
+    });
+    const object = new Live(state, makePartialTestDouble<Cloudflare.Env>({}));
+
+    yield* Effect.promise(() => Promise.resolve(object.alarm?.()));
+    yield* Effect.promise(() => Promise.resolve(object.alarm?.()));
+    assert.deepStrictEqual(observed, [1, 2, 3, 4]);
+    assert.strictEqual(constructed, 4);
+  }),
+);


### PR DESCRIPTION
## Summary

Repeated Durable Object callbacks can exhaust Cloudflare subrequest depth even when an alarm owns the run: each new stub captures the current request channel. Reuse targets within one invocation, discard failed channels, and start fresh for every incoming event or durable retry. Native adapters can join the same boundary through `RpcTargets`.

RPC payloads, authorization, tracing and durable receipts remain per call. Targets are never retained across request scopes.

## Validation

- `vp run ready` passed.
- A two-Worker remote alarm reproduction failed after 8 callback cycles with fresh stubs; the candidate completed all 100 cycles.
- The regression covers automatic alarm scope, repeated target use, failed-channel replacement, isolation between invocations, response-stream lifetime with and without an event layer, and fresh channels for Workflow step retries.
